### PR TITLE
xSQLServerNetwork: Add PsDscRunAsCredential parameter to example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 - Changes to xSQLServerNetwork
-  - added parameter sysadmin account to the example
+  - added sysadmin account parameter usage to the examples
 
 - Changes to xSQLServer
   - Updated appveyor.yml so that integration tests run in order and so that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change log for xSQLServer
 
 ## Unreleased
+- Changes to xSQLServerNetwork
+  - added parameter sysadmin account to the example
 
 - Changes to xSQLServer
   - Updated appveyor.yml so that integration tests run in order and so that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## Unreleased
 
-- Changes to xSQLServerNetwork
-  - added sysadmin account parameter usage to the examples
-
 - Changes to xSQLServer
   - Updated appveyor.yml so that integration tests run in order and so that
     the SQLPS module folders are renamed to not disturb the units test, but
@@ -99,6 +96,8 @@
     Services has not been initialized ([issue #822](https://github.com/PowerShell/xSQLServer/issues/822)).
   - Fixed so that when two Reporting Services are installed for the same major
     version the resource does not throw an error ([issue #819](https://github.com/PowerShell/xSQLServer/issues/819)).
+- Changes to xSQLServerNetwork
+  - added sysadmin account parameter usage to the examples
 
 ## 8.1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log for xSQLServer
 
 ## Unreleased
+
 - Changes to xSQLServerNetwork
   - added sysadmin account parameter usage to the examples
 

--- a/Examples/Resources/xSQLServerNetwork/1-EnableTcpIpWithStaticPort.ps1
+++ b/Examples/Resources/xSQLServerNetwork/1-EnableTcpIpWithStaticPort.ps1
@@ -25,6 +25,7 @@ Configuration Example
             TCPDynamicPorts = ''
             TCPPort         = 4509
             RestartService  = $true
+            PsDscRunAsCredential = $SysAdminAccount
         }
     }
 }

--- a/Examples/Resources/xSQLServerNetwork/2-EnableTcpIpWithDynamicPort.ps1
+++ b/Examples/Resources/xSQLServerNetwork/2-EnableTcpIpWithDynamicPort.ps1
@@ -24,6 +24,7 @@ Configuration Example
             IsEnabled       = $true
             TCPDynamicPorts = '0'
             RestartService  = $true
+            PsDscRunAsCredential = $SysAdminAccount
         }
     }
 }


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xSQLServerNetwork
  - added sysadmin account parameter usage to the examples

**This Pull Request (PR) fixes the following issues:**
n/a

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/840)
<!-- Reviewable:end -->
