### PR TITLE
SqlServerDsc: Fix inconsistent parameter names in all resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,9 @@
 - Changes to SqlDatabaseRecoveryModel
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+- Changes to SqlDatabaseRole
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
 
 ## 8.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@
 - Changes to SqlServerMemory
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+- Changes to SqlServerNetwork
+  - BREAKING CHANGE: Parameters SQLServer has been renamed to ServerName
+    ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
 - Changes to SqlServerOwner
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@
     the resource will only determine if a change is needed if the target node
     is the active host of the SQL Server instance ([issue #869](https://github.com/PowerShell/xSQLServer/issues/869)).
 - Changes to xSQLServerAlwaysOnAvailabilityGroupReplica
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
   - Made the resource cluster aware. When ProcessOnlyOnActiveNode is specified,
     the resource will only determine if a change is needed if the target node is
     the active host of the SQL Server instance ([issue #870](https://github.com/PowerShell/xSQLServer/issues/870)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@
     the resource will only determine if a change is needed if the target node
     is the active host of the SQL Server instance ([issue #868](https://github.com/PowerShell/xSQLServer/issues/868)).
 - Changes to xSQLServerAlwaysOnAvailabilityGroupDatabaseMembership
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
   - Made the resource cluster aware. When ProcessOnlyOnActiveNode is specified,
     the resource will only determine if a change is needed if the target node
     is the active host of the SQL Server instance ([issue #869](https://github.com/PowerShell/xSQLServer/issues/869)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@
 - Changes to SqlServerEndpointPermission
   - BREAKING CHANGE: Parameter NodeName has been renamed to ServerName
     ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+- Changes to SqlServerEndpointState
+  - BREAKING CHANGE: Parameter NodeName has been renamed to ServerName
+    ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
 - Changes to SqlServerLogin
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@
 - Changes to SqlDatabaseRole
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+- Changes to SqlServerConfiguration
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
 - Changes to SqlServerEndpoint
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,9 @@
 - Changes to SqlServerLogin
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+- Changes to SqlServerPermission
+  - BREAKING CHANGE: Parameter NodeName has been renamed to ServerName
+    ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
 
 ## 8.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - BREAKING CHANGE: Resource module has been renamed to SqlServerDsc
   ([issue #916](https://github.com/PowerShell/SqlServerDsc/issues/916)).
 - BREAKING CHANGE: Significant rename to reduce length of resource names
-  - See [issue #851](https://github.com/PowerShell/xSQLServer/issues/851) for a
+  - See [issue #851](https://github.com/PowerShell/SqlServerDsc/issues/851) for a
     complete table mapping rename changes.
   - Impact to all resources.
 - Changes to CONTRIBUTING.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,9 @@
 - Changes to SqlAlwaysOnService
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+- Changes to SqlDatabasePermission
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
 
 ## 8.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,9 @@
 - Changes to SqlServerPermission
   - BREAKING CHANGE: Parameter NodeName has been renamed to ServerName
     ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+- Changes to SqlServerEndpoint
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
 
 ## 8.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@
 - Changes to SqlServerPermission
   - BREAKING CHANGE: Parameter NodeName has been renamed to ServerName
     ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+- Changes to SqlServerRole
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
 
 ## 9.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,50 @@
     added to the comment-based help in each example stating it is obsolete.
     This is a temporary measure until they are replaced.
     ([issue #904](https://github.com/PowerShell/SqlServerDsc/issues/904)).
+- Changes to SqlAG
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
 - Changes to SqlAGDatabase
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
   - Changed the Get-MatchingDatabaseNames function to be case insensitive when
     matching database names. ([issue #912](https://github.com/PowerShell/SqlServerDsc/issues/912))
+- Changes to SqlAGListener
+  - BREAKING CHANGE: Parameter NodeName has been renamed to ServerName
+    ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+- Changes to SqlAGReplica
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+- Changes to SqlAlwaysOnService
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+- Changes to SqlDatabase
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+- Changes SqlDatabaseDefaultLocation
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+- Changes to SqlDatabasePermission
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+- Changes to SqlDatabaseRecoveryModel
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+- Changes to SqlDatabaseRole
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+- Changes to SqlServerEndpoint
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+- Changes to SqlServerLogin
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+- Changes to SqlServerOwner
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+- Changes to SqlServerPermission
+  - BREAKING CHANGE: Parameter NodeName has been renamed to ServerName
+    ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
 
 ## 9.0.0.0
 
@@ -25,15 +66,11 @@
   - Updated Pester syntax to v4
   - Fixes broken links to issues in the CHANGELOG.md.
 - Changes to xSQLServerDatabase
-  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
   - Added parameter to specify collation for a database to be different from server
     collation ([issue #767](https://github.com/PowerShell/xSQLServer/issues/767)).
   - Fixed unit tests for Get-TargetResource to ensure correctly testing return
     values ([issue #849](https://github.com/PowerShell/xSQLServer/issues/849))
 - Changes to xSQLServerAlwaysOnAvailabilityGroup
-  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
   - Refactored the unit tests to allow them to be more user friendly and to test
     additional SQLServer variations.
     - Each test will utilize the Import-SQLModuleStub to ensure the correct
@@ -47,14 +84,10 @@
     the resource will only determine if a change is needed if the target node
     is the active host of the SQL Server instance ([issue #868](https://github.com/PowerShell/xSQLServer/issues/868)).
 - Changes to xSQLServerAlwaysOnAvailabilityGroupDatabaseMembership
-  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
   - Made the resource cluster aware. When ProcessOnlyOnActiveNode is specified,
     the resource will only determine if a change is needed if the target node
     is the active host of the SQL Server instance ([issue #869](https://github.com/PowerShell/xSQLServer/issues/869)).
 - Changes to xSQLServerAlwaysOnAvailabilityGroupReplica
-  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
   - Made the resource cluster aware. When ProcessOnlyOnActiveNode is specified,
     the resource will only determine if a change is needed if the target node is
     the active host of the SQL Server instance ([issue #870](https://github.com/PowerShell/xSQLServer/issues/870)).
@@ -82,38 +115,12 @@
   - Fixed a problem when running the tests locally in a PowerShell console it
     would ask for parameters ([issue #897](https://github.com/PowerShell/xSQLServer/issues/897)).
 - Changes to xSQLServerAvailabilityGroupListener
-  - BREAKING CHANGE: Parameter NodeName has been renamed to ServerName
-    ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
   - Fixed a problem when running the tests locally in a PowerShell console it
     would ask for parameters ([issue #897](https://github.com/PowerShell/xSQLServer/issues/897)).
 - Changes to xSQLServerMaxDop
   - Made the resource cluster aware. When ProcessOnlyOnActiveNode is specified,
     the resource will only determine if a change is needed if the target node
     is the active host of the SQL Server instance ([issue #882](https://github.com/PowerShell/xSQLServer/issues/882)).
-- Changes to SqlServerLogin
-  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
-- Changes to SqlServerPermission
-  - BREAKING CHANGE: Parameter NodeName has been renamed to ServerName
-    ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
-- Changes to SqlServerEndpoint
-  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
-- Changes to SqlServerOwner
-  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
-- Changes to SqlAlwaysOnService
-  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
-- Changes to SqlDatabasePermission
-  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
-- Changes to SqlDatabaseRecoveryModel
-  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
-- Changes to SqlDatabaseRole
-  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
 
 ## 8.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,72 +17,72 @@
     ([issue #904](https://github.com/PowerShell/SqlServerDsc/issues/904)).
 - Changes to SqlAG
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
 - Changes to SqlAGDatabase
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
   - Changed the Get-MatchingDatabaseNames function to be case insensitive when
     matching database names. ([issue #912](https://github.com/PowerShell/SqlServerDsc/issues/912))
 - Changes to SqlAGListener
   - BREAKING CHANGE: Parameter NodeName has been renamed to ServerName
-    ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
 - Changes to SqlAGReplica
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
 - Changes to SqlAlwaysOnService
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
 - Changes to SqlDatabase
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
 - Changes SqlDatabaseDefaultLocation
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
 - Changes to SqlDatabasePermission
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
 - Changes to SqlDatabaseRecoveryModel
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
 - Changes to SqlDatabaseRole
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
 - Changes to SqlServerConfiguration
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
 - Changes to SqlServerEndpoint
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
 - Changes to SqlServerEndpointPermission
   - BREAKING CHANGE: Parameter NodeName has been renamed to ServerName
-    ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
 - Changes to SqlServerEndpointState
   - BREAKING CHANGE: Parameter NodeName has been renamed to ServerName
-    ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
 - Changes to SqlServerLogin
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
 - Changes to SqlServerMaxDop
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
 - Changes to SqlServerMemory
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
 - Changes to SqlServerNetwork
   - BREAKING CHANGE: Parameters SQLServer has been renamed to ServerName
-    ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
 - Changes to SqlServerOwner
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
 - Changes to SqlServerPermission
   - BREAKING CHANGE: Parameter NodeName has been renamed to ServerName
-    ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
 - Changes to SqlServerRole
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
 - Changes to SqlServerServiceAccount
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
 
 ## 9.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,9 @@
 - Changes to SqlServerOwner
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+- Changes to SqlAlwaysOnService
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
 
 ## 8.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@
 - Changes to SqlServerRole
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+- Changes to SqlServerServiceAccount
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
 
 ## 9.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 - BREAKING CHANGE: Resource module has been renamed to SqlServerDsc
   ([issue #916](https://github.com/PowerShell/SqlServerDsc/issues/916)).
-- BREAKING CHANGE: Significant rename to reduce length of Resource names
-  - See [issue #851](https://github.com/PowerShell/SqlServerDsc/issues/851) for a
-  complete table mapping rename changes.
-  - Impact to all resources
+- BREAKING CHANGE: Significant rename to reduce length of resource names
+  - See [issue #851](https://github.com/PowerShell/xSQLServer/issues/851) for a
+    complete table mapping rename changes.
+  - Impact to all resources.
 - Changes to CONTRIBUTING.md
   - Added details to the naming convention used in SqlServerDsc.
 - Changes to SqlServerDsc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@
   - Fixed a problem when running the tests locally in a PowerShell console it
     would ask for parameters ([issue #897](https://github.com/PowerShell/xSQLServer/issues/897)).
 - Changes to xSQLServerAvailabilityGroupListener
+  - BREAKING CHANGE: Parameter NodeName has been renamed to ServerName
+    ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
   - Fixed a problem when running the tests locally in a PowerShell console it
     would ask for parameters ([issue #897](https://github.com/PowerShell/xSQLServer/issues/897)).
 - Changes to xSQLServerMaxDop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@
 - Changes to SqlServerMaxDop
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+- Changes to SqlServerMemory
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
 - Changes to SqlServerOwner
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
   - Fixed unit tests for Get-TargetResource to ensure correctly testing return
     values ([issue #849](https://github.com/PowerShell/xSQLServer/issues/849))
 - Changes to xSQLServerAlwaysOnAvailabilityGroup
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
   - Refactored the unit tests to allow them to be more user friendly and to test
     additional SQLServer variations.
     - Each test will utilize the Import-SQLModuleStub to ensure the correct

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
   - Updated Pester syntax to v4
   - Fixes broken links to issues in the CHANGELOG.md.
 - Changes to xSQLServerDatabase
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
   - Added parameter to specify collation for a database to be different from server
     collation ([issue #767](https://github.com/PowerShell/xSQLServer/issues/767)).
   - Fixed unit tests for Get-TargetResource to ensure correctly testing return

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@
 - Changes to SqlServerLogin
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+- Changes to SqlServerMaxDop
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
 - Changes to SqlServerOwner
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,9 @@
 - Changes to SqlDatabasePermission
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+- Changes to SqlDatabaseRecoveryModel
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
 
 ## 8.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@
 - Changes to SqlServerEndpoint
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+- Changes to SqlServerEndpointPermission
+  - BREAKING CHANGE: Parameter NodeName has been renamed to ServerName
+    ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
 - Changes to SqlServerLogin
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,9 @@
 - Changes to SqlServerEndpoint
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
+- Changes to SqlServerOwner
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
 
 ## 8.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,9 @@
   - Made the resource cluster aware. When ProcessOnlyOnActiveNode is specified,
     the resource will only determine if a change is needed if the target node
     is the active host of the SQL Server instance ([issue #882](https://github.com/PowerShell/xSQLServer/issues/882)).
+- Changes to SqlServerLogin
+  - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
+    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/xSQLServer/issues/)).
 
 ## 8.2.0.0
 

--- a/DSCResources/MSFT_SqlAG/MSFT_SqlAG.schema.mof
+++ b/DSCResources/MSFT_SqlAG/MSFT_SqlAG.schema.mof
@@ -2,8 +2,8 @@
 class MSFT_SqlAG : OMI_BaseResource
 {
     [Key, Description("The name of the availability group.")] String Name;
-    [Required, Description("Hostname of the SQL Server to be configured.")] String SQLServer;
-    [Key, Description("Name of the SQL instance to be configured.")] String SQLInstanceName;
+    [Required, Description("Hostname of the SQL Server to be configured.")] String ServerName;
+    [Key, Description("Name of the SQL instance to be configured.")] String InstanceName;
     [Write, Description("Specifies if the availability group should be present or absent. Default is Present."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("Specifies the automated backup preference for the availability group. Default is None"), ValueMap{"Primary","SecondaryOnly","Secondary","None"}, Values{"Primary","SecondaryOnly","Secondary","None"}] String AutomatedBackupPreference;
     [Write, Description("Specifies the replica availability mode. Default is 'AsynchronousCommit'."), ValueMap{"AsynchronousCommit","SynchronousCommit"}, Values{"AsynchronousCommit","SynchronousCommit"}] String AvailabilityMode;

--- a/DSCResources/MSFT_SqlAGDatabase/MSFT_SqlAGDatabase.psm1
+++ b/DSCResources/MSFT_SqlAGDatabase/MSFT_SqlAGDatabase.psm1
@@ -14,12 +14,12 @@ $script:localizedData = Get-LocalizedData -ResourceName 'MSFT_SqlAGDatabase'
     .PARAMETER DatabaseName
         The name of the database(s) to add to the availability group. This accepts wildcards.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
         Hostname of the SQL Server where the primary replica of the availability group lives. If the
         availability group is not currently on this server, the resource will attempt to connect to the
         server where the primary replica lives.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
         Name of the SQL instance where the primary replica of the availability group lives. If the
         availability group is not currently on this instance, the resource will attempt to connect to
         the instance where the primary replica lives.
@@ -43,11 +43,11 @@ function Get-TargetResource
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        $SQLServer,
+        $ServerName,
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        $SQLInstanceName,
+        $InstanceName,
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -61,8 +61,8 @@ function Get-TargetResource
     # Create an object that reflects the current configuration
     $currentConfiguration = @{
         DatabaseName          = @()
-        SQLServer             = $SQLServer
-        SQLInstanceName       = $SQLInstanceName
+        ServerName             = $ServerName
+        InstanceName       = $InstanceName
         AvailabilityGroupName = ''
         BackupPath            = ''
         Ensure                = ''
@@ -72,7 +72,7 @@ function Get-TargetResource
     }
 
     # Connect to the instance
-    $serverObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    $serverObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
     # Is this node actively hosting the SQL instance?
     $currentConfiguration.IsActiveNode = Test-ActiveNode -ServerObject $serverObject
@@ -102,12 +102,12 @@ function Get-TargetResource
     .PARAMETER DatabaseName
         The name of the database(s) to add to the availability group. This accepts wildcards.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
         Hostname of the SQL Server where the primary replica of the availability group lives. If the
         availability group is not currently on this server, the resource will attempt to connect to the
         server where the primary replica lives.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
         Name of the SQL instance where the primary replica of the availability group lives. If the
         availability group is not currently on this instance, the resource will attempt to connect to
         the instance where the primary replica lives.
@@ -159,11 +159,11 @@ function Set-TargetResource
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        $SQLServer,
+        $ServerName,
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        $SQLInstanceName,
+        $InstanceName,
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -194,7 +194,7 @@ function Set-TargetResource
     Import-SQLPSModule
 
     # Connect to the defined instance
-    $serverObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    $serverObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
     # Get the Availability Group
     $availabilityGroup = $serverObject.AvailabilityGroups[$AvailabilityGroupName]
@@ -568,12 +568,12 @@ function Set-TargetResource
     .PARAMETER DatabaseName
         The name of the database(s) to add to the availability group. This accepts wildcards.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
         Hostname of the SQL Server where the primary replica of the availability group lives. If the
         availability group is not currently on this server, the resource will attempt to connect to the
         server where the primary replica lives.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
         Name of the SQL instance where the primary replica of the availability group lives. If the
         availability group is not currently on this instance, the resource will attempt to connect to
         the instance where the primary replica lives.
@@ -625,11 +625,11 @@ function Test-TargetResource
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        $SQLServer,
+        $ServerName,
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        $SQLInstanceName,
+        $InstanceName,
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -661,8 +661,8 @@ function Test-TargetResource
 
     $getTargetResourceParameters = @{
         DatabaseName          = $DatabaseName
-        SQLServer             = $SQLServer
-        SQLInstanceName       = $SQLInstanceName
+        ServerName             = $ServerName
+        InstanceName       = $InstanceName
         AvailabilityGroupName = $AvailabilityGroupName
         BackupPath            = $BackupPath
     }
@@ -674,12 +674,12 @@ function Test-TargetResource
     #>
     if ( $ProcessOnlyOnActiveNode -and -not $currentConfiguration.IsActiveNode )
     {
-        Write-Verbose -Message ( $script:localizedData.NotActiveNode -f $env:COMPUTERNAME,$SQLInstanceName )
+        Write-Verbose -Message ( $script:localizedData.NotActiveNode -f $env:COMPUTERNAME,$InstanceName )
         return $configurationInDesiredState
     }
 
     # Connect to the defined instance
-    $serverObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    $serverObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
     # Get the Availability Group if it exists
     if ( -not [string]::IsNullOrEmpty($currentConfiguration.AvailabilityGroupName) )

--- a/DSCResources/MSFT_SqlAGDatabase/MSFT_SqlAGDatabase.schema.mof
+++ b/DSCResources/MSFT_SqlAGDatabase/MSFT_SqlAGDatabase.schema.mof
@@ -2,8 +2,8 @@
 class MSFT_SqlAGDatabase : OMI_BaseResource
 {
     [Required, Description("The name of the database(s) to add to the availability group. This accepts wildcards.")] String DatabaseName[];
-    [Key, Description("Hostname of the SQL Server where the primary replica of the availability group lives. If the availability group is not currently on this server, the resource will attempt to connect to the server where the primary replica lives.")] String SQLServer;
-    [Key, Description("Name of the SQL instance to be configured.")] String SQLInstanceName;
+    [Key, Description("Hostname of the SQL Server where the primary replica of the availability group lives. If the availability group is not currently on this server, the resource will attempt to connect to the server where the primary replica lives.")] String ServerName;
+    [Key, Description("Name of the SQL instance to be configured.")] String InstanceName;
     [Key, Description("The name of the availability group in which to manage the database membership(s).")] String AvailabilityGroupName;
     [Required, Description("The path used to seed the availability group replicas. This should be a path that is accessible by all of the replicas")] String BackupPath;
     [Write, Description("Specifies the membership of the database(s) in the availability group. The options are: Present: The defined database(s) are added to the availability group. All other databases that may be a member of the availability group are ignored. Absent: The defined database(s) are removed from the availability group. All other databases that may be a member of the availability group are ignored. The default is 'Present'."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;

--- a/DSCResources/MSFT_SqlAGDatabase/en-US/about_SqlAGDatabase.help.txt
+++ b/DSCResources/MSFT_SqlAGDatabase/en-US/about_SqlAGDatabase.help.txt
@@ -4,12 +4,12 @@ SYNOPSIS
 PARAMETER DatabaseName
     The name of the database(s) to add to the availability group. This accepts wildcards.
 
-PARAMETER SQLServer
+PARAMETER ServerName
     Hostname of the SQL Server where the primary replica of the availability group lives. If the
     availability group is not currently on this server, the resource will attempt to connect to the
     server where the primary replica lives.
 
-PARAMETER SQLInstanceName
+PARAMETER InstanceName
     Name of the SQL instance where the primary replica of the availability group lives. If the
     availability group is not currently on this instance, the resource will attempt to connect to
     the instance where the primary replica lives.

--- a/DSCResources/MSFT_SqlAGListener/MSFT_SqlAGListener.psm1
+++ b/DSCResources/MSFT_SqlAGListener/MSFT_SqlAGListener.psm1
@@ -1,6 +1,6 @@
 Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) `
-                               -ChildPath 'SqlServerDscHelper.psm1') `
-                               -Force
+        -ChildPath 'SqlServerDscHelper.psm1') `
+    -Force
 <#
     .SYNOPSIS
         Returns the current state of the Availability Group listener.
@@ -8,7 +8,7 @@ Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Pare
     .PARAMETER InstanceName
         The SQL Server instance name of the primary replica. Default value is 'MSSQLSERVER'.
 
-    .PARAMETER NodeName
+    .PARAMETER ServerName
         The host name or FQDN of the primary replica.
 
     .PARAMETER Name
@@ -29,10 +29,10 @@ function Get-TargetResource
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        $NodeName,
+        $ServerName,
 
         [Parameter(Mandatory = $true)]
-        [ValidateLength(1,15)]
+        [ValidateLength(1, 15)]
         [System.String]
         $Name,
 
@@ -43,7 +43,7 @@ function Get-TargetResource
 
     try
     {
-        $availabilityGroupListener = Get-SQLAlwaysOnAvailabilityGroupListener -Name $Name -AvailabilityGroup $AvailabilityGroup -NodeName $NodeName -InstanceName $InstanceName
+        $availabilityGroupListener = Get-SQLAlwaysOnAvailabilityGroupListener -Name $Name -AvailabilityGroup $AvailabilityGroup -ServerName $ServerName -InstanceName $InstanceName
 
         if ($null -ne $availabilityGroupListener)
         {
@@ -77,14 +77,14 @@ function Get-TargetResource
     }
 
     return @{
-        InstanceName = [System.String] $InstanceName
-        NodeName = [System.String] $NodeName
-        Name = [System.String] $Name
-        Ensure = [System.String] $ensure
+        InstanceName      = [System.String] $InstanceName
+        ServerName        = [System.String] $ServerName
+        Name              = [System.String] $Name
+        Ensure            = [System.String] $ensure
         AvailabilityGroup = [System.String] $AvailabilityGroup
-        IpAddress = [System.String[]] $ipAddress
-        Port = [System.UInt16] $port
-        DHCP = [System.Boolean] $dhcp
+        IpAddress         = [System.String[]] $ipAddress
+        Port              = [System.UInt16] $port
+        DHCP              = [System.Boolean] $dhcp
     }
 }
 
@@ -95,7 +95,7 @@ function Get-TargetResource
     .PARAMETER InstanceName
         The SQL Server instance name of the primary replica. Default value is 'MSSQLSERVER'.
 
-    .PARAMETER NodeName
+    .PARAMETER ServerName
         The host name or FQDN of the primary replica.
 
     .PARAMETER Name
@@ -127,15 +127,15 @@ function Set-TargetResource
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        $NodeName,
+        $ServerName,
 
         [Parameter(Mandatory = $true)]
-        [ValidateLength(1,15)]
+        [ValidateLength(1, 15)]
         [System.String]
         $Name,
 
         [Parameter()]
-        [ValidateSet('Present','Absent')]
+        [ValidateSet('Present', 'Absent')]
         [System.String]
         $Ensure = 'Present',
 
@@ -157,9 +157,9 @@ function Set-TargetResource
     )
 
     $parameters = @{
-        InstanceName = [System.String] $InstanceName
-        NodeName = [System.String] $NodeName
-        Name = [System.String] $Name
+        InstanceName      = [System.String] $InstanceName
+        ServerName        = [System.String] $ServerName
+        Name              = [System.String] $Name
         AvailabilityGroup = [System.String] $AvailabilityGroup
     }
 
@@ -172,13 +172,13 @@ function Set-TargetResource
             {
                 New-VerboseMessage -Message "Create listener on $AvailabilityGroup"
 
-                $sqlServerObject = Connect-SQL -SQLServer $NodeName -SQLInstanceName $InstanceName
+                $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
                 $availabilityGroupObject = $sqlServerObject.AvailabilityGroups[$AvailabilityGroup]
                 if ($availabilityGroupObject)
                 {
                     $newListenerParams = @{
-                        Name = $Name
+                        Name        = $Name
                         InputObject = $availabilityGroupObject
                     }
 
@@ -213,14 +213,14 @@ function Set-TargetResource
                 }
                 else
                 {
-                    throw New-TerminatingError -ErrorType AvailabilityGroupNotFound -FormatArgs @($AvailabilityGroup,$InstanceName) -ErrorCategory ObjectNotFound
+                    throw New-TerminatingError -ErrorType AvailabilityGroupNotFound -FormatArgs @($AvailabilityGroup, $InstanceName) -ErrorCategory ObjectNotFound
                 }
             }
             else
             {
                 New-VerboseMessage -Message "Remove listener from $AvailabilityGroup"
 
-                $sqlServerObject = Connect-SQL -SQLServer $NodeName -SQLInstanceName $InstanceName
+                $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
                 $availabilityGroupObject = $sqlServerObject.AvailabilityGroups[$AvailabilityGroup]
                 if ($availabilityGroupObject)
@@ -237,7 +237,7 @@ function Set-TargetResource
                 }
                 else
                 {
-                    throw New-TerminatingError -ErrorType AvailabilityGroupNotFound -FormatArgs @($AvailabilityGroup,$InstanceName) -ErrorCategory ObjectNotFound
+                    throw New-TerminatingError -ErrorType AvailabilityGroupNotFound -FormatArgs @($AvailabilityGroup, $InstanceName) -ErrorCategory ObjectNotFound
                 }
             }
         }
@@ -260,11 +260,11 @@ function Set-TargetResource
                     # No new IP-address
                     if ($null -eq $IpAddress -or -not ( Compare-Object -ReferenceObject $IpAddress -DifferenceObject $availabilityGroupListenerState.IpAddress))
                     {
-                       $ipAddressEqual = $true
+                        $ipAddressEqual = $true
                     }
                     else
                     {
-                        throw New-TerminatingError -ErrorType AvailabilityGroupListenerIPChangeError -FormatArgs @($($IpAddress -join ', '),$($availabilityGroupListenerState.IpAddress -join ', ')) -ErrorCategory InvalidOperation
+                        throw New-TerminatingError -ErrorType AvailabilityGroupListenerIPChangeError -FormatArgs @($($IpAddress -join ', '), $($availabilityGroupListenerState.IpAddress -join ', ')) -ErrorCategory InvalidOperation
                     }
                 }
 
@@ -273,7 +273,7 @@ function Set-TargetResource
                     throw New-TerminatingError -ErrorType AvailabilityGroupListenerDHCPChangeError -FormatArgs @( $DHCP, $($availabilityGroupListenerState.DHCP) ) -ErrorCategory InvalidOperation
                 }
 
-                $sqlServerObject = Connect-SQL -SQLServer $NodeName -SQLInstanceName $InstanceName
+                $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
                 $availabilityGroupObject = $sqlServerObject.AvailabilityGroups[$AvailabilityGroup]
                 if ($availabilityGroupObject)
@@ -291,7 +291,7 @@ function Set-TargetResource
 
                                 $setListenerParams = @{
                                     InputObject = $availabilityGroupListenerObject
-                                    Port = $Port
+                                    Port        = $Port
                                 }
 
                                 Set-SqlAvailabilityGroupListener @setListenerParams -ErrorAction Stop | Out-Null
@@ -313,7 +313,7 @@ function Set-TargetResource
 
                                 $setListenerParams = @{
                                     InputObject = $availabilityGroupListenerObject
-                                    StaticIp = $newIpAddress
+                                    StaticIp    = $newIpAddress
                                 }
 
                                 Add-SqlAvailabilityGroupListenerStaticIp @setListenerParams -ErrorAction Stop | Out-Null
@@ -331,7 +331,7 @@ function Set-TargetResource
                 }
                 else
                 {
-                    throw New-TerminatingError -ErrorType AvailabilityGroupNotFound -FormatArgs @($AvailabilityGroup,$InstanceName) -ErrorCategory ObjectNotFound
+                    throw New-TerminatingError -ErrorType AvailabilityGroupNotFound -FormatArgs @($AvailabilityGroup, $InstanceName) -ErrorCategory ObjectNotFound
                 }
             }
         }
@@ -349,7 +349,7 @@ function Set-TargetResource
     .PARAMETER InstanceName
         The SQL Server instance name of the primary replica. Default value is 'MSSQLSERVER'.
 
-    .PARAMETER NodeName
+    .PARAMETER ServerName
         The host name or FQDN of the primary replica.
 
     .PARAMETER Name
@@ -382,15 +382,15 @@ function Test-TargetResource
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        $NodeName,
+        $ServerName,
 
         [Parameter(Mandatory = $true)]
-        [ValidateLength(1,15)]
+        [ValidateLength(1, 15)]
         [System.String]
         $Name,
 
         [Parameter()]
-        [ValidateSet('Present','Absent')]
+        [ValidateSet('Present', 'Absent')]
         [System.String]
         $Ensure = 'Present',
 
@@ -412,9 +412,9 @@ function Test-TargetResource
     )
 
     $parameters = @{
-        InstanceName = [System.String] $InstanceName
-        NodeName = [System.String] $NodeName
-        Name = [System.String] $Name
+        InstanceName      = [System.String] $InstanceName
+        ServerName        = [System.String] $ServerName
+        Name              = [System.String] $Name
         AvailabilityGroup = [System.String] $AvailabilityGroup
     }
 
@@ -479,12 +479,12 @@ function Get-SQLAlwaysOnAvailabilityGroupListener
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        $NodeName
+        $ServerName
     )
 
     Write-Debug "Connecting to availability group $Name as $([System.Security.Principal.WindowsIdentity]::GetCurrent().Name)"
 
-    $sqlServerObject = Connect-SQL -SQLServer $NodeName -SQLInstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
     $availabilityGroupObject = $sqlServerObject.AvailabilityGroups[$AvailabilityGroup]
     if ($availabilityGroupObject)
@@ -493,7 +493,7 @@ function Get-SQLAlwaysOnAvailabilityGroupListener
     }
     else
     {
-        throw New-TerminatingError -ErrorType AvailabilityGroupNotFound -FormatArgs @($AvailabilityGroup,$InstanceName) -ErrorCategory ObjectNotFound
+        throw New-TerminatingError -ErrorType AvailabilityGroupNotFound -FormatArgs @($AvailabilityGroup, $InstanceName) -ErrorCategory ObjectNotFound
     }
 
     return $availabilityGroupListener

--- a/DSCResources/MSFT_SqlAGListener/MSFT_SqlAGListener.schema.mof
+++ b/DSCResources/MSFT_SqlAGListener/MSFT_SqlAGListener.schema.mof
@@ -3,7 +3,7 @@
 class MSFT_SqlAGListener : OMI_BaseResource
 {
     [Key, Description("The SQL Server instance name of the primary replica.")] String InstanceName;
-    [Required, Description("The host name or FQDN of the primary replica.")] String NodeName;
+    [Required, Description("The host name or FQDN of the primary replica.")] String ServerName;
     [Required, Description("The name of the availability group listener, max 15 characters. This name will be used as the Virtual Computer Object (VCO).")] String Name;
     [Write, Description("If the availability group listener should be present or absent. Default value is 'Present'."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Key, Description("The name of the availability group to which the availability group listener is or will be connected.")] String AvailabilityGroup;

--- a/DSCResources/MSFT_SqlAGReplica/MSFT_SqlAGReplica.schema.mof
+++ b/DSCResources/MSFT_SqlAGReplica/MSFT_SqlAGReplica.schema.mof
@@ -3,8 +3,8 @@ class MSFT_SqlAGReplica : OMI_BaseResource
 {
     [Key, Description("The name of the availability group replica. For named instances this must be in the following format SQLServer\\InstanceName.")] String Name;
     [Key, Description("The name of the availability group.")] String AvailabilityGroupName;
-    [Required, Description("Hostname of the SQL Server to be configured.")] String SQLServer;
-    [Key, Description("Name of the SQL instance to be configured.")] String SQLInstanceName;
+    [Required, Description("Hostname of the SQL Server to be configured.")] String ServerName;
+    [Key, Description("Name of the SQL instance to be configured.")] String InstanceName;
     [Write, Description("Hostname of the SQL Server where the primary replica is expected to be active. If the primary replica is not found here, the resource will attempt to find the host that holds the primary replica and connect to it.")] String PrimaryReplicaSQLServer;
     [Write, Description("Name of the SQL instance where the primary replica lives.")] String PrimaryReplicaSQLInstanceName;
     [Write, Description("Specifies if the availability group replica should be present or absent. Default is Present."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;

--- a/DSCResources/MSFT_SqlAGReplica/MSFT_SqlAGReplica.schema.mof
+++ b/DSCResources/MSFT_SqlAGReplica/MSFT_SqlAGReplica.schema.mof
@@ -1,7 +1,7 @@
 [ClassVersion("1.0.0.0"), FriendlyName("SqlAGReplica")]
 class MSFT_SqlAGReplica : OMI_BaseResource
 {
-    [Key, Description("The name of the availability group replica. For named instances this must be in the following format SQLServer\\InstanceName.")] String Name;
+    [Key, Description("The name of the availability group replica. For named instances this must be in the following format ServerName\\InstanceName.")] String Name;
     [Key, Description("The name of the availability group.")] String AvailabilityGroupName;
     [Required, Description("Hostname of the SQL Server to be configured.")] String ServerName;
     [Key, Description("Name of the SQL instance to be configured.")] String InstanceName;

--- a/DSCResources/MSFT_SqlAlwaysOnService/MSFT_SqlAlwaysOnService.schema.mof
+++ b/DSCResources/MSFT_SqlAlwaysOnService/MSFT_SqlAlwaysOnService.schema.mof
@@ -2,8 +2,8 @@
 class MSFT_SqlAlwaysOnService : OMI_BaseResource
 {
     [Required, Description("An enumerated value that describes if the SQL Server should have Always On high availability and disaster recovery (HADR) property enabled ('Present') or disabled ('Absent')."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
-    [Key, Description("The hostname of the SQL Server to be configured.")] String SQLServer;
-    [Key, Description("The name of the SQL instance to be configured.")] String SQLInstanceName;
+    [Key, Description("The hostname of the SQL Server to be configured.")] String ServerName;
+    [Key, Description("The name of the SQL instance to be configured.")] String InstanceName;
     [Write, Description("The length of time, in seconds, to wait for the service to restart. Default is 120 seconds.")] Uint32 RestartTimeout;
     [Read, Description("Returns the status of AlwaysOn high availability and disaster recovery (HADR).")] Boolean IsHadrEnabled;
 };

--- a/DSCResources/MSFT_SqlDatabase/MSFT_SqlDatabase.psm1
+++ b/DSCResources/MSFT_SqlDatabase/MSFT_SqlDatabase.psm1
@@ -12,10 +12,10 @@ Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Pare
     .PARAMETER Name
     The name of database to be created or dropped.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
     The host name of the SQL Server to be configured.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     The name of the SQL instance to be configured.
 
     .PARAMETER Collation
@@ -43,12 +43,12 @@ function Get-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer,
+        $ServerName,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName,
+        $InstanceName,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
@@ -56,7 +56,7 @@ function Get-TargetResource
         $Collation
     )
 
-    $sqlServerObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
     if ($sqlServerObject)
     {
@@ -79,11 +79,11 @@ function Get-TargetResource
     }
 
     $returnValue = @{
-        Name            = $Name
-        Ensure          = $Ensure
-        SQLServer       = $SQLServer
-        SQLInstanceName = $SQLInstanceName
-        Collation       = $sqlDatabaseCollation
+        Name         = $Name
+        Ensure       = $Ensure
+        ServerName   = $ServerName
+        InstanceName = $InstanceName
+        Collation    = $sqlDatabaseCollation
     }
 
     $returnValue
@@ -100,10 +100,10 @@ function Get-TargetResource
     .PARAMETER Name
     The name of database to be created or dropped.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
     The host name of the SQL Server to be configured.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     The name of the SQL instance to be configured.
 
     .PARAMETER Collation
@@ -129,12 +129,12 @@ function Set-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer,
+        $ServerName,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName,
+        $InstanceName,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
@@ -142,7 +142,7 @@ function Set-TargetResource
         $Collation
     )
 
-    $sqlServerObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
     if ($sqlServerObject)
     {
@@ -156,7 +156,7 @@ function Set-TargetResource
             elseif ($Collation -notin $sqlServerObject.EnumCollations().Name)
             {
                 throw New-TerminatingError -ErrorType InvalidCollationError `
-                    -FormatArgs @($SQLServer, $SQLInstanceName, $Name, $Collation) `
+                    -FormatArgs @($ServerName, $InstanceName, $Name, $Collation) `
                     -ErrorCategory InvalidOperation
             }
 
@@ -174,7 +174,7 @@ function Set-TargetResource
                 catch
                 {
                     throw New-TerminatingError -ErrorType UpdateDatabaseSetError `
-                        -FormatArgs @($SQLServer, $SQLInstanceName, $Name) `
+                        -FormatArgs @($ServerName, $InstanceName, $Name) `
                         -ErrorCategory InvalidOperation `
                         -InnerException $_.Exception
                 }
@@ -195,7 +195,7 @@ function Set-TargetResource
                 catch
                 {
                     throw New-TerminatingError -ErrorType CreateDatabaseSetError `
-                        -FormatArgs @($SQLServer, $SQLInstanceName, $Name) `
+                        -FormatArgs @($ServerName, $InstanceName, $Name) `
                         -ErrorCategory InvalidOperation `
                         -InnerException $_.Exception
                 }
@@ -216,7 +216,7 @@ function Set-TargetResource
             catch
             {
                 throw New-TerminatingError -ErrorType DropDatabaseSetError `
-                    -FormatArgs @($SQLServer, $SQLInstanceName, $Name) `
+                    -FormatArgs @($ServerName, $InstanceName, $Name) `
                     -ErrorCategory InvalidOperation `
                     -InnerException $_.Exception
             }
@@ -235,10 +235,10 @@ function Set-TargetResource
     .PARAMETER Name
     The name of database to be created or dropped.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
     The host name of the SQL Server to be configured.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     The name of the SQL instance to be configured.
 
     .PARAMETER Collation
@@ -265,12 +265,12 @@ function Test-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer,
+        $ServerName,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName,
+        $InstanceName,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]

--- a/DSCResources/MSFT_SqlDatabase/MSFT_SqlDatabase.schema.mof
+++ b/DSCResources/MSFT_SqlDatabase/MSFT_SqlDatabase.schema.mof
@@ -3,7 +3,7 @@ class MSFT_SqlDatabase : OMI_BaseResource
 {
     [Key, Description("The name of the SQL database.")] String Name;
     [Write, Description("An enumerated value that describes if the database is added (Present) or dropped (Absent). Valid values are 'Present' or 'Absent'. Default Value is 'Present'."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
-    [Key, Description("The host name of the SQL Server to be configured.")] String SQLServer;
-    [Key, Description("The name of the SQL instance to be configured.")] String SQLInstanceName;
+    [Key, Description("The host name of the SQL Server to be configured.")] String ServerName;
+    [Key, Description("The name of the SQL instance to be configured.")] String InstanceName;
     [Write, Description("The name of the SQL collation to use for the new database. Defaults to server collation.")] String Collation;
 };

--- a/DSCResources/MSFT_SqlDatabaseDefaultLocation/MSFT_SqlDatabaseDefaultLocation.psm1
+++ b/DSCResources/MSFT_SqlDatabaseDefaultLocation/MSFT_SqlDatabaseDefaultLocation.psm1
@@ -3,7 +3,7 @@ Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Pare
     -Force
 
 Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
-                               -ChildPath 'CommonResourceHelper.psm1')
+        -ChildPath 'CommonResourceHelper.psm1')
 
 $script:localizedData = Get-LocalizedData -ResourceName 'MSFT_SqlDatabaseDefaultLocation'
 
@@ -11,10 +11,10 @@ $script:localizedData = Get-LocalizedData -ResourceName 'MSFT_SqlDatabaseDefault
     .SYNOPSIS
         Returns the current path to the the desired default location for the Data, Log, or Backup files.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
         The host name of the SQL Server to be configured.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
         The name of the SQL instance to be configured.
 
     .PARAMETER Type
@@ -33,12 +33,12 @@ Function Get-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer,
+        $ServerName,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName,
+        $InstanceName,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('Data', 'Log', 'Backup')]
@@ -51,10 +51,10 @@ Function Get-TargetResource
         $Path
     )
 
-    Write-Verbose -Message ($script:localizedData.GetCurrentPath -f $Type, $SQLInstanceName)
+    Write-Verbose -Message ($script:localizedData.GetCurrentPath -f $Type, $InstanceName)
 
     # Connect to the instance
-    $sqlServerObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
     # Is this node actively hosting the SQL instance?
     $isActiveNode = Test-ActiveNode -ServerObject $sqlServerObject
@@ -79,11 +79,11 @@ Function Get-TargetResource
     }
 
     return @{
-        SqlInstanceName     = $SQLInstanceName
-        SqlServer           = $SQLServer
-        Type                = $Type
-        Path                = $currentPath
-        IsActiveNode        = $isActiveNode
+        InstanceName = $InstanceName
+        ServerName   = $ServerName
+        Type         = $Type
+        Path         = $currentPath
+        IsActiveNode = $isActiveNode
     }
 }
 
@@ -91,10 +91,10 @@ Function Get-TargetResource
     .SYNOPSIS
         This function sets the current path for the default SQL Instance location for the Data, Log, or Backups files.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
         The host name of the SQL Server to be configured.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
         The name of the SQL instance to be configured.
 
     .PARAMETER Type
@@ -119,12 +119,12 @@ Function Set-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer,
+        $ServerName,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName,
+        $InstanceName,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('Data', 'Log', 'Backup')]
@@ -153,7 +153,7 @@ Function Set-TargetResource
     else
     {
         Write-Verbose -Message ($script:localizedData.SettingDefaultPath -f $Type)
-        $sqlServerObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+        $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
         # Check which default location is being updated
         switch ($Type)
@@ -187,8 +187,8 @@ Function Set-TargetResource
 
             if ($RestartService)
             {
-                Write-Verbose -Message ($script:localizedData.RestartSqlServer -f $SqlServer, $SQLInstanceName)
-                Restart-SqlService -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+                Write-Verbose -Message ($script:localizedData.RestartSqlServer -f $ServerName, $InstanceName)
+                Restart-SqlService -SQLServer $ServerName -SQLInstanceName $InstanceName
             }
         }
         catch
@@ -207,10 +207,10 @@ Function Set-TargetResource
     .SYNOPSIS
         This function tests the current path to the default database location for the Data, Log, or Backups files.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
         The host name of the SQL Server to be configured.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
         The name of the SQL instance to be configured.
 
     .PARAMETER Type
@@ -235,12 +235,12 @@ function Test-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer,
+        $ServerName,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName,
+        $InstanceName,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('Data', 'Log', 'Backup')]
@@ -264,10 +264,10 @@ function Test-TargetResource
     Write-Verbose -Message ($script:localizedData.TestingCurrentPath -f $Type)
 
     $getTargetResourceParameters = @{
-        SQLInstanceName     = $SQLInstanceName
-        SQLServer           = $SQLServer
-        Type                = $Type
-        Path                = $Path
+        InstanceName = $InstanceName
+        ServerName   = $ServerName
+        Type         = $Type
+        Path         = $Path
     }
 
     $isDefaultPathInDesiredState = $true
@@ -279,7 +279,7 @@ function Test-TargetResource
     #>
     if ( $ProcessOnlyOnActiveNode -and -not $getTargetResourceResult.IsActiveNode )
     {
-        Write-Verbose -Message ($script:localizedData.NotActiveClusterNode -f $env:COMPUTERNAME,$SQLInstanceName )
+        Write-Verbose -Message ($script:localizedData.NotActiveClusterNode -f $env:COMPUTERNAME, $InstanceName )
     }
     elseif ($getTargetResourceResult.Path -ne $Path)
     {

--- a/DSCResources/MSFT_SqlDatabaseDefaultLocation/MSFT_SqlDatabaseDefaultLocation.schema.mof
+++ b/DSCResources/MSFT_SqlDatabaseDefaultLocation/MSFT_SqlDatabaseDefaultLocation.schema.mof
@@ -1,8 +1,8 @@
 [ClassVersion("1.0.0.0"), FriendlyName("SqlDatabaseDefaultLocation")]
 class MSFT_SqlDatabaseDefaultLocation : OMI_BaseResource
 {
-    [Key, Description("The host name of the SQL Server to be configured.")] String SQLServer;
-    [Key, Description("The name of the SQL instance to be configured.")] String SQLInstanceName;
+    [Key, Description("The host name of the SQL Server to be configured.")] String ServerName;
+    [Key, Description("The name of the SQL instance to be configured.")] String InstanceName;
     [Key, Description("The type of database default location to be configured. { Data | Log | Backup }"), ValueMap{"Data","Log","Backup"}, Values{"Data","Log","Backup"}] String Type;
     [Required, Description("The path to the default directory to be configured.")] String Path;
     [Write, Description("If set to $true then SQL Server and dependent services will be restarted if a change to the default location is made.  The defaul value is $false.")] Boolean RestartService;

--- a/DSCResources/MSFT_SqlDatabaseOwner/MSFT_SqlDatabaseOwner.psm1
+++ b/DSCResources/MSFT_SqlDatabaseOwner/MSFT_SqlDatabaseOwner.psm1
@@ -11,10 +11,10 @@ Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Pare
     .PARAMETER Name
     The name of the login that will become a owner of the desired sql database.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
     The host name of the SQL Server to be configured.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     The name of the SQL instance to be configured.
 #>
 function Get-TargetResource
@@ -36,16 +36,16 @@ function Get-TargetResource
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer = $env:COMPUTERNAME,
+        $ServerName = $env:COMPUTERNAME,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName = 'MSSQLSERVER'
+        $InstanceName = 'MSSQLSERVER'
     )
 
     Write-Verbose -Message "Getting owner of database $Database"
-    $sqlServerObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
     if ($sqlServerObject)
     {
@@ -53,7 +53,7 @@ function Get-TargetResource
         if ( -not ($sqlDatabaseObject = $sqlServerObject.Databases[$Database]) )
         {
             throw New-TerminatingError -ErrorType NoDatabase `
-                -FormatArgs @($Database, $SQLServer, $SQLInstanceName) `
+                -FormatArgs @($Database, $ServerName, $InstanceName) `
                 -ErrorCategory ObjectNotFound
         }
 
@@ -65,16 +65,16 @@ function Get-TargetResource
         catch
         {
             throw New-TerminatingError -ErrorType FailedToGetOwnerDatabase `
-                -FormatArgs @($Database, $SQLServer, $SQLInstanceName) `
+                -FormatArgs @($Database, $ServerName, $InstanceName) `
                 -ErrorCategory InvalidOperation
         }
     }
 
     $returnValue = @{
-        Database        = $Database
-        Name            = $sqlDatabaseOwner
-        SQLServer       = $SQLServer
-        SQLInstanceName = $SQLInstanceName
+        Database     = $Database
+        Name         = $sqlDatabaseOwner
+        ServerName   = $ServerName
+        InstanceName = $InstanceName
     }
 
     $returnValue
@@ -90,10 +90,10 @@ function Get-TargetResource
     .PARAMETER Name
     The name of the login that will become a owner of the desired sql database.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
     The host name of the SQL Server to be configured.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     The name of the SQL instance to be configured.
 #>
 function Set-TargetResource
@@ -114,29 +114,29 @@ function Set-TargetResource
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer = $env:COMPUTERNAME,
+        $ServerName = $env:COMPUTERNAME,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName = 'MSSQLSERVER'
+        $InstanceName = 'MSSQLSERVER'
     )
 
     Write-Verbose -Message "Setting owner $Name of database $Database"
-    $sqlServerObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
     if ($sqlServerObject)
     {
         # Check database exists
         if ( -not ($sqlDatabaseObject = $sqlServerObject.Databases[$Database]) )
         {
-            throw New-TerminatingError -ErrorType NoDatabase -FormatArgs @($Database, $SQLServer, $SQLInstanceName) -ErrorCategory ObjectNotFound
+            throw New-TerminatingError -ErrorType NoDatabase -FormatArgs @($Database, $ServerName, $InstanceName) -ErrorCategory ObjectNotFound
         }
 
         # Check login exists
         if ( -not ($sqlServerObject.Logins[$Name]) )
         {
-            throw New-TerminatingError -ErrorType LoginNotFound -FormatArgs @($Name, $SQLServer, $SQLInstanceName) -ErrorCategory ObjectNotFound
+            throw New-TerminatingError -ErrorType LoginNotFound -FormatArgs @($Name, $ServerName, $InstanceName) -ErrorCategory ObjectNotFound
         }
 
         try
@@ -147,7 +147,7 @@ function Set-TargetResource
         catch
         {
             throw New-TerminatingError -ErrorType FailedToSetOwnerDatabase `
-                -FormatArgs @($Name, $Database, $SQLServer, $SQLInstanceName) `
+                -FormatArgs @($Name, $Database, $ServerName, $InstanceName) `
                 -ErrorCategory InvalidOperation `
                 -InnerException $_.Exception
         }
@@ -164,10 +164,10 @@ function Set-TargetResource
     .PARAMETER Name
     The name of the login that will become a owner of the desired sql database.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
     The host name of the SQL Server to be configured.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     The name of the SQL instance to be configured.
 #>
 function Test-TargetResource
@@ -189,12 +189,12 @@ function Test-TargetResource
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer = $env:COMPUTERNAME,
+        $ServerName = $env:COMPUTERNAME,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName = 'MSSQLSERVER'
+        $InstanceName = 'MSSQLSERVER'
     )
 
     Write-Verbose -Message "Testing owner $Name of database $Database"

--- a/DSCResources/MSFT_SqlDatabaseOwner/MSFT_SqlDatabaseOwner.schema.mof
+++ b/DSCResources/MSFT_SqlDatabaseOwner/MSFT_SqlDatabaseOwner.schema.mof
@@ -3,6 +3,6 @@ class MSFT_SqlDatabaseOwner : OMI_BaseResource
 {
     [Key, Description("The name of database to be configured.")] String Database;
     [Required, Description("The name of the login that will become a owner of the desired sql database.")] String Name;
-    [Write, Description("The host name of the SQL Server to be configured.")] String SQLServer;
-    [Write, Description("The name of the SQL instance to be configured.")] String SQLInstanceName;
+    [Write, Description("The host name of the SQL Server to be configured.")] String ServerName;
+    [Write, Description("The name of the SQL instance to be configured.")] String InstanceName;
 };

--- a/DSCResources/MSFT_SqlDatabasePermission/MSFT_SqlDatabasePermission.psm1
+++ b/DSCResources/MSFT_SqlDatabasePermission/MSFT_SqlDatabasePermission.psm1
@@ -17,10 +17,10 @@ Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Pare
     .PARAMETER Permissions
     This is a list that represents a SQL Server set of database permissions
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
     This is the SQL Server for the database
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     This is the SQL instance for the database
 #>
 function Get-TargetResource
@@ -52,15 +52,15 @@ function Get-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer,
+        $ServerName,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName
+        $InstanceName
     )
 
-    $sqlServerObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
     if ($sqlServerObject)
     {
@@ -96,7 +96,7 @@ function Get-TargetResource
                 catch
                 {
                     throw New-TerminatingError -ErrorType FailedToEnumDatabasePermissions `
-                        -FormatArgs @($Name, $Database, $SQLServer, $SQLInstanceName) `
+                        -FormatArgs @($Name, $Database, $ServerName, $InstanceName) `
                         -ErrorCategory InvalidOperation `
                         -InnerException $_.Exception
                 }
@@ -105,7 +105,7 @@ function Get-TargetResource
             else
             {
                 throw New-TerminatingError -ErrorType LoginNotFound `
-                    -FormatArgs @($Name, $SQLServer, $SQLInstanceName) `
+                    -FormatArgs @($Name, $ServerName, $InstanceName) `
                     -ErrorCategory ObjectNotFound `
                     -InnerException $_.Exception
             }
@@ -113,7 +113,7 @@ function Get-TargetResource
         else
         {
             throw New-TerminatingError -ErrorType NoDatabase `
-                -FormatArgs @($Database, $SQLServer, $SQLInstanceName) `
+                -FormatArgs @($Database, $ServerName, $InstanceName) `
                 -ErrorCategory InvalidResult `
                 -InnerException $_.Exception
         }
@@ -135,8 +135,8 @@ function Get-TargetResource
         Name            = $Name
         PermissionState = $PermissionState
         Permissions     = $getSqlDatabasePermissionResult
-        SQLServer       = $SQLServer
-        SQLInstanceName = $SQLInstanceName
+        ServerName      = $ServerName
+        InstanceName    = $InstanceName
     }
 
     $returnValue
@@ -161,10 +161,10 @@ function Get-TargetResource
     .PARAMETER Permissions
     This is a list that represents a SQL Server set of database permissions
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
     This is the SQL Server for the database
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     This is the SQL instance for the database
 #>
 function Set-TargetResource
@@ -200,15 +200,15 @@ function Set-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer = $env:COMPUTERNAME,
+        $ServerName = $env:COMPUTERNAME,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName = 'MSSQLSERVER'
+        $InstanceName = 'MSSQLSERVER'
     )
 
-    $sqlServerObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
     if ($sqlServerObject)
     {
@@ -230,7 +230,7 @@ function Set-TargetResource
                     catch
                     {
                         throw New-TerminatingError -ErrorType AddLoginDatabaseSetError `
-                            -FormatArgs @($SQLServer, $SQLInstanceName, $Name, $Database) `
+                            -FormatArgs @($ServerName, $InstanceName, $Name, $Database) `
                             -ErrorCategory InvalidOperation `
                             -InnerException $_.Exception
                     }
@@ -252,7 +252,7 @@ function Set-TargetResource
                             'Present'
                             {
                                 New-VerboseMessage -Message ('{0} the permissions ''{1}'' to the database {2} on the server {3}\{4}' `
-                                        -f $PermissionState, ($Permissions -join ','), $Database, $SQLServer, $SQLInstanceName)
+                                        -f $PermissionState, ($Permissions -join ','), $Database, $ServerName, $InstanceName)
 
                                 switch ($PermissionState)
                                 {
@@ -276,7 +276,7 @@ function Set-TargetResource
                             'Absent'
                             {
                                 New-VerboseMessage -Message ('Revoking {0} permissions {1} to the database {2} on the server {3}\{4}' `
-                                        -f $PermissionState, ($Permissions -join ','), $Database, $SQLServer, $SQLInstanceName)
+                                        -f $PermissionState, ($Permissions -join ','), $Database, $ServerName, $InstanceName)
 
                                 if ($PermissionState -eq 'GrantWithGrant')
                                 {
@@ -292,7 +292,7 @@ function Set-TargetResource
                     catch
                     {
                         throw New-TerminatingError -ErrorType FailedToSetPermissionDatabase `
-                            -FormatArgs @($Name, $Database, $SQLServer, $SQLInstanceName) `
+                            -FormatArgs @($Name, $Database, $ServerName, $InstanceName) `
                             -ErrorCategory InvalidOperation `
                             -InnerException $_.Exception
                     }
@@ -301,7 +301,7 @@ function Set-TargetResource
             else
             {
                 throw New-TerminatingError -ErrorType LoginNotFound `
-                    -FormatArgs @($Name, $SQLServer, $SQLInstanceName) `
+                    -FormatArgs @($Name, $ServerName, $InstanceName) `
                     -ErrorCategory ObjectNotFound `
                     -InnerException $_.Exception
             }
@@ -309,7 +309,7 @@ function Set-TargetResource
         else
         {
             throw New-TerminatingError -ErrorType NoDatabase `
-                -FormatArgs @($Database, $SQLServer, $SQLInstanceName) `
+                -FormatArgs @($Database, $ServerName, $InstanceName) `
                 -ErrorCategory InvalidResult `
                 -InnerException $_.Exception
         }
@@ -335,10 +335,10 @@ function Set-TargetResource
     .PARAMETER Permissions
     This is a list that represents a SQL Server set of database permissions
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
     This is the SQL Server for the database
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     This is the SQL instance for the database
 #>
 function Test-TargetResource
@@ -375,18 +375,18 @@ function Test-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer = $env:COMPUTERNAME,
+        $ServerName = $env:COMPUTERNAME,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName = 'MSSQLSERVER'
+        $InstanceName = 'MSSQLSERVER'
     )
 
     Write-Verbose -Message "Testing permissions for user $Name in database $Database."
     $getTargetResourceParameters = @{
-        SQLInstanceName = $PSBoundParameters.SQLInstanceName
-        SQLServer       = $PSBoundParameters.SQLServer
+        InstanceName    = $PSBoundParameters.InstanceName
+        ServerName      = $PSBoundParameters.ServerName
         Database        = $PSBoundParameters.Database
         Name            = $PSBoundParameters.Name
         PermissionState = $PSBoundParameters.PermissionState

--- a/DSCResources/MSFT_SqlDatabasePermission/MSFT_SqlDatabasePermission.schema.mof
+++ b/DSCResources/MSFT_SqlDatabasePermission/MSFT_SqlDatabasePermission.schema.mof
@@ -6,6 +6,6 @@ class MSFT_SqlDatabasePermission : OMI_BaseResource
     [Key, Description("The name of the user that should be granted or denied the permission.")] String Name;
     [Key, Description("The state of the permission. Valid values are 'Grant' or 'Deny'."), ValueMap{"Grant","Deny","GrantWithGrant"}, Values{"Grant","Deny","GrantWithGrant"}] String PermissionState;
     [Required, Description("The set of permissions for the SQL database.")] String Permissions[];
-    [Key, Description("The host name of the SQL Server to be configured.")] String SQLServer;
-    [Key, Description("The name of the SQL instance to be configured.")] String SQLInstanceName;
+    [Key, Description("The host name of the SQL Server to be configured.")] String ServerName;
+    [Key, Description("The name of the SQL instance to be configured.")] String InstanceName;
 };

--- a/DSCResources/MSFT_SqlDatabaseRecoveryModel/MSFT_SqlDatabaseRecoveryModel.psm1
+++ b/DSCResources/MSFT_SqlDatabaseRecoveryModel/MSFT_SqlDatabaseRecoveryModel.psm1
@@ -11,10 +11,10 @@ Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Pare
     .PARAMETER RecoveryModel
     This is the RecoveryModel of the SQL database
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
     This is a the SQL Server for the database
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     This is a the SQL instance for the database
 #>
 function Get-TargetResource
@@ -32,12 +32,12 @@ function Get-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer,
+        $ServerName,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName,
+        $InstanceName,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -45,7 +45,7 @@ function Get-TargetResource
         $Name
     )
 
-    $sqlServerObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
     if ($sqlServerObject)
     {
@@ -60,16 +60,16 @@ function Get-TargetResource
         else
         {
             throw New-TerminatingError -ErrorType NoDatabase `
-                -FormatArgs @($Name, $sqlServer, $sqlInstanceName) `
+                -FormatArgs @($Name, $ServerName, $InstanceName) `
                 -ErrorCategory InvalidResult
         }
     }
 
     $returnValue = @{
-        Name            = $Name
-        RecoveryModel   = $sqlDatabaseRecoveryModel
-        SQLServer       = $SQLServer
-        SQLInstanceName = $SQLInstanceName
+        Name          = $Name
+        RecoveryModel = $sqlDatabaseRecoveryModel
+        ServerName    = $ServerName
+        InstanceName  = $InstanceName
     }
 
     $returnValue
@@ -85,10 +85,10 @@ function Get-TargetResource
     .PARAMETER RecoveryModel
     This is the RecoveryModel of the SQL database
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
     This is a the SQL Server for the database
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     This is a the SQL instance for the database
 #>
 function Set-TargetResource
@@ -105,12 +105,12 @@ function Set-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer,
+        $ServerName,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName,
+        $InstanceName,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -118,7 +118,7 @@ function Set-TargetResource
         $Name
     )
 
-    $sqlServerObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
     if ($sqlServerObject)
     {
@@ -137,7 +137,7 @@ function Set-TargetResource
         else
         {
             throw New-TerminatingError -ErrorType NoDatabase `
-                -FormatArgs @($Name, $sqlServer, $sqlInstanceName) `
+                -FormatArgs @($Name, $ServerName, $InstanceName) `
                 -ErrorCategory InvalidResult
         }
     }
@@ -153,10 +153,10 @@ function Set-TargetResource
     .PARAMETER RecoveryModel
     This is the RecoveryModel of the SQL database
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
     This is a the SQL Server for the database
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     This is a the SQL instance for the database
 #>
 function Test-TargetResource
@@ -174,12 +174,12 @@ function Test-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer,
+        $ServerName,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName,
+        $InstanceName,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]

--- a/DSCResources/MSFT_SqlDatabaseRecoveryModel/MSFT_SqlDatabaseRecoveryModel.schema.mof
+++ b/DSCResources/MSFT_SqlDatabaseRecoveryModel/MSFT_SqlDatabaseRecoveryModel.schema.mof
@@ -3,6 +3,6 @@ class MSFT_SqlDatabaseRecoveryModel : OMI_BaseResource
 {
     [Key, Description("The SQL database name")] String Name;
     [Required, Description("The recovery model to use for the database."), ValueMap{"Full","Simple","BulkLogged"}, Values{"Full","Simple","BulkLogged"}]  String RecoveryModel;
-    [Key, Description("The host name of the SQL Server to be configured.")] String SQLServer;
-    [Key, Description("The name of the SQL instance to be configured.")] String SQLInstanceName;
+    [Key, Description("The host name of the SQL Server to be configured.")] String ServerName;
+    [Key, Description("The name of the SQL instance to be configured.")] String InstanceName;
 };

--- a/DSCResources/MSFT_SqlDatabaseRole/MSFT_SqlDatabaseRole.psm1
+++ b/DSCResources/MSFT_SqlDatabaseRole/MSFT_SqlDatabaseRole.psm1
@@ -12,10 +12,10 @@ Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Pare
     .PARAMETER Name
     Specifies the name of the login that evaluated if it is member of the role(s).
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
     Specifies the SQL server on which the instance exist.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     Specifies the SQL instance in which the database exist.
 
     .PARAMETER Database
@@ -38,12 +38,12 @@ function Get-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer,
+        $ServerName,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName,
+        $InstanceName,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -58,7 +58,7 @@ function Get-TargetResource
 
     Write-Verbose -Message "Getting SQL Database role for $Name"
 
-    $sqlServerObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
     if ($sqlServerObject)
     {
@@ -66,7 +66,7 @@ function Get-TargetResource
         if ( -not ($sqlDatabaseObject = $sqlServerObject.Databases[$Database]) )
         {
             throw New-TerminatingError -ErrorType NoDatabase `
-                -FormatArgs @($Database, $SQLServer, $SQLInstanceName) `
+                -FormatArgs @($Database, $ServerName, $InstanceName) `
                 -ErrorCategory ObjectNotFound
         }
 
@@ -76,7 +76,7 @@ function Get-TargetResource
             if ( -not ($sqlDatabaseObject.Roles[$currentRole]) )
             {
                 throw New-TerminatingError -ErrorType RoleNotFound `
-                    -FormatArgs @($currentRole, $Database, $SQLServer, $SQLInstanceName) `
+                    -FormatArgs @($currentRole, $Database, $ServerName, $InstanceName) `
                     -ErrorCategory ObjectNotFound
             }
         }
@@ -85,7 +85,7 @@ function Get-TargetResource
         if ( -not ($sqlServerObject.Logins[$Name]) )
         {
             throw New-TerminatingError -ErrorType LoginNotFound `
-                -FormatArgs @($Name, $SQLServer, $SQLInstanceName) `
+                -FormatArgs @($Name, $ServerName, $InstanceName) `
                 -ErrorCategory ObjectNotFound
         }
 
@@ -99,14 +99,14 @@ function Get-TargetResource
                 if ($sqlDatabaseUser.IsMember($currentRole))
                 {
                     New-VerboseMessage -Message ("The login '$Name' is a member of the role '$currentRole' on the " + `
-                            "database '$Database', on the instance $SQLServer\$SQLInstanceName")
+                            "database '$Database', on the instance $ServerName\$InstanceName")
 
                     $grantedRole += $currentRole
                 }
                 else
                 {
                     New-VerboseMessage -Message ("The login '$Name' is not a member of the role '$currentRole' on the " + `
-                            "database '$Database', on the instance $SQLServer\$SQLInstanceName")
+                            "database '$Database', on the instance $ServerName\$InstanceName")
                 }
             }
 
@@ -118,15 +118,15 @@ function Get-TargetResource
         else
         {
             New-VerboseMessage -Message ("The login '$Name' is not a user of the database " + `
-                    "'$Database' on the instance $SQLServer\$SQLInstanceName")
+                    "'$Database' on the instance $ServerName\$InstanceName")
         }
     }
 
     $returnValue = @{
         Ensure          = $ensure
         Name            = $Name
-        SQLServer       = $SQLServer
-        SQLInstanceName = $SQLInstanceName
+        ServerName      = $ServerName
+        InstanceName = $InstanceName
         Database        = $Database
         Role            = $grantedRole
     }
@@ -147,10 +147,10 @@ function Get-TargetResource
     Specifies the name of the login that evaluated if it is member of the role(s), if it is not it will be added.
     If the login does not exist as a user, a user will be created using the login.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
     Specifies the SQL server on which the instance exist.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     Specifies the SQL instance in which the database exist.
 
     .PARAMETER Database
@@ -178,12 +178,12 @@ function Set-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer,
+        $ServerName,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName,
+        $InstanceName,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -198,7 +198,7 @@ function Set-TargetResource
 
     Write-Verbose -Message "Setting SQL Database role for $Name"
 
-    $sqlServerObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
     if ($sqlServerObject)
     {
@@ -214,7 +214,7 @@ function Set-TargetResource
                     try
                     {
                         New-VerboseMessage -Message ("Adding the login '$Name' as a user of the database " + `
-                                "'$Database', on the instance $SQLServer\$SQLInstanceName")
+                                "'$Database', on the instance $ServerName\$InstanceName")
 
                         $sqlDatabaseUser = New-Object -TypeName Microsoft.SqlServer.Management.Smo.User `
                             -ArgumentList $sqlDatabaseObject, $Name
@@ -224,7 +224,7 @@ function Set-TargetResource
                     catch
                     {
                         throw New-TerminatingError -ErrorType AddLoginDatabaseSetError `
-                            -FormatArgs @($SQLServer, $SQLInstanceName, $Name, $Database) `
+                            -FormatArgs @($ServerName, $InstanceName, $Name, $Database) `
                             -ErrorCategory InvalidOperation `
                             -InnerException $_.Exception
                     }
@@ -236,7 +236,7 @@ function Set-TargetResource
                     try
                     {
                         New-VerboseMessage -Message ("Adding the login '$Name' to the role '$currentRole' on the " + `
-                                "database '$Database', on the instance $SQLServer\$SQLInstanceName")
+                                "database '$Database', on the instance $ServerName\$InstanceName")
 
                         $sqlDatabaseRole = $sqlDatabaseObject.Roles[$currentRole]
                         $sqlDatabaseRole.AddMember($Name)
@@ -244,7 +244,7 @@ function Set-TargetResource
                     catch
                     {
                         throw New-TerminatingError -ErrorType AddMemberDatabaseSetError `
-                            -FormatArgs @($SQLServer, $SQLInstanceName, $Name, $Role, $Database) `
+                            -FormatArgs @($ServerName, $InstanceName, $Name, $Role, $Database) `
                             -ErrorCategory InvalidOperation `
                             -InnerException $_.Exception
                     }
@@ -258,7 +258,7 @@ function Set-TargetResource
                     foreach ($currentRole in $Role)
                     {
                         New-VerboseMessage -Message ("Removing the login '$Name' to the role '$currentRole' on the " + `
-                                "database '$Database', on the instance $SQLServer\$SQLInstanceName")
+                                "database '$Database', on the instance $ServerName\$InstanceName")
 
                         $sqlDatabaseRole = $sqlDatabaseObject.Roles[$currentRole]
                         $sqlDatabaseRole.DropMember($Name)
@@ -267,7 +267,7 @@ function Set-TargetResource
                 catch
                 {
                     throw New-TerminatingError -ErrorType DropMemberDatabaseSetError `
-                        -FormatArgs @($SQLServer, $SQLInstanceName, $Name, $Role, $Database) `
+                        -FormatArgs @($ServerName, $InstanceName, $Name, $Role, $Database) `
                         -ErrorCategory InvalidOperation `
                         -InnerException $_.Exception
                 }
@@ -286,10 +286,10 @@ function Set-TargetResource
     .PARAMETER Name
     Specifies the name of the login that evaluated if it is member of the role(s).
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
     Specifies the SQL server on which the instance exist.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     Specifies the SQL instance in which the database exist.
 
     .PARAMETER Database
@@ -318,12 +318,12 @@ function Test-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer,
+        $ServerName,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName,
+        $InstanceName,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -339,8 +339,8 @@ function Test-TargetResource
     Write-Verbose -Message "Testing SQL Database role for $Name"
 
     $getTargetResourceParameters = @{
-        SQLInstanceName = $PSBoundParameters.SQLInstanceName
-        SQLServer       = $PSBoundParameters.SQLServer
+        InstanceName = $PSBoundParameters.InstanceName
+        ServerName      = $PSBoundParameters.ServerName
         Role            = $PSBoundParameters.Role
         Database        = $PSBoundParameters.Database
         Name            = $PSBoundParameters.Name

--- a/DSCResources/MSFT_SqlDatabaseRole/MSFT_SqlDatabaseRole.psm1
+++ b/DSCResources/MSFT_SqlDatabaseRole/MSFT_SqlDatabaseRole.psm1
@@ -123,12 +123,12 @@ function Get-TargetResource
     }
 
     $returnValue = @{
-        Ensure          = $ensure
-        Name            = $Name
-        ServerName      = $ServerName
+        Ensure       = $ensure
+        Name         = $Name
+        ServerName   = $ServerName
         InstanceName = $InstanceName
-        Database        = $Database
-        Role            = $grantedRole
+        Database     = $Database
+        Role         = $grantedRole
     }
 
     $returnValue
@@ -340,10 +340,10 @@ function Test-TargetResource
 
     $getTargetResourceParameters = @{
         InstanceName = $PSBoundParameters.InstanceName
-        ServerName      = $PSBoundParameters.ServerName
-        Role            = $PSBoundParameters.Role
-        Database        = $PSBoundParameters.Database
-        Name            = $PSBoundParameters.Name
+        ServerName   = $PSBoundParameters.ServerName
+        Role         = $PSBoundParameters.Role
+        Database     = $PSBoundParameters.Database
+        Name         = $PSBoundParameters.Name
     }
 
     $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters

--- a/DSCResources/MSFT_SqlDatabaseRole/MSFT_SqlDatabaseRole.schema.mof
+++ b/DSCResources/MSFT_SqlDatabaseRole/MSFT_SqlDatabaseRole.schema.mof
@@ -3,8 +3,8 @@ class MSFT_SqlDatabaseRole : OMI_BaseResource
 {
     [Write, Description("If 'Present' (the default value) then the login (user) will be added to the role(s). If 'Absent' then the login (user) will be removed from the role(s)."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Key, Description("The name of the login that will become a member, or removed as a member, of the role(s).")] String Name;
-    [Key, Description("The host name of the SQL Server to be configured.")] String SQLServer;
-    [Key, Description("The name of the SQL instance to be configured.")] String SQLInstanceName;
+    [Key, Description("The host name of the SQL Server to be configured.")] String ServerName;
+    [Key, Description("The name of the SQL instance to be configured.")] String InstanceName;
     [Key, Description("The database in which the login (user) and role(s) exist.")] String Database;
     [Required, Description("One or more roles to which the login (user) will be added or removed.")] String Role[];
 };

--- a/DSCResources/MSFT_SqlServerConfiguration/MSFT_SqlServerConfiguration.psm1
+++ b/DSCResources/MSFT_SqlServerConfiguration/MSFT_SqlServerConfiguration.psm1
@@ -6,10 +6,10 @@ Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Pare
     .SYNOPSIS
     Gets the current value of a SQL configuration option
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
     Hostname of the SQL Server to be configured
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     Name of the SQL instance to be configued. Default is 'MSSQLSERVER'
 
     .PARAMETER OptionName
@@ -33,11 +33,11 @@ function Get-TargetResource
     param(
         [Parameter(Mandatory = $true)]
         [String]
-        $SQLServer,
+        $ServerName,
 
         [Parameter(Mandatory = $true)]
         [String]
-        $SQLInstanceName,
+        $InstanceName,
 
         [Parameter(Mandatory = $true)]
         [String]
@@ -56,7 +56,7 @@ function Get-TargetResource
         $RestartTimeout = 120
     )
 
-    $sql = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    $sql = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
     ## get the configuration option
     $option = $sql.Configuration.Properties | Where-Object { $_.DisplayName -eq $OptionName }
@@ -67,12 +67,12 @@ function Get-TargetResource
     }
 
     return @{
-        SqlServer       = $SQLServer
-        SQLInstanceName = $SQLInstanceName
-        OptionName      = $option.DisplayName
-        OptionValue     = $option.ConfigValue
-        RestartService  = $RestartService
-        RestartTimeout  = $RestartTimeout
+        ServerName     = $ServerName
+        InstanceName   = $InstanceName
+        OptionName     = $option.DisplayName
+        OptionValue    = $option.ConfigValue
+        RestartService = $RestartService
+        RestartTimeout = $RestartTimeout
     }
 }
 
@@ -80,10 +80,10 @@ function Get-TargetResource
     .SYNOPSIS
     Sets the value of a SQL configuration option
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
     Hostname of the SQL Server to be configured
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     Name of the SQL instance to be configued. Default is 'MSSQLSERVER'
 
     .PARAMETER OptionName
@@ -104,11 +104,11 @@ function Set-TargetResource
     param(
         [Parameter(Mandatory = $true)]
         [String]
-        $SQLServer,
+        $ServerName,
 
         [Parameter(Mandatory = $true)]
         [String]
-        $SQLInstanceName,
+        $InstanceName,
 
         [Parameter(Mandatory = $true)]
         [String]
@@ -127,7 +127,7 @@ function Set-TargetResource
         $RestartTimeout = 120
     )
 
-    $sql = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    $sql = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
     ## get the configuration option
     $option = $sql.Configuration.Properties | Where-Object { $_.DisplayName -eq $OptionName }
@@ -147,7 +147,7 @@ function Set-TargetResource
     elseif (($option.IsDynamic -eq $false) -and ($RestartService -eq $true))
     {
         New-VerboseMessage -Message 'Configuration option has been updated, restarting instance...'
-        Restart-SqlService -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName -Timeout $RestartTimeout
+        Restart-SqlService -SQLServer $ServerName -SQLInstanceName $InstanceName -Timeout $RestartTimeout
     }
     else
     {
@@ -159,10 +159,10 @@ function Set-TargetResource
     .SYNOPSIS
     Determines whether a SQL configuration option value is properly set
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
     Hostname of the SQL Server to be configured
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     Name of the SQL instance to be configued. Default is 'MSSQLSERVER'
 
     .PARAMETER OptionName
@@ -186,11 +186,11 @@ function Test-TargetResource
     param(
         [Parameter(Mandatory = $true)]
         [String]
-        $SQLServer,
+        $ServerName,
 
         [Parameter(Mandatory = $true)]
         [String]
-        $SQLInstanceName,
+        $InstanceName,
 
         [Parameter(Mandatory = $true)]
         [String]

--- a/DSCResources/MSFT_SqlServerConfiguration/MSFT_SqlServerConfiguration.schema.mof
+++ b/DSCResources/MSFT_SqlServerConfiguration/MSFT_SqlServerConfiguration.schema.mof
@@ -1,8 +1,8 @@
 [ClassVersion("1.0.0.0"), FriendlyName("SqlServerConfiguration")]
 class MSFT_SqlServerConfiguration : OMI_BaseResource
 {
-    [Key, Description("The hostname of the SQL Server to be configured.")] String SQLServer;
-    [Key, Description("Name of the SQL instance to be configured.")] String SQLInstanceName;
+    [Key, Description("The hostname of the SQL Server to be configured.")] String ServerName;
+    [Key, Description("Name of the SQL instance to be configured.")] String InstanceName;
     [Key, Description("The name of the SQL configuration option to be checked.")] String OptionName;
     [Required, Description("The desired value of the SQL configuration option.")] Sint32 OptionValue;
     [Write, Description("Determines whether the instance should be restarted after updating the configuration option.")] Boolean RestartService;

--- a/DSCResources/MSFT_SqlServerEndpoint/MSFT_SqlServerEndpoint.psm1
+++ b/DSCResources/MSFT_SqlServerEndpoint/MSFT_SqlServerEndpoint.psm1
@@ -8,10 +8,10 @@ Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Pare
     .PARAMETER EndpointName
         The name of the endpoint.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
         The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
         The name of the SQL instance to be configured.
 #>
 function Get-TargetResource
@@ -26,26 +26,26 @@ function Get-TargetResource
 
         [Parameter()]
         [System.String]
-        $SQLServer = $env:COMPUTERNAME,
+        $ServerName = $env:COMPUTERNAME,
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        $SQLInstanceName
+        $InstanceName
     )
 
     $getTargetResourceReturnValues = @{
-        SQLServer       = $SQLServer
-        SQLInstanceName = $SQLInstanceName
-        Ensure          = 'Absent'
-        EndpointName    = ''
-        Port            = ''
-        IpAddress       = ''
+        ServerName   = $ServerName
+        InstanceName = $InstanceName
+        Ensure       = 'Absent'
+        EndpointName = ''
+        Port         = ''
+        IpAddress    = ''
     }
 
-    $sqlServerObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
     if ($sqlServerObject)
     {
-        Write-Verbose -Message ('Connected to {0}\{1}' -f $SQLServer, $SQLInstanceName)
+        Write-Verbose -Message ('Connected to {0}\{1}' -f $ServerName, $InstanceName)
 
         $endpointObject = $sqlServerObject.Endpoints[$EndpointName]
         if ($endpointObject.Name -eq $EndpointName)
@@ -73,7 +73,7 @@ function Get-TargetResource
     else
     {
         throw New-TerminatingError -ErrorType NotConnectedToInstance `
-            -FormatArgs @($SQLServer, $SQLInstanceName) `
+            -FormatArgs @($ServerName, $InstanceName) `
             -ErrorCategory InvalidOperation
     }
 
@@ -93,10 +93,10 @@ function Get-TargetResource
     .PARAMETER Port
         The network port the endpoint is listening on. Default value is 5022.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
         The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
         The name of the SQL instance to be configured.
 
     .PARAMETER IpAddress
@@ -122,20 +122,20 @@ function Set-TargetResource
 
         [Parameter()]
         [System.String]
-        $SQLServer = $env:COMPUTERNAME,
+        $ServerName = $env:COMPUTERNAME,
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        $SQLInstanceName,
+        $InstanceName,
 
         [Parameter()]
         [System.String]
         $IpAddress = '0.0.0.0'
     )
 
-    $getTargetResourceResult = Get-TargetResource -EndpointName $EndpointName -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    $getTargetResourceResult = Get-TargetResource -EndpointName $EndpointName -ServerName $ServerName -InstanceName $InstanceName
 
-    $sqlServerObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
     if ($sqlServerObject)
     {
         if ($Ensure -eq 'Present' -and $getTargetResourceResult.Ensure -eq 'Absent')
@@ -196,7 +196,7 @@ function Set-TargetResource
     else
     {
         throw New-TerminatingError -ErrorType NotConnectedToInstance `
-            -FormatArgs @($SQLServer, $SQLInstanceName) `
+            -FormatArgs @($ServerName, $InstanceName) `
             -ErrorCategory InvalidOperation
     }
 }
@@ -214,10 +214,10 @@ function Set-TargetResource
     .PARAMETER Port
         The network port the endpoint is listening on. Default value is 5022.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
         The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
         The name of the SQL instance to be configured.
 
     .PARAMETER IpAddress
@@ -244,18 +244,18 @@ function Test-TargetResource
 
         [Parameter()]
         [System.String]
-        $SQLServer = $env:COMPUTERNAME,
+        $ServerName = $env:COMPUTERNAME,
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        $SQLInstanceName,
+        $InstanceName,
 
         [Parameter()]
         [System.String]
         $IpAddress = '0.0.0.0'
     )
 
-    $getTargetResourceResult = Get-TargetResource -EndpointName $EndpointName -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    $getTargetResourceResult = Get-TargetResource -EndpointName $EndpointName -ServerName $ServerName -InstanceName $InstanceName
     if ($getTargetResourceResult.Ensure -eq $Ensure)
     {
         $result = $true

--- a/DSCResources/MSFT_SqlServerEndpoint/MSFT_SqlServerEndpoint.schema.mof
+++ b/DSCResources/MSFT_SqlServerEndpoint/MSFT_SqlServerEndpoint.schema.mof
@@ -4,7 +4,7 @@ class MSFT_SqlServerEndpoint : OMI_BaseResource
     [Key, Description("The name of the endpoint.")] String EndpointName;
     [Write, Description("If the endpoint should be present or absent. Default values is 'Present'."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("The network port the endpoint is listening on. Default value is 5022.")] Uint16 Port;
-    [Write, Description("The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.")] String SQLServer;
-    [Key, Description("The name of the SQL instance to be configured.")] String SQLInstanceName;
+    [Write, Description("The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.")] String ServerName;
+    [Key, Description("The name of the SQL instance to be configured.")] String InstanceName;
     [Write, Description("The network IP address the endpoint is listening on. Default the endpoint will listen on any valid IP address.")] String IpAddress;
 };

--- a/DSCResources/MSFT_SqlServerEndpointPermission/MSFT_SqlServerEndpointPermission.psm1
+++ b/DSCResources/MSFT_SqlServerEndpointPermission/MSFT_SqlServerEndpointPermission.psm1
@@ -8,7 +8,7 @@ Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Pare
     .PARAMETER InstanceName
         The name of the SQL instance to be configured.
 
-    .PARAMETER NodeName
+    .PARAMETER ServerName
         The host name of the SQL Server to be configured.
 
     .PARAMETER Name
@@ -29,7 +29,7 @@ function Get-TargetResource
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        $NodeName,
+        $ServerName,
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -42,7 +42,7 @@ function Get-TargetResource
 
     try
     {
-        $sqlServerObject = Connect-SQL -SQLServer $NodeName -SQLInstanceName $InstanceName
+        $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
         $endpointObject = $sqlServerObject.Endpoints[$Name]
         if ( $null -ne $endpointObject )
@@ -75,7 +75,7 @@ function Get-TargetResource
 
     return @{
         InstanceName = [System.String] $InstanceName
-        NodeName     = [System.String] $NodeName
+        ServerName   = [System.String] $ServerName
         Ensure       = [System.String] $Ensure
         Name         = [System.String] $Name
         Principal    = [System.String] $Principal
@@ -90,7 +90,7 @@ function Get-TargetResource
     .PARAMETER InstanceName
         The name of the SQL instance to be configured.
 
-    .PARAMETER NodeName
+    .PARAMETER ServerName
         The host name of the SQL Server to be configured.
 
     .PARAMETER Ensure
@@ -116,7 +116,7 @@ function Set-TargetResource
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        $NodeName,
+        $ServerName,
 
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
@@ -139,7 +139,7 @@ function Set-TargetResource
 
     $parameters = @{
         InstanceName = [System.String] $InstanceName
-        NodeName     = [System.String] $NodeName
+        ServerName   = [System.String] $ServerName
         Name         = [System.String] $Name
         Principal    = [System.String] $Principal
     }
@@ -147,7 +147,7 @@ function Set-TargetResource
     $getTargetResourceResult = Get-TargetResource @parameters
     if ($getTargetResourceResult.Ensure -ne $Ensure)
     {
-        $sqlServerObject = Connect-SQL -SQLServer $NodeName -SQLInstanceName $InstanceName
+        $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
         $endpointObject = $sqlServerObject.Endpoints[$Name]
         if ($null -ne $endpointObject)
@@ -184,7 +184,7 @@ function Set-TargetResource
     .PARAMETER InstanceName
         The name of the SQL instance to be configured.
 
-    .PARAMETER NodeName
+    .PARAMETER ServerName
         The host name of the SQL Server to be configured.
 
     .PARAMETER Ensure
@@ -211,7 +211,7 @@ function Test-TargetResource
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        $NodeName,
+        $ServerName,
 
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
@@ -234,7 +234,7 @@ function Test-TargetResource
 
     $parameters = @{
         InstanceName = [System.String] $InstanceName
-        NodeName     = [System.String] $NodeName
+        ServerName   = [System.String] $ServerName
         Name         = [System.String] $Name
         Principal    = [System.String] $Principal
     }

--- a/DSCResources/MSFT_SqlServerEndpointPermission/MSFT_SqlServerEndpointPermission.schema.mof
+++ b/DSCResources/MSFT_SqlServerEndpointPermission/MSFT_SqlServerEndpointPermission.schema.mof
@@ -3,7 +3,7 @@
 class MSFT_SqlServerEndpointPermission : OMI_BaseResource
 {
     [Key, Description("The name of the SQL instance to be configured.")] String InstanceName;
-    [Required, Description("The host name of the SQL Server to be configured.")] String NodeName;
+    [Required, Description("The host name of the SQL Server to be configured.")] String ServerName;
     [Write, Description("If the permission should be present or absent. Default value is 'Present'."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Required, Description("The name of the endpoint.")] String Name;
     [Key, Description("The login to which permission will be set.")] String Principal;

--- a/DSCResources/MSFT_SqlServerEndpointState/MSFT_SqlServerEndpointState.psm1
+++ b/DSCResources/MSFT_SqlServerEndpointState/MSFT_SqlServerEndpointState.psm1
@@ -8,7 +8,7 @@ Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Pare
     .PARAMETER InstanceName
         The name of the SQL instance to be configured.
 
-    .PARAMETER NodeName
+    .PARAMETER ServerName
         The host name of the SQL Server to be configured.
 
     .PARAMETER Name
@@ -26,7 +26,7 @@ function Get-TargetResource
 
         [Parameter()]
         [System.String]
-        $NodeName = $env:COMPUTERNAME,
+        $ServerName = $env:COMPUTERNAME,
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -37,7 +37,7 @@ function Get-TargetResource
 
     try
     {
-        $sqlServerObject = Connect-SQL -SQLServer $NodeName -SQLInstanceName $InstanceName
+        $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
         $endpointObject = $sqlServerObject.Endpoints[$Name]
         if ($null -ne $endpointObject)
@@ -56,7 +56,7 @@ function Get-TargetResource
 
     return @{
         InstanceName = [System.String] $InstanceName
-        NodeName     = [System.String] $NodeName
+        ServerName   = [System.String] $ServerName
         Name         = [System.String] $Name
         State        = [System.String] $currentState
     }
@@ -69,7 +69,7 @@ function Get-TargetResource
     .PARAMETER InstanceName
         The name of the SQL instance to be configured.
 
-    .PARAMETER NodeName
+    .PARAMETER ServerName
         The host name of the SQL Server to be configured.
 
     .PARAMETER Name
@@ -89,7 +89,7 @@ function Set-TargetResource
 
         [Parameter()]
         [System.String]
-        $NodeName = $env:COMPUTERNAME,
+        $ServerName = $env:COMPUTERNAME,
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -103,7 +103,7 @@ function Set-TargetResource
 
     $parameters = @{
         InstanceName = [System.String] $InstanceName
-        NodeName     = [System.String] $NodeName
+        ServerName   = [System.String] $ServerName
         Name         = [System.String] $Name
     }
 
@@ -114,7 +114,7 @@ function Set-TargetResource
         {
             New-VerboseMessage -Message ('Changing state of endpoint ''{0}''' -f $Name)
 
-            $sqlServerObject = Connect-SQL -SQLServer $NodeName -SQLInstanceName $InstanceName
+            $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
             $endpointObject = $sqlServerObject.Endpoints[$Name]
 
@@ -143,7 +143,7 @@ function Set-TargetResource
     .PARAMETER InstanceName
         The name of the SQL instance to be configured.
 
-    .PARAMETER NodeName
+    .PARAMETER ServerName
         The host name of the SQL Server to be configured.
 
     .PARAMETER Name
@@ -164,7 +164,7 @@ function Test-TargetResource
 
         [Parameter()]
         [System.String]
-        $NodeName = $env:COMPUTERNAME,
+        $ServerName = $env:COMPUTERNAME,
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -178,7 +178,7 @@ function Test-TargetResource
 
     $parameters = @{
         InstanceName = $InstanceName
-        NodeName     = $NodeName
+        ServerName   = $ServerName
         Name         = $Name
     }
 

--- a/DSCResources/MSFT_SqlServerEndpointState/MSFT_SqlServerEndpointState.schema.mof
+++ b/DSCResources/MSFT_SqlServerEndpointState/MSFT_SqlServerEndpointState.schema.mof
@@ -2,7 +2,7 @@
 class MSFT_SqlServerEndpointState : OMI_BaseResource
 {
     [Key, Description("The name of the SQL instance to be configured.")] String InstanceName;
-    [Write, Description("The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.")] String NodeName;
+    [Write, Description("The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.")] String ServerName;
     [Key, Description("The name of the endpoint.")] String Name;
     [Write, Description("The state of the endpoint. Valid states are Started, Stopped or Disabled. Default value is 'Started'."), ValueMap{"Started","Stopped","Disabled"}, Values{"Started","Stopped","Disabled"}] String State;
 };

--- a/DSCResources/MSFT_SqlServerLogin/MSFT_SqlServerLogin.schema.mof
+++ b/DSCResources/MSFT_SqlServerLogin/MSFT_SqlServerLogin.schema.mof
@@ -6,8 +6,8 @@ class MSFT_SqlServerLogin : OMI_BaseResource
     [Write, Description("The type of login to be created. If LoginType is 'WindowsUser' or 'WindowsGroup' then provide the name in the format DOMAIN\name. Default is WindowsUser. Unsupported login types are Certificate, AsymmetricKey, ExternalUser, and ExternalGroup."),
         ValueMap{"WindowsUser","WindowsGroup","SqlLogin","Certificate","AsymmetricKey","ExternalUser","ExternalGroup"},
         Values{"WindowsUser","WindowsGroup","SqlLogin","Certificate","AsymmetricKey","ExternalUser","ExternalGroup"}] String LoginType;
-    [Key, Description("The hostname of the SQL Server to be configured.")] String SQLServer;
-    [Key, Description("Name of the SQL instance to be configured.")] String SQLInstanceName;
+    [Key, Description("The hostname of the SQL Server to be configured.")] String ServerName;
+    [Key, Description("Name of the SQL instance to be configured.")] String InstanceName;
     [Write, EmbeddedInstance("MSFT_Credential"), Description("If LoginType is 'SqlLogin' then a PSCredential is needed for the password to the login.")] String LoginCredential;
     [Write, Description("Specifies if the login is required to have its password change on the next login. Only applies to SQL Logins. Default is $true.")] Boolean LoginMustChangePassword;
     [Write, Description("Specifies if the login password is required to expire in accordance to the operating system security policy. Only applies to SQL Logins. Default is $true.")] Boolean LoginPasswordExpirationEnabled;

--- a/DSCResources/MSFT_SqlServerMaxDop/MSFT_SqlServerMaxDop.psm1
+++ b/DSCResources/MSFT_SqlServerMaxDop/MSFT_SqlServerMaxDop.psm1
@@ -5,10 +5,10 @@ Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Pare
     .SYNOPSIS
     This function gets the max degree of parallelism server configuration option.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
     The host name of the SQL Server to be configured.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     The name of the SQL instance to be configured.
 #>
 function Get-TargetResource
@@ -20,15 +20,15 @@ function Get-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName,
+        $InstanceName,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer = $env:COMPUTERNAME
+        $ServerName = $env:COMPUTERNAME
     )
 
-    $sqlServerObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
     # Is this node actively hosting the SQL instance?
     $isActiveNode = Test-ActiveNode -ServerObject $sqlServerObject
@@ -40,10 +40,10 @@ function Get-TargetResource
     }
 
     $returnValue = @{
-        SQLInstanceName = $SQLInstanceName
-        SQLServer       = $SQLServer
-        MaxDop          = $currentMaxDop
-        IsActiveNode    = $isActiveNode
+        InstanceName = $InstanceName
+        ServerName   = $ServerName
+        MaxDop       = $currentMaxDop
+        IsActiveNode = $isActiveNode
     }
 
     $returnValue
@@ -53,10 +53,10 @@ function Get-TargetResource
     .SYNOPSIS
     This function sets the max degree of parallelism server configuration option.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
     The host name of the SQL Server to be configured.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     The name of the SQL instance to be configured.
 
     .PARAMETER Ensure
@@ -82,12 +82,12 @@ function Set-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName,
+        $InstanceName,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer = $env:COMPUTERNAME,
+        $ServerName = $env:COMPUTERNAME,
 
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
@@ -108,7 +108,7 @@ function Set-TargetResource
         $ProcessOnlyOnActiveNode
     )
 
-    $sqlServerObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
     if ($sqlServerObject)
     {
@@ -122,7 +122,7 @@ function Set-TargetResource
                     if ($MaxDop)
                     {
                         throw New-TerminatingError -ErrorType MaxDopParamMustBeNull `
-                            -FormatArgs @( $SQLServer, $SQLInstanceName ) `
+                            -FormatArgs @( $ServerName, $InstanceName ) `
                             -ErrorCategory InvalidArgument
                     }
 
@@ -151,7 +151,7 @@ function Set-TargetResource
         catch
         {
             throw New-TerminatingError -ErrorType MaxDopSetError `
-                -FormatArgs @($SQLServer, $SQLInstanceName, $targetMaxDop) `
+                -FormatArgs @($ServerName, $InstanceName, $targetMaxDop) `
                 -ErrorCategory InvalidOperation `
                 -InnerException $_.Exception
         }
@@ -162,10 +162,10 @@ function Set-TargetResource
     .SYNOPSIS
     This function tests the max degree of parallelism server configuration option.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
     The host name of the SQL Server to be configured.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     The name of the SQL instance to be configured.
 
     .PARAMETER Ensure
@@ -191,12 +191,12 @@ function Test-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName,
+        $InstanceName,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer = $env:COMPUTERNAME,
+        $ServerName = $env:COMPUTERNAME,
 
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
@@ -220,8 +220,8 @@ function Test-TargetResource
     Write-Verbose -Message 'Testing the max degree of parallelism server configuration option'
 
     $parameters = @{
-        SQLInstanceName = $SQLInstanceName
-        SQLServer       = $SQLServer
+        InstanceName = $InstanceName
+        ServerName   = $ServerName
     }
 
     $currentValues = Get-TargetResource @parameters
@@ -235,7 +235,7 @@ function Test-TargetResource
     #>
     if ( $ProcessOnlyOnActiveNode -and -not $getTargetResourceResult.IsActiveNode )
     {
-        New-VerboseMessage -Message ( 'The node "{0}" is not actively hosting the instance "{1}". Exiting the test.' -f $env:COMPUTERNAME,$SQLInstanceName )
+        New-VerboseMessage -Message ( 'The node "{0}" is not actively hosting the instance "{1}". Exiting the test.' -f $env:COMPUTERNAME, $InstanceName )
         return $isMaxDopInDesiredState
     }
 
@@ -256,7 +256,7 @@ function Test-TargetResource
                 if ($MaxDop)
                 {
                     throw New-TerminatingError -ErrorType MaxDopParamMustBeNull `
-                        -FormatArgs @( $SQLServer, $SQLInstanceName ) `
+                        -FormatArgs @( $ServerName, $InstanceName ) `
                         -ErrorCategory InvalidArgument
                 }
 

--- a/DSCResources/MSFT_SqlServerMaxDop/MSFT_SqlServerMaxDop.schema.mof
+++ b/DSCResources/MSFT_SqlServerMaxDop/MSFT_SqlServerMaxDop.schema.mof
@@ -4,8 +4,8 @@ class MSFT_SqlServerMaxDop : OMI_BaseResource
     [Write, Description("When set to 'Present' then max degree of parallelism will be set to either the value in parameter MaxDop or dynamically configured when parameter DynamicAlloc is set to $true. When set to 'Absent' max degree of parallelism will be set to 0 which means no limit in number of processors used in parallel plan execution."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("If set to $true then max degree of parallelism will be dynamically configured. When this is set parameter is set to $true, the parameter MaxDop must be set to $null or not be configured.")] Boolean DynamicAlloc;
     [Write, Description("A numeric value to limit the number of processors used in parallel plan execution.")] Sint32 MaxDop;
-    [Write, Description("The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.")] String SQLServer;
-    [Key, Description("The name of the SQL instance to be configured.")] String SQLInstanceName;
+    [Write, Description("The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.")] String ServerName;
+    [Key, Description("The name of the SQL instance to be configured.")] String InstanceName;
     [Write, Description("Specifies that the resource will only determine if a change is needed if the target node is the active host of the SQL Server instance.")] Boolean ProcessOnlyOnActiveNode;
     [Read, Description("Determines if the current node is actively hosting the SQL Server instance.")] Boolean IsActiveNode;
 };

--- a/DSCResources/MSFT_SqlServerMemory/MSFT_SqlServerMemory.psm1
+++ b/DSCResources/MSFT_SqlServerMemory/MSFT_SqlServerMemory.psm1
@@ -4,10 +4,10 @@ Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Pare
     .SYNOPSIS
         This function gets the value of the min and max memory server configuration option.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
         The host name of the SQL Server to be configured.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
         The name of the SQL instance to be configured.
 #>
 
@@ -20,15 +20,15 @@ function Get-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName,
+        $InstanceName,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer = $env:COMPUTERNAME
+        $ServerName = $env:COMPUTERNAME
     )
 
-    $sqlServerObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
     if ($sqlServerObject)
     {
@@ -41,11 +41,11 @@ function Get-TargetResource
     }
 
     $returnValue = @{
-        SQLInstanceName = $SQLInstanceName
-        SQLServer       = $SQLServer
-        MinMemory       = $minMemory
-        MaxMemory       = $maxMemory
-        IsActiveNode    = $isActiveNode
+        InstanceName = $InstanceName
+        ServerName   = $ServerName
+        MinMemory    = $minMemory
+        MaxMemory    = $maxMemory
+        IsActiveNode = $isActiveNode
     }
 
     $returnValue
@@ -55,10 +55,10 @@ function Get-TargetResource
     .SYNOPSIS
         This function sets the value for the min and max memory server configuration option.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
         The host name of the SQL Server to be configured.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
         The name of the SQL instance to be configured.
 
     .PARAMETER Ensure
@@ -87,12 +87,12 @@ function Set-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName,
+        $InstanceName,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer = $env:COMPUTERNAME,
+        $ServerName = $env:COMPUTERNAME,
 
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
@@ -116,7 +116,7 @@ function Set-TargetResource
         $ProcessOnlyOnActiveNode
     )
 
-    $sqlServerObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
     if ($sqlServerObject)
     {
@@ -130,7 +130,7 @@ function Set-TargetResource
                     if ($MaxMemory)
                     {
                         throw New-TerminatingError -ErrorType MaxMemoryParamMustBeNull `
-                            -FormatArgs @( $SQLServer, $SQLInstanceName ) `
+                            -FormatArgs @( $ServerName, $InstanceName ) `
                             -ErrorCategory InvalidArgument
                     }
 
@@ -142,7 +142,7 @@ function Set-TargetResource
                     if (-not $MaxMemory)
                     {
                         throw New-TerminatingError -ErrorType MaxMemoryParamMustNotBeNull `
-                            -FormatArgs @( $SQLServer, $SQLInstanceName ) `
+                            -FormatArgs @( $ServerName, $InstanceName ) `
                             -ErrorCategory InvalidArgument
                     }
                 }
@@ -173,7 +173,7 @@ function Set-TargetResource
         catch
         {
             throw New-TerminatingError -ErrorType AlterServerMemoryFailed `
-                -FormatArgs @($SQLServer, $SQLInstanceName) `
+                -FormatArgs @($ServerName, $InstanceName) `
                 -ErrorCategory InvalidOperation `
                 -InnerException $_.Exception
         }
@@ -184,10 +184,10 @@ function Set-TargetResource
     .SYNOPSIS
         This function tests the value of the min and max memory server configuration option.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
         The host name of the SQL Server to be configured.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
         The name of the SQL instance to be configured.
 
     .PARAMETER Ensure
@@ -216,12 +216,12 @@ function Test-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName,
+        $InstanceName,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer = $env:COMPUTERNAME,
+        $ServerName = $env:COMPUTERNAME,
 
         [Parameter()]
         [ValidateSet("Present", "Absent")]
@@ -248,8 +248,8 @@ function Test-TargetResource
     Write-Verbose -Message 'Testing the values of the minimum and maximum memory server configuration option set to be used by the instance.'
 
     $getTargetResourceParameters = @{
-        SQLInstanceName = $SQLInstanceName
-        SQLServer       = $SQLServer
+        InstanceName = $InstanceName
+        ServerName   = $ServerName
     }
 
     $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
@@ -265,7 +265,7 @@ function Test-TargetResource
     if ( $ProcessOnlyOnActiveNode -and -not $getTargetResourceResult.IsActiveNode )
     {
         # Use localization if the resource has been converted
-        New-VerboseMessage -Message ( 'The node "{0}" is not actively hosting the instance "{1}". Exiting the test.' -f $env:COMPUTERNAME,$SQLInstanceName )
+        New-VerboseMessage -Message ( 'The node "{0}" is not actively hosting the instance "{1}". Exiting the test.' -f $env:COMPUTERNAME, $InstanceName )
         return $isServerMemoryInDesiredState
     }
 
@@ -293,7 +293,7 @@ function Test-TargetResource
                 if ($MaxMemory)
                 {
                     throw New-TerminatingError -ErrorType MaxMemoryParamMustBeNull `
-                        -FormatArgs @( $SQLServer, $SQLInstanceName ) `
+                        -FormatArgs @( $ServerName, $InstanceName ) `
                         -ErrorCategory InvalidArgument
                 }
 
@@ -305,7 +305,7 @@ function Test-TargetResource
                 if (-not $MaxMemory)
                 {
                     throw New-TerminatingError -ErrorType MaxMemoryParamMustNotBeNull `
-                        -FormatArgs @( $SQLServer, $SQLInstanceName ) `
+                        -FormatArgs @( $ServerName, $InstanceName ) `
                         -ErrorCategory InvalidArgument
                 }
             }

--- a/DSCResources/MSFT_SqlServerMemory/MSFT_SqlServerMemory.schema.mof
+++ b/DSCResources/MSFT_SqlServerMemory/MSFT_SqlServerMemory.schema.mof
@@ -1,8 +1,8 @@
 [ClassVersion("1.0.0.0"), FriendlyName("SqlServerMemory")]
 class MSFT_SqlServerMemory : OMI_BaseResource
 {
-    [Key, Description("The name of the SQL instance to be configured.")] String SQLInstanceName;
-    [Write, Description("The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.")] String SQLServer;
+    [Key, Description("The name of the SQL instance to be configured.")] String InstanceName;
+    [Write, Description("The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.")] String ServerName;
     [Write, Description("When set to 'Present' then min and max memory will be set to either the value in parameter MinMemory and MaxMemory or dynamically configured when parameter DynamicAlloc is set to $true. When set to 'Absent' min and max memory will be set to default values. Default value is Present."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("If set to $true then max memory will be dynamically configured. When this is set parameter is set to $true, the parameter MaxMemory must be set to $null or not be configured. Default value is $false.")] Boolean DynamicAlloc;
     [Write, Description("Minimum amount of memory, in MB, in the buffer pool used by the instance of SQL Server.")] Sint32 MinMemory;

--- a/DSCResources/MSFT_SqlServerNetwork/MSFT_SqlServerNetwork.psm1
+++ b/DSCResources/MSFT_SqlServerNetwork/MSFT_SqlServerNetwork.psm1
@@ -67,7 +67,7 @@ function Get-TargetResource
     .SYNOPSIS
     Sets the SQL Server network properties.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
     The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.
 
     .PARAMETER InstanceName
@@ -105,7 +105,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer = $env:COMPUTERNAME,
+        $ServerName = $env:COMPUTERNAME,
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -223,7 +223,7 @@ function Set-TargetResource
 
         if ($RestartService -and $isRestartNeeded)
         {
-            Restart-SqlService -SQLServer $SQLServer -SQLInstanceName $InstanceName -Timeout $RestartTimeout
+            Restart-SqlService -SQLServer $ServerName -SQLInstanceName $InstanceName -Timeout $RestartTimeout
         }
     }
     finally
@@ -236,7 +236,7 @@ function Set-TargetResource
     .SYNOPSIS
     Sets the SQL Server network properties.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
     The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.
 
     Not used in Test-TargetResource.
@@ -280,7 +280,7 @@ function Test-TargetResource
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer = $env:COMPUTERNAME,
+        $ServerName = $env:COMPUTERNAME,
 
         [Parameter(Mandatory = $true)]
         [System.String]

--- a/DSCResources/MSFT_SqlServerNetwork/MSFT_SqlServerNetwork.schema.mof
+++ b/DSCResources/MSFT_SqlServerNetwork/MSFT_SqlServerNetwork.schema.mof
@@ -3,7 +3,7 @@ class MSFT_SqlServerNetwork : OMI_BaseResource
 {
     [Key, Description("The name of the SQL instance to be configured.")] String InstanceName;
     [Required, Description("The name of network protocol to be configured. Only tcp is currently supported."), ValueMap{"Tcp"}, Values{"Tcp"}] String ProtocolName;
-    [Write, Description("The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.")] String SQLServer;
+    [Write, Description("The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.")] String ServerName;
     [Write, Description("Enables or disables the network protocol.")] Boolean IsEnabled;
     [Write, Description("Specifies whether the SQL Server instance should use a dynamic port. Value cannot be set to 'True' if TcpPort is set to a non-empty string.")] Boolean TcpDynamicPort;
     [Write, Description("The TCP port(s) that SQL Server should be listening on. If the IP address should listen on more than one port, list all ports separated with a comma ('1433,1500,1501'). To use this parameter set TcpDynamicPorts to 'False'.")] String TcpPort;

--- a/DSCResources/MSFT_SqlServerPermission/MSFT_SqlServerPermission.psm1
+++ b/DSCResources/MSFT_SqlServerPermission/MSFT_SqlServerPermission.psm1
@@ -8,7 +8,7 @@ Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Pare
     .PARAMETER InstanceName
         The name of the SQL instance to be configured.
 
-    .PARAMETER NodeName
+    .PARAMETER ServerName
         The host name of the SQL Server to be configured.
 
     .PARAMETER Principal
@@ -29,7 +29,7 @@ function Get-TargetResource
 
         [Parameter()]
         [System.String]
-        $NodeName = $env:COMPUTERNAME,
+        $ServerName = $env:COMPUTERNAME,
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -45,7 +45,7 @@ function Get-TargetResource
 
     try
     {
-        $sqlServerObject = Connect-SQL -SQLServer $NodeName -SQLInstanceName $InstanceName
+        $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
         # Gets a set of permissions granted based on the desired permissions in $Permission
         $desiredPermissionSet = Get-SQLServerPermissionSet -Permission $Permission
@@ -82,7 +82,7 @@ function Get-TargetResource
 
     return @{
         InstanceName = [System.String] $InstanceName
-        NodeName     = [System.String] $NodeName
+        ServerName   = [System.String] $ServerName
         Ensure       = [System.String] $ensure
         Principal    = [System.String] $Principal
         Permission   = [System.String[]] $grantedPermission
@@ -96,7 +96,7 @@ function Get-TargetResource
     .PARAMETER InstanceName
         The name of the SQL instance to be configured.
 
-    .PARAMETER NodeName
+    .PARAMETER ServerName
         The host name of the SQL Server to be configured.
 
     .PARAMETER Ensure
@@ -119,7 +119,7 @@ function Set-TargetResource
 
         [Parameter()]
         [System.String]
-        $NodeName = $env:COMPUTERNAME,
+        $ServerName = $env:COMPUTERNAME,
 
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
@@ -138,7 +138,7 @@ function Set-TargetResource
 
     $getTargetResourceParameters = @{
         InstanceName = [System.String] $InstanceName
-        NodeName     = [System.String] $NodeName
+        ServerName   = [System.String] $ServerName
         Principal    = [System.String] $Principal
         Permission   = [System.String[]] $Permission
     }
@@ -149,7 +149,7 @@ function Set-TargetResource
     {
         try
         {
-            $sqlServerObject = Connect-SQL -SQLServer $NodeName -SQLInstanceName $InstanceName
+            $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
             $permissionSet = Get-SQLServerPermissionSet -Permission $Permission
 
@@ -184,7 +184,7 @@ function Set-TargetResource
     .PARAMETER InstanceName
         The name of the SQL instance to be configured.
 
-    .PARAMETER NodeName
+    .PARAMETER ServerName
         The host name of the SQL Server to be configured.
 
     .PARAMETER Ensure
@@ -208,7 +208,7 @@ function Test-TargetResource
 
         [Parameter()]
         [System.String]
-        $NodeName = $env:COMPUTERNAME,
+        $ServerName = $env:COMPUTERNAME,
 
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
@@ -227,7 +227,7 @@ function Test-TargetResource
 
     $getTargetResourceParameters = @{
         InstanceName = $InstanceName
-        NodeName     = $NodeName
+        ServerName   = $ServerName
         Principal    = $Principal
         Permission   = $Permission
     }

--- a/DSCResources/MSFT_SqlServerPermission/MSFT_SqlServerPermission.schema.mof
+++ b/DSCResources/MSFT_SqlServerPermission/MSFT_SqlServerPermission.schema.mof
@@ -2,7 +2,7 @@
 class MSFT_SqlServerPermission : OMI_BaseResource
 {
     [Key, Description("The name of the SQL instance to be configured.")] String InstanceName;
-    [Write, Description("The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.")] String NodeName;
+    [Write, Description("The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.")] String ServerName;
     [Write, Description("If the permission should be present or absent. Default value is 'Present'."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Key, Description("The login to which permission will be set.")] String Principal;
     [Write, Description("The permission to set for the login. Valid values are ConnectSql, AlterAnyAvailabilityGroup, ViewServerState or AlterAnyEndPoint."), ValueMap{"ConnectSql","AlterAnyAvailabilityGroup","ViewServerState","AlterAnyEndPoint"}, Values{"ConnectSql","AlterAnyAvailabilityGroup","ViewServerState","AlterAnyEndPoint"}] String Permission[];

--- a/DSCResources/MSFT_SqlServerRole/MSFT_SqlServerRole.psm1
+++ b/DSCResources/MSFT_SqlServerRole/MSFT_SqlServerRole.psm1
@@ -17,10 +17,10 @@ Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Pare
     .PARAMETER ServerRoleName
     The name of server role to be created or dropped.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
     The host name of the SQL Server to be configured.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     The name of the SQL instance to be configured.
 #>
 function Get-TargetResource
@@ -49,15 +49,15 @@ function Get-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer,
+        $ServerName,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName
+        $InstanceName
     )
 
-    $sqlServerObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
     $ensure = 'Present'
 
     if ($sqlServerObject)
@@ -72,7 +72,7 @@ function Get-TargetResource
             catch
             {
                 throw New-TerminatingError -ErrorType EnumMemberNamesServerRoleGetError `
-                    -FormatArgs @($SQLServer, $SQLInstanceName, $ServerRoleName) `
+                    -FormatArgs @($ServerName, $InstanceName, $ServerRoleName) `
                     -ErrorCategory InvalidOperation `
                     -InnerException $_.Exception
             }
@@ -82,7 +82,7 @@ function Get-TargetResource
                 if ($MembersToInclude -or $MembersToExclude)
                 {
                     throw New-TerminatingError -ErrorType MembersToIncludeAndExcludeParamMustBeNull `
-                        -FormatArgs @($SQLServer, $SQLInstanceName) `
+                        -FormatArgs @($ServerName, $InstanceName) `
                         -ErrorCategory InvalidArgument
                 }
 
@@ -131,8 +131,8 @@ function Get-TargetResource
         MembersToInclude = $MembersToInclude
         MembersToExclude = $MembersToExclude
         ServerRoleName   = $ServerRoleName
-        SQLServer        = $SQLServer
-        SQLInstanceName  = $SQLInstanceName
+        ServerName       = $ServerName
+        InstanceName     = $InstanceName
     }
     $returnValue
 }
@@ -157,10 +157,10 @@ function Get-TargetResource
     .PARAMETER ServerRoleName
     The name of server role to be created or dropped.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
     The host name of the SQL Server to be configured.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     The name of the SQL instance to be configured.
 #>
 function Set-TargetResource
@@ -193,15 +193,15 @@ function Set-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer,
+        $ServerName,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName
+        $InstanceName
     )
 
-    $sqlServerObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
     if ($sqlServerObject)
     {
@@ -224,7 +224,7 @@ function Set-TargetResource
                 catch
                 {
                     throw New-TerminatingError -ErrorType DropServerRoleSetError `
-                        -FormatArgs @($SQLServer, $SQLInstanceName, $ServerRoleName) `
+                        -FormatArgs @($ServerName, $InstanceName, $ServerRoleName) `
                         -ErrorCategory InvalidOperation `
                         -InnerException $_.Exception
                 }
@@ -248,7 +248,7 @@ function Set-TargetResource
                     catch
                     {
                         throw New-TerminatingError -ErrorType CreateServerRoleSetError `
-                            -FormatArgs @($SQLServer, $SQLInstanceName, $ServerRoleName) `
+                            -FormatArgs @($ServerName, $InstanceName, $ServerRoleName) `
                             -ErrorCategory InvalidOperation `
                             -InnerException $_.Exception
                     }
@@ -259,7 +259,7 @@ function Set-TargetResource
                     if ($MembersToInclude -or $MembersToExclude)
                     {
                         throw New-TerminatingError -ErrorType MembersToIncludeAndExcludeParamMustBeNull `
-                            -FormatArgs @($SQLServer, $SQLInstanceName) `
+                            -FormatArgs @($ServerName, $InstanceName) `
                             -ErrorCategory InvalidArgument
                     }
 
@@ -342,10 +342,10 @@ function Set-TargetResource
     .PARAMETER ServerRoleName
     The name of server role to be created or dropped.
 
-    .PARAMETER SQLServer
+    .PARAMETER ServerName
     The host name of the SQL Server to be configured.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     The name of the SQL instance to be configured.
 #>
 function Test-TargetResource
@@ -379,19 +379,19 @@ function Test-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLServer,
+        $ServerName,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName
+        $InstanceName
     )
 
     Write-Verbose -Message "Testing SQL Server role $ServerRoleName properties."
 
     $getTargetResourceParameters = @{
-        SQLInstanceName  = $PSBoundParameters.SQLInstanceName
-        SQLServer        = $PSBoundParameters.SQLServer
+        InstanceName     = $PSBoundParameters.InstanceName
+        ServerName       = $PSBoundParameters.ServerName
         ServerRoleName   = $PSBoundParameters.ServerRoleName
         Members          = $PSBoundParameters.Members
         MembersToInclude = $PSBoundParameters.MembersToInclude
@@ -463,7 +463,7 @@ function Add-SqlDscServerRoleMember
     if ( -not ($SqlServerObject.Logins[$LoginName]) )
     {
         throw New-TerminatingError -ErrorType LoginNotFound `
-            -FormatArgs @($LoginName, $SQLServer, $SQLInstanceName) `
+            -FormatArgs @($LoginName, $ServerName, $InstanceName) `
             -ErrorCategory ObjectNotFound
     }
 
@@ -476,7 +476,7 @@ function Add-SqlDscServerRoleMember
     catch
     {
         throw New-TerminatingError -ErrorType AddMemberServerRoleSetError `
-            -FormatArgs @($SQLServer, $SQLInstanceName, $ServerRoleName, $LoginName) `
+            -FormatArgs @($ServerName, $InstanceName, $ServerRoleName, $LoginName) `
             -ErrorCategory InvalidOperation `
             -InnerException $_.Exception
     }
@@ -519,7 +519,7 @@ function Remove-SqlDscServerRoleMember
     if ( -not ($SqlServerObject.Logins[$LoginName]) )
     {
         throw New-TerminatingError -ErrorType LoginNotFound `
-            -FormatArgs @($LoginName, $SQLServer, $SQLInstanceName) `
+            -FormatArgs @($LoginName, $ServerName, $InstanceName) `
             -ErrorCategory ObjectNotFound
     }
 
@@ -532,7 +532,7 @@ function Remove-SqlDscServerRoleMember
     catch
     {
         throw New-TerminatingError -ErrorType DropMemberServerRoleSetError `
-            -FormatArgs @($SQLServer, $SQLInstanceName, $ServerRoleName, $LoginName) `
+            -FormatArgs @($ServerName, $InstanceName, $ServerRoleName, $LoginName) `
             -ErrorCategory InvalidOperation `
             -InnerException $_.Exception
     }

--- a/DSCResources/MSFT_SqlServerRole/MSFT_SqlServerRole.schema.mof
+++ b/DSCResources/MSFT_SqlServerRole/MSFT_SqlServerRole.schema.mof
@@ -2,8 +2,8 @@
 class MSFT_SqlServerRole : OMI_BaseResource
 {
     [Key, Description("The name of of SQL role to add or remove.")] String ServerRoleName;
-    [Key, Description("The host name of the SQL Server to be configured.")] String SQLServer;
-    [Key, Description("The name of the SQL instance to be configured.")] String SQLInstanceName;
+    [Key, Description("The host name of the SQL Server to be configured.")] String ServerName;
+    [Key, Description("The name of the SQL instance to be configured.")] String InstanceName;
     [Write, Description("An enumerated value that describes if the server role is added (Present) or dropped (Absent). Default value is 'Present'."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("The members the server role should have. This parameter will replace all the current server role members with the specified members.")] String Members[];
     [Write, Description("The members the server role should include. This parameter will only add members to a server role. Can not be used at the same time as parameter Members.")] String MembersToInclude[];

--- a/DSCResources/MSFT_SqlServiceAccount/MSFT_SqlServiceAccount.schema.mof
+++ b/DSCResources/MSFT_SqlServiceAccount/MSFT_SqlServiceAccount.schema.mof
@@ -1,8 +1,8 @@
 [ClassVersion("1.0.0.0"), FriendlyName("SqlServiceAccount")]
 class MSFT_SqlServiceAccount : OMI_BaseResource
 {
-    [Key, Description("Hostname of the SQL Server.")] String SQLServer;
-    [Key, Description("Name of the SQL instance.")] String SQLInstanceName;
+    [Key, Description("Hostname of the SQL Server.")] String ServerName;
+    [Key, Description("Name of the SQL instance.")] String InstanceName;
     [Key, Description("Type of service being managed."), ValueMap {"DatabaseEngine","SQLServerAgent","Search","IntegrationServices","AnalysisServices","ReportingServices","SQLServerBrowser","NotificationServices"}, Values {"DatabaseEngine","SQLServerAgent","Search","IntegrationServices","AnalysisServices","ReportingServices","SQLServerBrowser","NotificationServices"}] String ServiceType;
     [Required, EmbeddedInstance("MSFT_Credential"), Description("The service account that should be used when running the service.")] String ServiceAccount;
     [Write, Description("Determines whether the service is automatically restarted.")] Boolean RestartService;

--- a/Examples/Resources/SqlAG/1-CreateAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAG/1-CreateAvailabilityGroup.ps1
@@ -44,7 +44,7 @@ Configuration Example
         {
             DependsOn            = '[SqlServerLogin]AddNTServiceClusSvc'
             Ensure               = 'Present'
-            NodeName             = $Node.NodeName
+            ServerName           = $Node.NodeName
             InstanceName         = $Node.InstanceName
             Principal            = 'NT SERVICE\ClusSvc'
             Permission           = 'AlterAnyAvailabilityGroup', 'ViewServerState'

--- a/Examples/Resources/SqlAG/1-CreateAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAG/1-CreateAvailabilityGroup.ps1
@@ -6,8 +6,8 @@
 $ConfigurationData = @{
     AllNodes = @(
         @{
-            NodeName        = '*'
-            SQLInstanceName = 'MSSQLSERVER'
+            NodeName     = '*'
+            InstanceName = 'MSSQLSERVER'
         },
 
         @{
@@ -34,8 +34,8 @@ Configuration Example
             Ensure               = 'Present'
             Name                 = 'NT SERVICE\ClusSvc'
             LoginType            = 'WindowsUser'
-            SQLServer            = $Node.NodeName
-            SQLInstanceName      = $Node.SQLInstanceName
+            ServerName           = $Node.NodeName
+            InstanceName         = $Node.InstanceName
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -45,7 +45,7 @@ Configuration Example
             DependsOn            = '[SqlServerLogin]AddNTServiceClusSvc'
             Ensure               = 'Present'
             NodeName             = $Node.NodeName
-            InstanceName         = $Node.SqlInstanceName
+            InstanceName         = $Node.InstanceName
             Principal            = 'NT SERVICE\ClusSvc'
             Permission           = 'AlterAnyAvailabilityGroup', 'ViewServerState'
             PsDscRunAsCredential = $SysAdminAccount
@@ -57,8 +57,8 @@ Configuration Example
             EndPointName         = 'HADR'
             Ensure               = 'Present'
             Port                 = 5022
-            SQLServer            = $Node.NodeName
-            SQLInstanceName      = $Node.SQLInstanceName
+            ServerName           = $Node.NodeName
+            InstanceName         = $Node.InstanceName
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -69,8 +69,8 @@ Configuration Example
             {
                 Ensure               = 'Present'
                 Name                 = 'TestAG'
-                SQLInstanceName      = $Node.SQLInstanceName
-                SQLServer            = $Node.NodeName
+                InstanceName         = $Node.InstanceName
+                ServerName           = $Node.NodeName
                 DependsOn            = '[SqlServerEndpoint]HADREndpoint', '[SqlServerPermission]AddNTServiceClusSvcPermissions'
                 PsDscRunAsCredential = $SysAdminAccount
             }

--- a/Examples/Resources/SqlAG/2-RemoveAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAG/2-RemoveAvailabilityGroup.ps1
@@ -6,8 +6,8 @@ This example shows how to ensure that the Availability Group 'TestAG' does not e
 $ConfigurationData = @{
     AllNodes = @(
         @{
-            NodeName        = '*'
-            SQLInstanceName = 'MSSQLSERVER'
+            NodeName     = '*'
+            InstanceName = 'MSSQLSERVER'
         },
 
         @{
@@ -35,8 +35,8 @@ Configuration Example
             {
                 Ensure               = 'Absent'
                 Name                 = 'TestAG'
-                SQLInstanceName      = $Node.SQLInstanceName
-                SQLServer            = $Node.NodeName
+                InstanceName         = $Node.InstanceName
+                ServerName           = $Node.NodeName
                 PsDscRunAsCredential = $SysAdminAccount
             }
         }

--- a/Examples/Resources/SqlAG/3-CreateAvailabilityGroupDetailed.ps1
+++ b/Examples/Resources/SqlAG/3-CreateAvailabilityGroupDetailed.ps1
@@ -12,7 +12,7 @@ $ConfigurationData = @{
     AllNodes = @(
         @{
             NodeName                      = '*'
-            SQLInstanceName               = 'MSSQLSERVER'
+            InstanceName                  = 'MSSQLSERVER'
             ProcessOnlyOnActiveNode       = $true
 
             AutomatedBackupPreference     = 'Primary'
@@ -29,8 +29,8 @@ $ConfigurationData = @{
         },
 
         @{
-            NodeName                      = 'SP23-VM-SQL1'
-            Role                          = 'PrimaryReplica'
+            NodeName = 'SP23-VM-SQL1'
+            Role     = 'PrimaryReplica'
         }
     )
 }
@@ -52,8 +52,8 @@ Configuration Example
             Ensure               = 'Present'
             Name                 = 'NT SERVICE\ClusSvc'
             LoginType            = 'WindowsUser'
-            SQLServer            = $Node.NodeName
-            SQLInstanceName      = $Node.SQLInstanceName
+            ServerName           = $Node.NodeName
+            InstanceName         = $Node.InstanceName
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -63,7 +63,7 @@ Configuration Example
             DependsOn            = '[SqlServerLogin]AddNTServiceClusSvc'
             Ensure               = 'Present'
             NodeName             = $Node.NodeName
-            InstanceName         = $Node.SqlInstanceName
+            InstanceName         = $Node.InstanceName
             Principal            = 'NT SERVICE\ClusSvc'
             Permission           = 'AlterAnyAvailabilityGroup', 'ViewServerState'
             PsDscRunAsCredential = $SysAdminAccount
@@ -75,8 +75,8 @@ Configuration Example
             EndPointName         = 'HADR'
             Ensure               = 'Present'
             Port                 = 5022
-            SQLServer            = $Node.NodeName
-            SQLInstanceName      = $Node.SQLInstanceName
+            ServerName           = $Node.NodeName
+            InstanceName         = $Node.InstanceName
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -87,8 +87,8 @@ Configuration Example
             {
                 Ensure                        = 'Present'
                 Name                          = 'TestAG'
-                SQLInstanceName               = $Node.SQLInstanceName
-                SQLServer                     = $Node.NodeName
+                InstanceName                  = $Node.InstanceName
+                ServerName                    = $Node.NodeName
                 ProcessOnlyOnActiveNode       = $Node.ProcessOnlyOnActiveNode
 
                 AutomatedBackupPreference     = $Node.AutomatedBackupPreference

--- a/Examples/Resources/SqlAG/3-CreateAvailabilityGroupDetailed.ps1
+++ b/Examples/Resources/SqlAG/3-CreateAvailabilityGroupDetailed.ps1
@@ -62,7 +62,7 @@ Configuration Example
         {
             DependsOn            = '[SqlServerLogin]AddNTServiceClusSvc'
             Ensure               = 'Present'
-            NodeName             = $Node.NodeName
+            ServerName           = $Node.NodeName
             InstanceName         = $Node.InstanceName
             Principal            = 'NT SERVICE\ClusSvc'
             Permission           = 'AlterAnyAvailabilityGroup', 'ViewServerState'

--- a/Examples/Resources/SqlAGDatabase/1-AddDatabaseToAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAGDatabase/1-AddDatabaseToAvailabilityGroup.ps1
@@ -95,8 +95,8 @@ Configuration Example
                 Ensure                        = 'Present'
                 Name                          = $Node.NodeName
                 AvailabilityGroupName         = $Node.AvailabilityGroupName
-                SQLServer                     = $Node.NodeName
-                SQLInstanceName               = $Node.SQLInstanceName
+                ServerName                    = $Node.NodeName
+                InstanceName                  = $Node.SQLInstanceName
                 PrimaryReplicaSQLServer       = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).NodeName
                 PrimaryReplicaSQLInstanceName = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).SQLInstanceName
             }
@@ -109,8 +109,8 @@ Configuration Example
                 AvailabilityGroupName   = $Node.AvailabilityGroupName
                 BackupPath              = '\\SQL1\AgInitialize'
                 DatabaseName            = 'DB*', 'AdventureWorks'
-                SQLInstanceName         = $Node.SQLInstanceName
-                SQLServer               = $Node.NodeName
+                InstanceName            = $Node.SQLInstanceName
+                ServerName              = $Node.NodeName
                 Ensure                  = 'Present'
                 ProcessOnlyOnActiveNode = $true
                 PsDscRunAsCredential    = $SysAdminAccount

--- a/Examples/Resources/SqlAGDatabase/1-AddDatabaseToAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAGDatabase/1-AddDatabaseToAvailabilityGroup.ps1
@@ -45,8 +45,8 @@ Configuration Example
             Ensure               = 'Present'
             Name                 = 'NT SERVICE\ClusSvc'
             LoginType            = 'WindowsUser'
-            SQLServer            = $Node.NodeName
-            SQLInstanceName      = $Node.SQLInstanceName
+            ServerName           = $Node.NodeName
+            InstanceName         = $Node.SQLInstanceName
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -55,7 +55,7 @@ Configuration Example
         {
             DependsOn            = '[SqlServerLogin]AddNTServiceClusSvc'
             Ensure               = 'Present'
-            NodeName             = $Node.NodeName
+            ServerName           = $Node.NodeName
             InstanceName         = $Node.SqlInstanceName
             Principal            = 'NT SERVICE\ClusSvc'
             Permission           = 'AlterAnyAvailabilityGroup', 'ViewServerState'
@@ -68,8 +68,8 @@ Configuration Example
             EndPointName         = 'HADR'
             Ensure               = 'Present'
             Port                 = 5022
-            SQLServer            = $Node.NodeName
-            SQLInstanceName      = $Node.SQLInstanceName
+            ServerName           = $Node.NodeName
+            InstanceName         = $Node.SQLInstanceName
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -80,8 +80,8 @@ Configuration Example
             {
                 Ensure               = 'Present'
                 Name                 = $Node.AvailabilityGroupName
-                SQLInstanceName      = $Node.SQLInstanceName
-                SQLServer            = $Node.NodeName
+                InstanceName         = $Node.SQLInstanceName
+                ServerName           = $Node.NodeName
                 DependsOn            = '[SqlServerEndpoint]HADREndpoint', '[SqlServerPermission]AddNTServiceClusSvcPermissions'
                 PsDscRunAsCredential = $SysAdminAccount
             }

--- a/Examples/Resources/SqlAGDatabase/2-RemoveDatabaseFromAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAGDatabase/2-RemoveDatabaseFromAvailabilityGroup.ps1
@@ -40,8 +40,8 @@ Configuration Example
             Ensure               = 'Present'
             Name                 = 'NT SERVICE\ClusSvc'
             LoginType            = 'WindowsUser'
-            SQLServer            = $Node.NodeName
-            SQLInstanceName      = $Node.SQLInstanceName
+            ServerName            = $Node.NodeName
+            InstanceName      = $Node.SQLInstanceName
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -50,7 +50,7 @@ Configuration Example
         {
             DependsOn            = '[SqlServerLogin]AddNTServiceClusSvc'
             Ensure               = 'Present'
-            NodeName             = $Node.NodeName
+            ServerName             = $Node.NodeName
             InstanceName         = $Node.SqlInstanceName
             Principal            = 'NT SERVICE\ClusSvc'
             Permission           = 'AlterAnyAvailabilityGroup', 'ViewServerState'
@@ -63,8 +63,8 @@ Configuration Example
             EndPointName         = 'HADR'
             Ensure               = 'Present'
             Port                 = 5022
-            SQLServer            = $Node.NodeName
-            SQLInstanceName      = $Node.SQLInstanceName
+            ServerName            = $Node.NodeName
+            InstanceName      = $Node.SQLInstanceName
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -75,8 +75,8 @@ Configuration Example
             {
                 Ensure               = 'Present'
                 Name                 = $Node.AvailabilityGroupName
-                SQLInstanceName      = $Node.SQLInstanceName
-                SQLServer            = $Node.NodeName
+                InstanceName      = $Node.SQLInstanceName
+                ServerName            = $Node.NodeName
                 DependsOn            = '[SqlServerEndpoint]HADREndpoint', '[SqlServerPermission]AddNTServiceClusSvcPermissions'
                 PsDscRunAsCredential = $SysAdminAccount
             }

--- a/Examples/Resources/SqlAGDatabase/2-RemoveDatabaseFromAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAGDatabase/2-RemoveDatabaseFromAvailabilityGroup.ps1
@@ -90,8 +90,8 @@ Configuration Example
                 Ensure                        = 'Present'
                 Name                          = $Node.NodeName
                 AvailabilityGroupName         = $Node.AvailabilityGroupName
-                SQLServer                     = $Node.NodeName
-                SQLInstanceName               = $Node.SQLInstanceName
+                ServerName                    = $Node.NodeName
+                InstanceName                  = $Node.SQLInstanceName
                 PrimaryReplicaSQLServer       = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).NodeName
                 PrimaryReplicaSQLInstanceName = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).SQLInstanceName
             }
@@ -104,8 +104,8 @@ Configuration Example
                 AvailabilityGroupName = $Node.AvailabilityGroupName
                 BackupPath            = '\\SQL1\AgInitialize'
                 DatabaseName          = 'DB*', 'AdventureWorks'
-                SQLInstanceName       = $Node.SQLInstanceName
-                SQLServer             = $Node.NodeName
+                InstanceName          = $Node.SQLInstanceName
+                ServerName            = $Node.NodeName
                 Ensure                = 'Absent'
                 PsDscRunAsCredential  = $SysAdminAccount
             }

--- a/Examples/Resources/SqlAGDatabase/3-MatchDefinedDatabaseInAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAGDatabase/3-MatchDefinedDatabaseInAvailabilityGroup.ps1
@@ -90,8 +90,8 @@ Configuration Example
                 Ensure                        = 'Present'
                 Name                          = $Node.NodeName
                 AvailabilityGroupName         = $Node.AvailabilityGroupName
-                SQLServer                     = $Node.NodeName
-                SQLInstanceName               = $Node.SQLInstanceName
+                ServerName                    = $Node.NodeName
+                InstanceName                  = $Node.SQLInstanceName
                 PrimaryReplicaSQLServer       = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).NodeName
                 PrimaryReplicaSQLInstanceName = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).SQLInstanceName
             }
@@ -104,8 +104,8 @@ Configuration Example
                 AvailabilityGroupName = $Node.AvailabilityGroupName
                 BackupPath            = '\\SQL1\AgInitialize'
                 DatabaseName          = 'DB*', 'AdventureWorks'
-                SQLInstanceName       = $Node.SQLInstanceName
-                SQLServer             = $Node.NodeName
+                InstanceName          = $Node.SQLInstanceName
+                ServerName            = $Node.NodeName
                 Ensure                = 'Present'
                 Force                 = $true
                 PsDscRunAsCredential  = $SysAdminAccount

--- a/Examples/Resources/SqlAGDatabase/3-MatchDefinedDatabaseInAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAGDatabase/3-MatchDefinedDatabaseInAvailabilityGroup.ps1
@@ -40,8 +40,8 @@ Configuration Example
             Ensure               = 'Present'
             Name                 = 'NT SERVICE\ClusSvc'
             LoginType            = 'WindowsUser'
-            SQLServer            = $Node.NodeName
-            SQLInstanceName      = $Node.SQLInstanceName
+            ServerName            = $Node.NodeName
+            InstanceName      = $Node.SQLInstanceName
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -50,7 +50,7 @@ Configuration Example
         {
             DependsOn            = '[SqlServerLogin]AddNTServiceClusSvc'
             Ensure               = 'Present'
-            NodeName             = $Node.NodeName
+            ServerName             = $Node.NodeName
             InstanceName         = $Node.SqlInstanceName
             Principal            = 'NT SERVICE\ClusSvc'
             Permission           = 'AlterAnyAvailabilityGroup', 'ViewServerState'
@@ -63,8 +63,8 @@ Configuration Example
             EndPointName         = 'HADR'
             Ensure               = 'Present'
             Port                 = 5022
-            SQLServer            = $Node.NodeName
-            SQLInstanceName      = $Node.SQLInstanceName
+            ServerName            = $Node.NodeName
+            InstanceName      = $Node.SQLInstanceName
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -75,8 +75,8 @@ Configuration Example
             {
                 Ensure               = 'Present'
                 Name                 = $Node.AvailabilityGroupName
-                SQLInstanceName      = $Node.SQLInstanceName
-                SQLServer            = $Node.NodeName
+                InstanceName      = $Node.SQLInstanceName
+                ServerName            = $Node.NodeName
                 DependsOn            = '[SqlServerEndpoint]HADREndpoint', '[SqlServerPermission]AddNTServiceClusSvcPermissions'
                 PsDscRunAsCredential = $SysAdminAccount
             }

--- a/Examples/Resources/SqlAGListener/1-AddAvailabilityGroupListenerWithSameNameAsVCO.ps1
+++ b/Examples/Resources/SqlAGListener/1-AddAvailabilityGroupListenerWithSameNameAsVCO.ps1
@@ -19,7 +19,7 @@ Configuration Example
         SqlAGListener AvailabilityGroupListenerWithSameNameAsVCO
         {
             Ensure               = 'Present'
-            NodeName             = 'SQLNODE01.company.local'
+            ServerName           = 'SQLNODE01.company.local'
             InstanceName         = 'MSSQLSERVER'
             AvailabilityGroup    = 'AG-01'
             Name                 = 'AG-01'

--- a/Examples/Resources/SqlAGListener/2-AddAvailabilityGroupListenerWithDifferentNameAsVCO.ps1
+++ b/Examples/Resources/SqlAGListener/2-AddAvailabilityGroupListenerWithDifferentNameAsVCO.ps1
@@ -19,7 +19,7 @@ Configuration Example
         SqlAGListener AvailabilityGroupListenerWithDifferentNameAsVCO
         {
             Ensure               = 'Present'
-            NodeName             = 'SQLNODE01.company.local'
+            ServerName           = 'SQLNODE01.company.local'
             InstanceName         = 'MSSQLSERVER'
             AvailabilityGroup    = 'AvailabilityGroup-01'
             Name                 = 'AG-01'

--- a/Examples/Resources/SqlAGListener/3-RemoveAvailabilityGroupListenerWithSameNameAsVCO.ps1
+++ b/Examples/Resources/SqlAGListener/3-RemoveAvailabilityGroupListenerWithSameNameAsVCO.ps1
@@ -19,7 +19,7 @@ Configuration Example
         SqlAGListener RemoveAvailabilityGroupListenerWithDifferentNameAsVCO
         {
             Ensure               = 'Absent'
-            NodeName             = 'SQLNODE01.company.local'
+            ServerName           = 'SQLNODE01.company.local'
             InstanceName         = 'MSSQLSERVER'
             AvailabilityGroup    = 'AvailabilityGroup-01'
             Name                 = 'AG-01'

--- a/Examples/Resources/SqlAGListener/4-RemoveAvailabilityGroupListenerWithDifferentNameAsVCO.ps1
+++ b/Examples/Resources/SqlAGListener/4-RemoveAvailabilityGroupListenerWithDifferentNameAsVCO.ps1
@@ -19,7 +19,7 @@ Configuration Example
         SqlAGListener RemoveAvailabilityGroupListenerWithSameNameAsVCO
         {
             Ensure               = 'Absent'
-            NodeName             = 'SQLNODE01.company.local'
+            ServerName           = 'SQLNODE01.company.local'
             InstanceName         = 'MSSQLSERVER'
             AvailabilityGroup    = 'AG-01'
             Name                 = "AG-01"

--- a/Examples/Resources/SqlAGListener/5-AddAvailabilityGroupListenerUsingDHCPWithDefaultServerSubnet.ps1
+++ b/Examples/Resources/SqlAGListener/5-AddAvailabilityGroupListenerUsingDHCPWithDefaultServerSubnet.ps1
@@ -19,7 +19,7 @@ Configuration Example
         SqlAGListener AvailabilityGroupListenerWithSameNameAsVCO
         {
             Ensure               = 'Present'
-            NodeName             = 'SQLNODE01.company.local'
+            ServerName           = 'SQLNODE01.company.local'
             InstanceName         = 'MSSQLSERVER'
             AvailabilityGroup    = 'AG-01'
             Name                 = 'AG-01'

--- a/Examples/Resources/SqlAGListener/6-AddAvailabilityGroupListenerUsingDHCPWithSpecificSubnet.ps1
+++ b/Examples/Resources/SqlAGListener/6-AddAvailabilityGroupListenerUsingDHCPWithSpecificSubnet.ps1
@@ -19,7 +19,7 @@ Configuration Example
         SqlAGListener AvailabilityGroupListenerWithSameNameAsVCO
         {
             Ensure               = 'Present'
-            NodeName             = 'SQLNODE01.company.local'
+            ServerName           = 'SQLNODE01.company.local'
             InstanceName         = 'MSSQLSERVER'
             AvailabilityGroup    = 'AG-01'
             Name                 = 'AG-01'

--- a/Examples/Resources/SqlAGReplica/1-CreateAvailabilityGroupReplica.ps1
+++ b/Examples/Resources/SqlAGReplica/1-CreateAvailabilityGroupReplica.ps1
@@ -47,8 +47,8 @@ Configuration Example
             Ensure               = 'Present'
             Name                 = 'NT SERVICE\ClusSvc'
             LoginType            = 'WindowsUser'
-            SQLServer            = $Node.NodeName
-            SQLInstanceName      = $Node.SQLInstanceName
+            ServerName           = $Node.NodeName
+            InstanceName         = $Node.SQLInstanceName
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -57,7 +57,7 @@ Configuration Example
         {
             DependsOn            = '[SqlServerLogin]AddNTServiceClusSvc'
             Ensure               = 'Present'
-            NodeName             = $Node.NodeName
+            ServerName           = $Node.NodeName
             InstanceName         = $Node.SqlInstanceName
             Principal            = 'NT SERVICE\ClusSvc'
             Permission           = 'AlterAnyAvailabilityGroup', 'ViewServerState'
@@ -70,8 +70,8 @@ Configuration Example
             EndPointName         = 'HADR'
             Ensure               = 'Present'
             Port                 = 5022
-            SQLServer            = $Node.NodeName
-            SQLInstanceName      = $Node.SQLInstanceName
+            ServerName           = $Node.NodeName
+            InstanceName         = $Node.SQLInstanceName
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -82,8 +82,8 @@ Configuration Example
             {
                 Ensure               = 'Present'
                 Name                 = $Node.AvailabilityGroupName
-                SQLInstanceName      = $Node.SQLInstanceName
-                SQLServer            = $Node.NodeName
+                InstanceName         = $Node.SQLInstanceName
+                ServerName           = $Node.NodeName
                 DependsOn            = '[SqlServerEndpoint]HADREndpoint', '[SqlServerPermission]AddNTServiceClusSvcPermissions'
                 PsDscRunAsCredential = $SysAdminAccount
             }

--- a/Examples/Resources/SqlAGReplica/1-CreateAvailabilityGroupReplica.ps1
+++ b/Examples/Resources/SqlAGReplica/1-CreateAvailabilityGroupReplica.ps1
@@ -97,8 +97,8 @@ Configuration Example
                 Ensure                        = 'Present'
                 Name                          = $Node.NodeName
                 AvailabilityGroupName         = $Node.AvailabilityGroupName
-                SQLServer                     = $Node.NodeName
-                SQLInstanceName               = $Node.SQLInstanceName
+                ServerName                    = $Node.NodeName
+                InstanceName                  = $Node.SQLInstanceName
                 PrimaryReplicaSQLServer       = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).NodeName
                 PrimaryReplicaSQLInstanceName = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).SQLInstanceName
                 ProcessOnlyOnActiveNode       = $Node.ProcessOnlyOnActiveNode

--- a/Examples/Resources/SqlAGReplica/2-RemoveAvailabilityGroupReplica.ps1
+++ b/Examples/Resources/SqlAGReplica/2-RemoveAvailabilityGroupReplica.ps1
@@ -40,8 +40,8 @@ Configuration Example
             Ensure               = 'Present'
             Name                 = 'NT SERVICE\ClusSvc'
             LoginType            = 'WindowsUser'
-            SQLServer            = $Node.NodeName
-            SQLInstanceName      = $Node.SQLInstanceName
+            ServerName           = $Node.NodeName
+            InstanceName         = $Node.SQLInstanceName
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -50,7 +50,7 @@ Configuration Example
         {
             DependsOn            = '[SqlServerLogin]AddNTServiceClusSvc'
             Ensure               = 'Present'
-            NodeName             = $Node.NodeName
+            ServerName           = $Node.NodeName
             InstanceName         = $Node.SqlInstanceName
             Principal            = 'NT SERVICE\ClusSvc'
             Permission           = 'AlterAnyAvailabilityGroup', 'ViewServerState'
@@ -63,8 +63,8 @@ Configuration Example
             EndPointName         = 'HADR'
             Ensure               = 'Present'
             Port                 = 5022
-            SQLServer            = $Node.NodeName
-            SQLInstanceName      = $Node.SQLInstanceName
+            ServerName           = $Node.NodeName
+            InstanceName         = $Node.SQLInstanceName
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -75,8 +75,8 @@ Configuration Example
             {
                 Ensure               = 'Present'
                 Name                 = $Node.AvailabilityGroupName
-                SQLInstanceName      = $Node.SQLInstanceName
-                SQLServer            = $Node.NodeName
+                InstanceName         = $Node.SQLInstanceName
+                ServerName           = $Node.NodeName
                 DependsOn            = '[SqlServerEndpoint]HADREndpoint', '[SqlServerPermission]AddNTServiceClusSvcPermissions'
                 PsDscRunAsCredential = $SysAdminAccount
             }

--- a/Examples/Resources/SqlAGReplica/2-RemoveAvailabilityGroupReplica.ps1
+++ b/Examples/Resources/SqlAGReplica/2-RemoveAvailabilityGroupReplica.ps1
@@ -90,8 +90,8 @@ Configuration Example
                 Ensure                        = 'Absent'
                 Name                          = $Node.NodeName
                 AvailabilityGroupName         = $Node.AvailabilityGroupName
-                SQLServer                     = $Node.NodeName
-                SQLInstanceName               = $Node.SQLInstanceName
+                ServerName                    = $Node.NodeName
+                InstanceName                  = $Node.SQLInstanceName
                 PrimaryReplicaSQLServer       = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).NodeName
                 PrimaryReplicaSQLInstanceName = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).SQLInstanceName
             }

--- a/Examples/Resources/SqlAlias/1-AddSqlAlias.ps1
+++ b/Examples/Resources/SqlAlias/1-AddSqlAlias.ps1
@@ -19,7 +19,7 @@ Configuration Example
         {
             Ensure               = 'Present'
             Name                 = 'SQLDSC-TCP'
-            ServerName           = "SQLServer\DSC"
+            ServerName           = 'sqltest.company.local\DSC'
             Protocol             = 'TCP'
             TcpPort              = 1777
             PsDscRunAsCredential = $SysAdminAccount
@@ -29,7 +29,7 @@ Configuration Example
         {
             Ensure               = 'Present'
             Name                 = 'SQLDSC-DYN'
-            ServerName           = "SQLServer\DSC"
+            ServerName           = 'sqltest.company.local\DSC'
             Protocol             = 'TCP'
             UseDynamicTcpPort    = $true
             PsDscRunAsCredential = $SysAdminAccount
@@ -39,7 +39,7 @@ Configuration Example
         {
             Ensure               = 'Present'
             Name                 = 'SQLDSC-NP'
-            ServerName           = "\\sqlnode\PIPE\sql\query"
+            ServerName           = '\\sqlnode\PIPE\sql\query'
             Protocol             = 'NP'
             PsDscRunAsCredential = $SysAdminAccount
         }

--- a/Examples/Resources/SqlAlias/2-RemoveSqlAlias.ps1
+++ b/Examples/Resources/SqlAlias/2-RemoveSqlAlias.ps1
@@ -19,7 +19,7 @@ Configuration Example
         {
             Ensure               = 'Absent'
             Name                 = 'SQLDSC-TCP'
-            ServerName           = "SQLServer\DSC"
+            ServerName           = 'sqltest.company.local\DSC'
             Protocol             = 'TCP'
             TcpPort              = 1777
             PsDscRunAsCredential = $SysAdminAccount
@@ -29,7 +29,7 @@ Configuration Example
         {
             Ensure               = 'Absent'
             Name                 = 'SQLDSC-NP'
-            ServerName           = "\\sqlnode\PIPE\sql\query"
+            ServerName           = '\\sqlnode\PIPE\sql\query'
             Protocol             = 'NP'
             PsDscRunAsCredential = $SysAdminAccount
         }

--- a/Examples/Resources/SqlAlwaysOnService/1-EnableAlwaysOn.ps1
+++ b/Examples/Resources/SqlAlwaysOnService/1-EnableAlwaysOn.ps1
@@ -20,8 +20,8 @@ Configuration Example
         SqlAlwaysOnService 'EnableAlwaysOn'
         {
             Ensure               = 'Present'
-            SQLServer            = 'SP23-VM-SQL1'
-            SQLInstanceName      = 'MSSQLSERVER'
+            ServerName           = 'SP23-VM-SQL1'
+            InstanceName         = 'MSSQLSERVER'
             RestartTimeout       = 120
 
             PsDscRunAsCredential = $SysAdminAccount

--- a/Examples/Resources/SqlAlwaysOnService/2-DisableAlwaysOn.ps1
+++ b/Examples/Resources/SqlAlwaysOnService/2-DisableAlwaysOn.ps1
@@ -20,8 +20,8 @@ Configuration Example
         SqlAlwaysOnService 'DisableAlwaysOn'
         {
             Ensure               = 'Absent'
-            SQLServer            = 'SP23-VM-SQL1'
-            SQLInstanceName      = 'MSSQLSERVER'
+            ServerName           = 'SP23-VM-SQL1'
+            InstanceName         = 'MSSQLSERVER'
             RestartTimeout       = 120
 
             PsDscRunAsCredential = $SysAdminAccount

--- a/Examples/Resources/SqlDatabase/1-CreateDatabase.ps1
+++ b/Examples/Resources/SqlDatabase/1-CreateDatabase.ps1
@@ -23,7 +23,7 @@ Configuration Example
         SqlDatabase Create_Database
         {
             Ensure       = 'Present'
-            ServerName   = 'SQLServer'
+            ServerName   = 'sqltest.company.local'
             InstanceName = 'DSC'
             Name         = 'Contoso'
         }
@@ -31,7 +31,7 @@ Configuration Example
         SqlDatabase Create_Database_with_different_collation
         {
             Ensure       = 'Present'
-            ServerName   = 'SQLServer'
+            ServerName   = 'sqltest.company.local'
             InstanceName = 'DSC'
             Name         = 'AdventureWorks'
             Collation    = 'SQL_Latin1_General_Pref_CP850_CI_AS'

--- a/Examples/Resources/SqlDatabase/1-CreateDatabase.ps1
+++ b/Examples/Resources/SqlDatabase/1-CreateDatabase.ps1
@@ -22,19 +22,19 @@ Configuration Example
     {
         SqlDatabase Create_Database
         {
-            Ensure          = 'Present'
-            SQLServer       = 'SQLServer'
-            SQLInstanceName = 'DSC'
-            Name            = 'Contoso'
+            Ensure       = 'Present'
+            ServerName   = 'SQLServer'
+            InstanceName = 'DSC'
+            Name         = 'Contoso'
         }
 
         SqlDatabase Create_Database_with_different_collation
         {
-            Ensure          = 'Present'
-            SQLServer       = 'SQLServer'
-            SQLInstanceName = 'DSC'
-            Name            = 'AdventureWorks'
-            Collation       = 'SQL_Latin1_General_Pref_CP850_CI_AS'
+            Ensure       = 'Present'
+            ServerName   = 'SQLServer'
+            InstanceName = 'DSC'
+            Name         = 'AdventureWorks'
+            Collation    = 'SQL_Latin1_General_Pref_CP850_CI_AS'
         }
     }
 }

--- a/Examples/Resources/SqlDatabase/2-DeleteDatabase.ps1
+++ b/Examples/Resources/SqlDatabase/2-DeleteDatabase.ps1
@@ -19,10 +19,10 @@ Configuration Example
     {
         SqlDatabase Delete_Database
         {
-            Ensure          = 'Absent'
-            SQLServer       = 'SQLServer'
-            SQLInstanceName = 'DSC'
-            Name            = 'AdventureWorks'
+            Ensure       = 'Absent'
+            ServerName   = 'SQLServer'
+            InstanceName = 'DSC'
+            Name         = 'AdventureWorks'
         }
     }
 }

--- a/Examples/Resources/SqlDatabase/2-DeleteDatabase.ps1
+++ b/Examples/Resources/SqlDatabase/2-DeleteDatabase.ps1
@@ -20,7 +20,7 @@ Configuration Example
         SqlDatabase Delete_Database
         {
             Ensure       = 'Absent'
-            ServerName   = 'SQLServer'
+            ServerName   = 'sqltest.company.local'
             InstanceName = 'DSC'
             Name         = 'AdventureWorks'
         }

--- a/Examples/Resources/SqlDatabaseDefaultLocation/1-SetDatabaseDefaultLocation.ps1
+++ b/Examples/Resources/SqlDatabaseDefaultLocation/1-SetDatabaseDefaultLocation.ps1
@@ -22,32 +22,32 @@ Configuration Example
     {
         SqlDatabaseDefaultLocation Set_SqlDatabaseDefaultDirectory_Data
         {
-            SQLServer                       = 'SQLServer'
-            SQLInstanceName                 = 'DSC'
-            ProcessOnlyOnActiveNode         = $true
-            Type                            = 'Data'
-            Path                            = 'C:\Program Files\Microsoft SQL Server'
-            PsDscRunAsCredential            = $SysAdminAccount
+            ServerName              = 'SQLServer'
+            InstanceName            = 'DSC'
+            ProcessOnlyOnActiveNode = $true
+            Type                    = 'Data'
+            Path                    = 'C:\Program Files\Microsoft SQL Server'
+            PsDscRunAsCredential    = $SysAdminAccount
         }
 
         SqlDatabaseDefaultLocation Set_SqlDatabaseDefaultDirectory_Log
         {
-            SQLServer                       = 'SQLServer'
-            SQLInstanceName                 = 'DSC'
-            ProcessOnlyOnActiveNode         = $true
-            Type                            = 'Log'
-            Path                            = 'C:\Program Files\Microsoft SQL Server'
-            PsDscRunAsCredential            = $SysAdminAccount
+            ServerName              = 'SQLServer'
+            InstanceName            = 'DSC'
+            ProcessOnlyOnActiveNode = $true
+            Type                    = 'Log'
+            Path                    = 'C:\Program Files\Microsoft SQL Server'
+            PsDscRunAsCredential    = $SysAdminAccount
         }
 
         SqlDatabaseDefaultLocation Set_SqlDatabaseDefaultDirectory_Backup
         {
-            SQLServer                       = 'SQLServer'
-            SQLInstanceName                 = 'DSC'
-            ProcessOnlyOnActiveNode         = $true
-            Type                            = 'Backup'
-            Path                            = 'C:\Program Files\Microsoft SQL Server'
-            PsDscRunAsCredential            = $SysAdminAccount
+            ServerName              = 'SQLServer'
+            InstanceName            = 'DSC'
+            ProcessOnlyOnActiveNode = $true
+            Type                    = 'Backup'
+            Path                    = 'C:\Program Files\Microsoft SQL Server'
+            PsDscRunAsCredential    = $SysAdminAccount
         }
     }
 }

--- a/Examples/Resources/SqlDatabaseDefaultLocation/1-SetDatabaseDefaultLocation.ps1
+++ b/Examples/Resources/SqlDatabaseDefaultLocation/1-SetDatabaseDefaultLocation.ps1
@@ -22,7 +22,7 @@ Configuration Example
     {
         SqlDatabaseDefaultLocation Set_SqlDatabaseDefaultDirectory_Data
         {
-            ServerName              = 'SQLServer'
+            ServerName              = 'sqltest.company.local'
             InstanceName            = 'DSC'
             ProcessOnlyOnActiveNode = $true
             Type                    = 'Data'
@@ -32,7 +32,7 @@ Configuration Example
 
         SqlDatabaseDefaultLocation Set_SqlDatabaseDefaultDirectory_Log
         {
-            ServerName              = 'SQLServer'
+            ServerName              = 'sqltest.company.local'
             InstanceName            = 'DSC'
             ProcessOnlyOnActiveNode = $true
             Type                    = 'Log'
@@ -42,7 +42,7 @@ Configuration Example
 
         SqlDatabaseDefaultLocation Set_SqlDatabaseDefaultDirectory_Backup
         {
-            ServerName              = 'SQLServer'
+            ServerName              = 'sqltest.company.local'
             InstanceName            = 'DSC'
             ProcessOnlyOnActiveNode = $true
             Type                    = 'Backup'

--- a/Examples/Resources/SqlDatabaseOwner/1-SetDatabaseOwner.ps1
+++ b/Examples/Resources/SqlDatabaseOwner/1-SetDatabaseOwner.ps1
@@ -22,8 +22,8 @@ Configuration Example
             Ensure               = 'Present'
             Name                 = 'CONTOSO\SQLAdmin'
             LoginType            = 'WindowsUser'
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -31,8 +31,8 @@ Configuration Example
         {
             Name                 = 'CONTOSO\SQLAdmin'
             Database             = 'AdventureWorks'
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
     }

--- a/Examples/Resources/SqlDatabaseOwner/1-SetDatabaseOwner.ps1
+++ b/Examples/Resources/SqlDatabaseOwner/1-SetDatabaseOwner.ps1
@@ -31,7 +31,7 @@ Configuration Example
         {
             Name                 = 'CONTOSO\SQLAdmin'
             Database             = 'AdventureWorks'
-            ServerName           = 'SQLServer'
+            SQLServer            = 'SQLServer'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }

--- a/Examples/Resources/SqlDatabaseOwner/1-SetDatabaseOwner.ps1
+++ b/Examples/Resources/SqlDatabaseOwner/1-SetDatabaseOwner.ps1
@@ -31,7 +31,7 @@ Configuration Example
         {
             Name                 = 'CONTOSO\SQLAdmin'
             Database             = 'AdventureWorks'
-            SQLServer            = 'SQLServer'
+            ServerName           = 'SQLServer'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }

--- a/Examples/Resources/SqlDatabaseOwner/1-SetDatabaseOwner.ps1
+++ b/Examples/Resources/SqlDatabaseOwner/1-SetDatabaseOwner.ps1
@@ -22,7 +22,7 @@ Configuration Example
             Ensure               = 'Present'
             Name                 = 'CONTOSO\SQLAdmin'
             LoginType            = 'WindowsUser'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
@@ -31,7 +31,7 @@ Configuration Example
         {
             Name                 = 'CONTOSO\SQLAdmin'
             Database             = 'AdventureWorks'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }

--- a/Examples/Resources/SqlDatabasePermission/1-GrantDatabasePermissions.ps1
+++ b/Examples/Resources/SqlDatabasePermission/1-GrantDatabasePermissions.ps1
@@ -42,8 +42,8 @@ Configuration Example
             Database             = 'AdventureWorks'
             PermissionState      = 'Grant'
             Permissions          = 'Connect', 'Update'
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -54,8 +54,8 @@ Configuration Example
             Database             = 'AdventureWorks'
             PermissionState      = 'Grant'
             Permissions          = 'Connect', 'Update'
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -66,8 +66,8 @@ Configuration Example
             Database             = 'AdventureWorksLT'
             PermissionState      = 'Grant'
             Permissions          = 'Connect', 'Update'
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
     }

--- a/Examples/Resources/SqlDatabasePermission/1-GrantDatabasePermissions.ps1
+++ b/Examples/Resources/SqlDatabasePermission/1-GrantDatabasePermissions.ps1
@@ -20,8 +20,8 @@ Configuration Example
             Ensure               = 'Present'
             Name                 = 'CONTOSO\SQLAdmin'
             LoginType            = 'WindowsUser'
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -30,8 +30,8 @@ Configuration Example
             Ensure               = 'Present'
             Name                 = 'CONTOSO\SQLUser'
             LoginType            = 'WindowsUser'
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
 

--- a/Examples/Resources/SqlDatabasePermission/1-GrantDatabasePermissions.ps1
+++ b/Examples/Resources/SqlDatabasePermission/1-GrantDatabasePermissions.ps1
@@ -20,7 +20,7 @@ Configuration Example
             Ensure               = 'Present'
             Name                 = 'CONTOSO\SQLAdmin'
             LoginType            = 'WindowsUser'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
@@ -30,7 +30,7 @@ Configuration Example
             Ensure               = 'Present'
             Name                 = 'CONTOSO\SQLUser'
             LoginType            = 'WindowsUser'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
@@ -42,7 +42,7 @@ Configuration Example
             Database             = 'AdventureWorks'
             PermissionState      = 'Grant'
             Permissions          = 'Connect', 'Update'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
@@ -54,7 +54,7 @@ Configuration Example
             Database             = 'AdventureWorks'
             PermissionState      = 'Grant'
             Permissions          = 'Connect', 'Update'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
@@ -66,7 +66,7 @@ Configuration Example
             Database             = 'AdventureWorksLT'
             PermissionState      = 'Grant'
             Permissions          = 'Connect', 'Update'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }

--- a/Examples/Resources/SqlDatabasePermission/2-RevokeDatabasePermissions.ps1
+++ b/Examples/Resources/SqlDatabasePermission/2-RevokeDatabasePermissions.ps1
@@ -22,7 +22,7 @@ Configuration Example
             Database             = 'AdventureWorks'
             PermissionState      = 'Grant'
             Permissions          = 'Connect', 'Update'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
@@ -34,7 +34,7 @@ Configuration Example
             Database             = 'AdventureWorks'
             PermissionState      = 'Deny'
             Permissions          = 'Select', 'Create Table'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }

--- a/Examples/Resources/SqlDatabasePermission/2-RevokeDatabasePermissions.ps1
+++ b/Examples/Resources/SqlDatabasePermission/2-RevokeDatabasePermissions.ps1
@@ -22,8 +22,8 @@ Configuration Example
             Database             = 'AdventureWorks'
             PermissionState      = 'Grant'
             Permissions          = 'Connect', 'Update'
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -34,8 +34,8 @@ Configuration Example
             Database             = 'AdventureWorks'
             PermissionState      = 'Deny'
             Permissions          = 'Select', 'Create Table'
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
     }

--- a/Examples/Resources/SqlDatabasePermission/3-DenyDatabasePermissions.ps1
+++ b/Examples/Resources/SqlDatabasePermission/3-DenyDatabasePermissions.ps1
@@ -20,7 +20,7 @@ Configuration Example
             Ensure               = 'Present'
             Name                 = 'CONTOSO\SQLAdmin'
             LoginType            = 'WindowsUser'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
@@ -30,7 +30,7 @@ Configuration Example
             Ensure               = 'Present'
             Name                 = 'CONTOSO\SQLUser'
             LoginType            = 'WindowsUser'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
@@ -42,7 +42,7 @@ Configuration Example
             Database             = 'AdventureWorks'
             PermissionState      = 'Deny'
             Permissions          = 'Select', 'Create Table'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
@@ -54,7 +54,7 @@ Configuration Example
             Database             = 'AdventureWorks'
             PermissionState      = 'Deny'
             Permissions          = 'Select', 'Create Table'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
@@ -66,7 +66,7 @@ Configuration Example
             Database             = 'AdventureWorksLT'
             PermissionState      = 'Deny'
             Permissions          = 'Select', 'Create Table'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }

--- a/Examples/Resources/SqlDatabasePermission/3-DenyDatabasePermissions.ps1
+++ b/Examples/Resources/SqlDatabasePermission/3-DenyDatabasePermissions.ps1
@@ -42,8 +42,8 @@ Configuration Example
             Database             = 'AdventureWorks'
             PermissionState      = 'Deny'
             Permissions          = 'Select', 'Create Table'
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -54,8 +54,8 @@ Configuration Example
             Database             = 'AdventureWorks'
             PermissionState      = 'Deny'
             Permissions          = 'Select', 'Create Table'
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -66,8 +66,8 @@ Configuration Example
             Database             = 'AdventureWorksLT'
             PermissionState      = 'Deny'
             Permissions          = 'Select', 'Create Table'
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
     }

--- a/Examples/Resources/SqlDatabasePermission/3-DenyDatabasePermissions.ps1
+++ b/Examples/Resources/SqlDatabasePermission/3-DenyDatabasePermissions.ps1
@@ -20,8 +20,8 @@ Configuration Example
             Ensure               = 'Present'
             Name                 = 'CONTOSO\SQLAdmin'
             LoginType            = 'WindowsUser'
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -30,8 +30,8 @@ Configuration Example
             Ensure               = 'Present'
             Name                 = 'CONTOSO\SQLUser'
             LoginType            = 'WindowsUser'
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
 

--- a/Examples/Resources/SqlDatabaseRecoveryModel/1-SetDatabaseRecoveryModel.ps1
+++ b/Examples/Resources/SqlDatabaseRecoveryModel/1-SetDatabaseRecoveryModel.ps1
@@ -22,7 +22,7 @@ Configuration Example
         {
             Ensure               = 'Present'
             Name                 = 'Adventureworks'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
@@ -31,7 +31,7 @@ Configuration Example
         {
             Ensure               = 'Present'
             Name                 = 'AdventureWorks2012'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
@@ -40,7 +40,7 @@ Configuration Example
         {
             Name                 = 'Adventureworks'
             RecoveryModel        = 'Full'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
@@ -49,7 +49,7 @@ Configuration Example
         {
             Name                 = 'AdventureWorks2012'
             RecoveryModel        = 'Simple'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }

--- a/Examples/Resources/SqlDatabaseRecoveryModel/1-SetDatabaseRecoveryModel.ps1
+++ b/Examples/Resources/SqlDatabaseRecoveryModel/1-SetDatabaseRecoveryModel.ps1
@@ -22,8 +22,8 @@ Configuration Example
         {
             Ensure               = 'Present'
             Name                 = 'Adventureworks'
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -31,8 +31,8 @@ Configuration Example
         {
             Ensure               = 'Present'
             Name                 = 'AdventureWorks2012'
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -40,8 +40,8 @@ Configuration Example
         {
             Name                 = 'Adventureworks'
             RecoveryModel        = 'Full'
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -49,8 +49,8 @@ Configuration Example
         {
             Name                 = 'AdventureWorks2012'
             RecoveryModel        = 'Simple'
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
     }

--- a/Examples/Resources/SqlDatabaseRole/1-AddDatabaseRole.ps1
+++ b/Examples/Resources/SqlDatabaseRole/1-AddDatabaseRole.ps1
@@ -20,8 +20,8 @@ Configuration Example
         SqlDatabaseRole Add_Database_Role
         {
             Ensure               = 'Present'
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             Name                 = 'CONTOSO\SQLAdmin'
             Role                 = 'MyRole', 'MySecondRole'
             Database             = 'AdventureWorks'

--- a/Examples/Resources/SqlDatabaseRole/1-AddDatabaseRole.ps1
+++ b/Examples/Resources/SqlDatabaseRole/1-AddDatabaseRole.ps1
@@ -20,7 +20,7 @@ Configuration Example
         SqlDatabaseRole Add_Database_Role
         {
             Ensure               = 'Present'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             Name                 = 'CONTOSO\SQLAdmin'
             Role                 = 'MyRole', 'MySecondRole'

--- a/Examples/Resources/SqlDatabaseRole/2-RemoveDatabaseRole.ps1
+++ b/Examples/Resources/SqlDatabaseRole/2-RemoveDatabaseRole.ps1
@@ -20,7 +20,7 @@ Configuration Example
         SqlDatabaseRole Remove_Database_Role
         {
             Ensure               = 'Absent'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             Name                 = 'CONTOSO\SQLAdmin'
             Role                 = 'DeleteRole'

--- a/Examples/Resources/SqlDatabaseRole/2-RemoveDatabaseRole.ps1
+++ b/Examples/Resources/SqlDatabaseRole/2-RemoveDatabaseRole.ps1
@@ -20,8 +20,8 @@ Configuration Example
         SqlDatabaseRole Remove_Database_Role
         {
             Ensure               = 'Absent'
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             Name                 = 'CONTOSO\SQLAdmin'
             Role                 = 'DeleteRole'
             Database             = 'AdventureWorks'

--- a/Examples/Resources/SqlServerConfiguration/1-ConfigureTwoInstancesOnTheSameServerToEnableClr.ps1
+++ b/Examples/Resources/SqlServerConfiguration/1-ConfigureTwoInstancesOnTheSameServerToEnableClr.ps1
@@ -25,10 +25,10 @@ Configuration Example
         {
             SqlServerConfiguration ('SQLConfigCLR_{0}' -f $SQLInstance)
             {
-                SQLServer       = $node.NodeName
-                SQLInstanceName = $SQLInstance
-                OptionName      = $node.OptionName
-                OptionValue     = 1
+                Servername   = $node.NodeName
+                InstanceName = $SQLInstance
+                OptionName   = $node.OptionName
+                OptionValue  = 1
             }
         }
     }

--- a/Examples/Resources/SqlServerConfiguration/2-ConfigureInstanceToEnablePriorityBoost.ps1
+++ b/Examples/Resources/SqlServerConfiguration/2-ConfigureInstanceToEnablePriorityBoost.ps1
@@ -14,11 +14,11 @@ Configuration Example
         SqlServerConfiguration 'SQLConfigPriorityBoost'
         {
 
-            SQLServer       = 'localhost'
-            SQLInstanceName = 'MSSQLSERVER'
-            OptionName      = 'priority boost'
-            OptionValue     = 1
-            RestartService  = $false
+            ServerName     = 'localhost'
+            InstanceName   = 'MSSQLSERVER'
+            OptionName     = 'priority boost'
+            OptionValue    = 1
+            RestartService = $false
         }
     }
 }

--- a/Examples/Resources/SqlServerEndpoint/1-CreateEndpointWithDefaultValues.ps1
+++ b/Examples/Resources/SqlServerEndpoint/1-CreateEndpointWithDefaultValues.ps1
@@ -20,7 +20,7 @@ Configuration Example
         SqlServerEndpoint SQLConfigureEndpoint-Instance1
         {
             EndpointName         = 'HADR'
-            SQLInstanceName      = 'INST1'
+            InstanceName         = 'INST1'
 
             PsDscRunAsCredential = $SysAdminAccount
         }
@@ -28,7 +28,7 @@ Configuration Example
         SqlServerEndpoint SQLConfigureEndpoint-Instances2
         {
             EndpointName         = 'HADR'
-            SQLInstanceName      = 'INST2'
+            InstanceName         = 'INST2'
 
             PsDscRunAsCredential = $SysAdminAccount
         }

--- a/Examples/Resources/SqlServerEndpoint/2-CreateEndpointWithSpecificPortAndIPAddress.ps1
+++ b/Examples/Resources/SqlServerEndpoint/2-CreateEndpointWithSpecificPortAndIPAddress.ps1
@@ -24,8 +24,8 @@ Configuration Example
             Port                 = 9001
             IpAddress            = '192.168.0.20'
 
-            SQLServer            = 'server1.company.local'
-            SQLInstanceName      = 'INST1'
+            ServerName           = 'server1.company.local'
+            InstanceName         = 'INST1'
 
             PsDscRunAsCredential = $SysAdminAccount
         }

--- a/Examples/Resources/SqlServerEndpoint/3-RemoveEndpoint.ps1
+++ b/Examples/Resources/SqlServerEndpoint/3-RemoveEndpoint.ps1
@@ -22,7 +22,7 @@ Configuration Example
             Ensure               = 'Absent'
 
             EndpointName         = 'HADR'
-            SQLInstanceName      = 'INST1'
+            InstanceName      = 'INST1'
 
             PsDscRunAsCredential = $SysAdminAccount
         }
@@ -32,7 +32,7 @@ Configuration Example
             Ensure               = 'Absent'
 
             EndpointName         = 'HADR'
-            SQLInstanceName      = 'INST2'
+            InstanceName      = 'INST2'
 
             PsDscRunAsCredential = $SysAdminAccount
         }

--- a/Examples/Resources/SqlServerEndpointPermission/1-AddConnectPermission.ps1
+++ b/Examples/Resources/SqlServerEndpointPermission/1-AddConnectPermission.ps1
@@ -25,7 +25,7 @@ Configuration Example
         SqlServerEndpointPermission SQLConfigureEndpointPermission
         {
             Ensure               = 'Present'
-            NodeName             = $Node.NodeName
+            ServerName           = $Node.NodeName
             InstanceName         = $Node.SqlInstanceName
             Name                 = 'DefaultMirrorEndpoint'
             Principal            = $SqlServiceCredential.UserName

--- a/Examples/Resources/SqlServerEndpointPermission/2-RemoveConnectPermission.ps1
+++ b/Examples/Resources/SqlServerEndpointPermission/2-RemoveConnectPermission.ps1
@@ -25,7 +25,7 @@ Configuration Example
         SqlServerEndpointPermission SQLConfigureEndpointPermission
         {
             Ensure               = 'Absent'
-            NodeName             = $Node.NodeName
+            ServerName           = $Node.NodeName
             InstanceName         = $Node.SqlInstanceName
             Name                 = 'DefaultMirrorEndpoint'
             Principal            = $SqlServiceCredential.UserName

--- a/Examples/Resources/SqlServerEndpointPermission/3-AddConnectPermissionToAlwaysOnPrimaryAndSecondaryReplicaEachWithDifferentSqlServiceAccounts.ps1
+++ b/Examples/Resources/SqlServerEndpointPermission/3-AddConnectPermissionToAlwaysOnPrimaryAndSecondaryReplicaEachWithDifferentSqlServiceAccounts.ps1
@@ -50,7 +50,7 @@ Configuration Example
         SqlServerEndpointPermission SQLConfigureEndpointPermissionPrimary
         {
             Ensure               = 'Present'
-            NodeName             = $Node.NodeName
+            ServerName           = $Node.NodeName
             InstanceName         = $Node.SqlInstanceName
             Name                 = 'DefaultMirrorEndpoint'
             Principal            = $SqlServiceNode1Credential.UserName
@@ -62,7 +62,7 @@ Configuration Example
         SqlServerEndpointPermission SQLConfigureEndpointPermissionSecondary
         {
             Ensure               = 'Present'
-            NodeName             = $Node.NodeName
+            ServerName           = $Node.NodeName
             InstanceName         = $Node.SqlInstanceName
             Name                 = 'DefaultMirrorEndpoint'
             Principal            = $SqlServiceNode2Credential.UserName
@@ -77,7 +77,7 @@ Configuration Example
         SqlServerEndpointPermission SQLConfigureEndpointPermissionPrimary
         {
             Ensure               = 'Present'
-            NodeName             = $Node.NodeName
+            ServerName           = $Node.NodeName
             InstanceName         = $Node.SqlInstanceName
             Name                 = 'DefaultMirrorEndpoint'
             Principal            = $SqlServiceNode1Credential.UserName
@@ -89,7 +89,7 @@ Configuration Example
         SqlServerEndpointPermission SQLConfigureEndpointPermissionSecondary
         {
             Ensure               = 'Present'
-            NodeName             = $Node.NodeName
+            ServerName           = $Node.NodeName
             InstanceName         = $Node.SqlInstanceName
             Name                 = 'DefaultMirrorEndpoint'
             Principal            = $SqlServiceNode2Credential.UserName

--- a/Examples/Resources/SqlServerEndpointPermission/4-RemoveConnectPermissionToAlwaysOnPrimaryAndSecondaryReplicaEachWithDifferentSqlServiceAccounts.ps1
+++ b/Examples/Resources/SqlServerEndpointPermission/4-RemoveConnectPermissionToAlwaysOnPrimaryAndSecondaryReplicaEachWithDifferentSqlServiceAccounts.ps1
@@ -50,7 +50,7 @@ Configuration Example
         SqlServerEndpointPermission RemoveSQLConfigureEndpointPermissionPrimary
         {
             Ensure               = 'Absent'
-            NodeName             = $Node.NodeName
+            ServerName           = $Node.NodeName
             InstanceName         = $Node.SqlInstanceName
             Name                 = 'DefaultMirrorEndpoint'
             Principal            = $SqlServiceCredentialNode2.UserName
@@ -64,7 +64,7 @@ Configuration Example
         SqlServerEndpointPermission RemoveSQLConfigureEndpointPermissionSecondary
         {
             Ensure               = 'Absent'
-            NodeName             = $Node.NodeName
+            ServerName           = $Node.NodeName
             InstanceName         = $Node.SqlInstanceName
             Name                 = 'DefaultMirrorEndpoint'
             Principal            = $SqlServiceCredentialNode2.UserName
@@ -81,7 +81,7 @@ Configuration Example
         SqlServerEndpointPermission RemoveSQLConfigureEndpointPermissionPrimary
         {
             Ensure               = 'Absent'
-            NodeName             = $Node.NodeName
+            ServerName           = $Node.NodeName
             InstanceName         = $Node.SqlInstanceName
             Name                 = 'DefaultMirrorEndpoint'
             Principal            = $SqlServiceCredentialNode2.UserName
@@ -95,7 +95,7 @@ Configuration Example
         SqlServerEndpointPermission RemoveSQLConfigureEndpointPermissionSecondary
         {
             Ensure               = 'Absent'
-            NodeName             = $Node.NodeName
+            ServerName           = $Node.NodeName
             InstanceName         = $Node.SqlInstanceName
             Name                 = 'DefaultMirrorEndpoint'
             Principal            = $SqlServiceCredentialNode2.UserName

--- a/Examples/Resources/SqlServerEndpointState/1-MakeSureEndpointIsStarted.ps1
+++ b/Examples/Resources/SqlServerEndpointState/1-MakeSureEndpointIsStarted.ps1
@@ -28,7 +28,7 @@ Configuration Example
         # Start the DefaultMirrorEndpoint in the default instance
         SqlServerEndpointState StartEndpoint1
         {
-            NodeName             = 'SQLNODE01.company.local'
+            ServerName           = 'SQLNODE01.company.local'
             InstanceName         = 'MSSQLSERVER'
             Name                 = 'DefaultMirrorEndpoint'
             State                = 'Started'
@@ -39,7 +39,7 @@ Configuration Example
         # Start the HADR in the default instance
         SqlServerEndpointState StartEndpoint2
         {
-            NodeName             = 'SQLNODE01.company.local'
+            ServerName           = 'SQLNODE01.company.local'
             InstanceName         = 'MSSQLSERVER'
             Name                 = 'HADR'
             State                = 'Started'
@@ -50,7 +50,7 @@ Configuration Example
         # Start the DefaultMirrorEndpoint in the named instance INSTANCE1
         SqlServerEndpointState StartEndpoint3
         {
-            NodeName             = 'SQLNODE01.company.local'
+            ServerName           = 'SQLNODE01.company.local'
             InstanceName         = 'INSTANCE1'
             Name                 = 'DefaultMirrorEndpoint'
             State                = 'Started'

--- a/Examples/Resources/SqlServerEndpointState/2-MakeSureEndpointIsStopped.ps1
+++ b/Examples/Resources/SqlServerEndpointState/2-MakeSureEndpointIsStopped.ps1
@@ -18,7 +18,7 @@ Configuration Example
     {
         SqlServerEndpointState StopEndpoint
         {
-            NodeName             = 'SQLNODE01.company.local'
+            ServerName           = 'SQLNODE01.company.local'
             InstanceName         = 'MSSQLSERVER'
             Name                 = 'DefaultMirrorEndpoint'
             State                = 'Stopped'

--- a/Examples/Resources/SqlServerLogin/1-AddLogin.ps1
+++ b/Examples/Resources/SqlServerLogin/1-AddLogin.ps1
@@ -29,8 +29,8 @@ Configuration Example
             Ensure               = 'Present'
             Name                 = 'CONTOSO\WindowsUser'
             LoginType            = 'WindowsUser'
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'TestServer.company.local'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -39,8 +39,8 @@ Configuration Example
             Ensure               = 'Present'
             Name                 = 'CONTOSO\WindowsUser2'
             LoginType            = 'WindowsUser'
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'TestServer.company.local'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
             Disabled             = $true
         }
@@ -50,8 +50,8 @@ Configuration Example
             Ensure               = 'Present'
             Name                 = 'CONTOSO\WindowsGroup'
             LoginType            = 'WindowsGroup'
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'TestServer.company.local'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -60,8 +60,8 @@ Configuration Example
             Ensure                         = 'Present'
             Name                           = 'SqlLogin'
             LoginType                      = 'SqlLogin'
-            SQLServer                      = 'SQLServer'
-            SQLInstanceName                = 'DSC'
+            ServerName                     = 'TestServer.company.local'
+            InstanceName                   = 'DSC'
             LoginCredential                = $LoginCredential
             LoginMustChangePassword        = $false
             LoginPasswordExpirationEnabled = $true

--- a/Examples/Resources/SqlServerLogin/2-RemoveLogin.ps1
+++ b/Examples/Resources/SqlServerLogin/2-RemoveLogin.ps1
@@ -16,29 +16,29 @@ Configuration Example
     node localhost {
         SqlServerLogin Remove_WindowsUser
         {
-            Ensure          = 'Absent'
-            Name            = 'CONTOSO\WindowsUser'
-            LoginType       = 'WindowsUser'
-            SQLServer       = 'SQLServer'
-            SQLInstanceName = 'DSC'
+            Ensure       = 'Absent'
+            Name         = 'CONTOSO\WindowsUser'
+            LoginType    = 'WindowsUser'
+            ServerName   = 'TestServer.company.local'
+            InstanceName = 'DSC'
         }
 
         SqlServerLogin Remove_WindowsGroup
         {
-            Ensure          = 'Absent'
-            Name            = 'CONTOSO\WindowsGroup'
-            LoginType       = 'WindowsGroup'
-            SQLServer       = 'SQLServer'
-            SQLInstanceName = 'DSC'
+            Ensure       = 'Absent'
+            Name         = 'CONTOSO\WindowsGroup'
+            LoginType    = 'WindowsGroup'
+            ServerName   = 'TestServer.company.local'
+            InstanceName = 'DSC'
         }
 
         SqlServerLogin Remove_SqlLogin
         {
-            Ensure          = 'Absent'
-            Name            = 'SqlLogin'
-            LoginType       = 'SqlLogin'
-            SQLServer       = 'SQLServer'
-            SQLInstanceName = 'DSC'
+            Ensure       = 'Absent'
+            Name         = 'SqlLogin'
+            LoginType    = 'SqlLogin'
+            ServerName   = 'TestServer.company.local'
+            InstanceName = 'DSC'
         }
     }
 }

--- a/Examples/Resources/SqlServerMaxDop/1-SetMaxDopToOne.ps1
+++ b/Examples/Resources/SqlServerMaxDop/1-SetMaxDopToOne.ps1
@@ -22,7 +22,7 @@ Configuration Example
             Ensure               = 'Present'
             DynamicAlloc         = $false
             MaxDop               = 1
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }

--- a/Examples/Resources/SqlServerMaxDop/1-SetMaxDopToOne.ps1
+++ b/Examples/Resources/SqlServerMaxDop/1-SetMaxDopToOne.ps1
@@ -22,8 +22,8 @@ Configuration Example
             Ensure               = 'Present'
             DynamicAlloc         = $false
             MaxDop               = 1
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
     }

--- a/Examples/Resources/SqlServerMaxDop/2-SetMaxDopToAuto.ps1
+++ b/Examples/Resources/SqlServerMaxDop/2-SetMaxDopToAuto.ps1
@@ -26,7 +26,7 @@ Configuration Example
         {
             Ensure                  = 'Present'
             DynamicAlloc            = $true
-            ServerName              = 'SQLServer'
+            ServerName              = 'sqltest.company.local'
             InstanceName            = 'DSC'
             PsDscRunAsCredential    = $SysAdminAccount
             ProcessOnlyOnActiveNode = $true

--- a/Examples/Resources/SqlServerMaxDop/2-SetMaxDopToAuto.ps1
+++ b/Examples/Resources/SqlServerMaxDop/2-SetMaxDopToAuto.ps1
@@ -26,8 +26,8 @@ Configuration Example
         {
             Ensure                  = 'Present'
             DynamicAlloc            = $true
-            SQLServer               = 'SQLServer'
-            SQLInstanceName         = 'DSC'
+            ServerName              = 'SQLServer'
+            InstanceName            = 'DSC'
             PsDscRunAsCredential    = $SysAdminAccount
             ProcessOnlyOnActiveNode = $true
         }

--- a/Examples/Resources/SqlServerMaxDop/3-SetMaxDopToDefault.ps1
+++ b/Examples/Resources/SqlServerMaxDop/3-SetMaxDopToDefault.ps1
@@ -20,7 +20,7 @@ Configuration Example
         SqlServerMaxDop Set_SQLServerMaxDop_ToDefault
         {
             Ensure               = 'Absent'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }

--- a/Examples/Resources/SqlServerMaxDop/3-SetMaxDopToDefault.ps1
+++ b/Examples/Resources/SqlServerMaxDop/3-SetMaxDopToDefault.ps1
@@ -20,8 +20,8 @@ Configuration Example
         SqlServerMaxDop Set_SQLServerMaxDop_ToDefault
         {
             Ensure               = 'Absent'
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
     }

--- a/Examples/Resources/SqlServerMemory/1-SetMaxMemoryTo12GB.ps1
+++ b/Examples/Resources/SqlServerMemory/1-SetMaxMemoryTo12GB.ps1
@@ -23,7 +23,7 @@ Configuration Example
             DynamicAlloc         = $false
             MinMemory            = 1024
             MaxMemory            = 12288
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }

--- a/Examples/Resources/SqlServerMemory/1-SetMaxMemoryTo12GB.ps1
+++ b/Examples/Resources/SqlServerMemory/1-SetMaxMemoryTo12GB.ps1
@@ -23,8 +23,8 @@ Configuration Example
             DynamicAlloc         = $false
             MinMemory            = 1024
             MaxMemory            = 12288
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
     }

--- a/Examples/Resources/SqlServerMemory/2-SetMaxMemoryToAuto.ps1
+++ b/Examples/Resources/SqlServerMemory/2-SetMaxMemoryToAuto.ps1
@@ -26,7 +26,7 @@ Configuration Example
         {
             Ensure                  = 'Present'
             DynamicAlloc            = $true
-            ServerName              = 'SQLServer'
+            ServerName              = 'sqltest.company.local'
             InstanceName            = 'DSC'
             PsDscRunAsCredential    = $SysAdminAccount
             ProcessOnlyOnActiveNode = $true

--- a/Examples/Resources/SqlServerMemory/2-SetMaxMemoryToAuto.ps1
+++ b/Examples/Resources/SqlServerMemory/2-SetMaxMemoryToAuto.ps1
@@ -26,8 +26,8 @@ Configuration Example
         {
             Ensure                  = 'Present'
             DynamicAlloc            = $true
-            SQLServer               = 'SQLServer'
-            SQLInstanceName         = 'DSC'
+            ServerName              = 'SQLServer'
+            InstanceName            = 'DSC'
             PsDscRunAsCredential    = $SysAdminAccount
             ProcessOnlyOnActiveNode = $true
         }

--- a/Examples/Resources/SqlServerMemory/3-SetMinMemoryToFixedValueAndMaxMemoryToAuto.ps1
+++ b/Examples/Resources/SqlServerMemory/3-SetMinMemoryToFixedValueAndMaxMemoryToAuto.ps1
@@ -21,8 +21,8 @@ Configuration Example
         {
             Ensure               = 'Present'
             DynamicAlloc         = $true
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             MinMemory            = 2048
             PsDscRunAsCredential = $SysAdminAccount
         }

--- a/Examples/Resources/SqlServerMemory/3-SetMinMemoryToFixedValueAndMaxMemoryToAuto.ps1
+++ b/Examples/Resources/SqlServerMemory/3-SetMinMemoryToFixedValueAndMaxMemoryToAuto.ps1
@@ -21,7 +21,7 @@ Configuration Example
         {
             Ensure               = 'Present'
             DynamicAlloc         = $true
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             MinMemory            = 2048
             PsDscRunAsCredential = $SysAdminAccount

--- a/Examples/Resources/SqlServerMemory/4-SetMaxMemoryToDefault.ps1
+++ b/Examples/Resources/SqlServerMemory/4-SetMaxMemoryToDefault.ps1
@@ -20,7 +20,7 @@ Configuration Example
         SqlServerMemory Set_SQLServerMaxMemory_ToDefault
         {
             Ensure               = 'Absent'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }

--- a/Examples/Resources/SqlServerMemory/4-SetMaxMemoryToDefault.ps1
+++ b/Examples/Resources/SqlServerMemory/4-SetMaxMemoryToDefault.ps1
@@ -20,8 +20,8 @@ Configuration Example
         SqlServerMemory Set_SQLServerMaxMemory_ToDefault
         {
             Ensure               = 'Absent'
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
     }

--- a/Examples/Resources/SqlServerPermission/1-AddServerPermissionForLogin.ps1
+++ b/Examples/Resources/SqlServerPermission/1-AddServerPermissionForLogin.ps1
@@ -21,7 +21,7 @@ Configuration Example
         SqlServerPermission 'SQLConfigureServerPermission-SYSTEM'
         {
             Ensure               = 'Present'
-            NodeName             = 'SQLNODE01.company.local'
+            ServerName           = 'SQLNODE01.company.local'
             InstanceName         = 'MSSQLSERVER'
             Principal            = 'NT AUTHORITY\SYSTEM'
             Permission           = 'AlterAnyAvailabilityGroup', 'ViewServerState'
@@ -32,7 +32,7 @@ Configuration Example
         SqlServerPermission 'SQLConfigureServerPermission-ClusSvc'
         {
             Ensure               = 'Present'
-            NodeName             = 'SQLNODE01.company.local'
+            ServerName           = 'SQLNODE01.company.local'
             InstanceName         = 'MSSQLSERVER'
             Principal            = 'NT SERVICE\ClusSvc'
             Permission           = 'AlterAnyAvailabilityGroup', 'ViewServerState'

--- a/Examples/Resources/SqlServerPermission/2-RemoveServerPermissionForLogin.ps1
+++ b/Examples/Resources/SqlServerPermission/2-RemoveServerPermissionForLogin.ps1
@@ -21,7 +21,7 @@ Configuration Example
         SqlServerPermission SQLConfigureServerPermission
         {
             Ensure               = 'Absent'
-            NodeName             = 'SQLNODE01.company.local'
+            ServerName           = 'SQLNODE01.company.local'
             InstanceName         = 'MSSQLSERVER'
             Principal            = 'NT AUTHORITY\SYSTEM'
             Permission           = 'AlterAnyAvailabilityGroup', 'ViewServerState'

--- a/Examples/Resources/SqlServerRole/1-AddServerRole.ps1
+++ b/Examples/Resources/SqlServerRole/1-AddServerRole.ps1
@@ -1,7 +1,7 @@
 <#
 .EXAMPLE
     This example shows how to ensure that the server role named
-    AdminSqlforBI is present on instance SQLServer\DSC.
+    AdminSqlforBI is present on instance sqltest.company.local\DSC.
 #>
 
 Configuration Example
@@ -19,7 +19,7 @@ Configuration Example
         {
             Ensure               = 'Present'
             ServerRoleName       = 'AdminSqlforBI'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }

--- a/Examples/Resources/SqlServerRole/1-AddServerRole.ps1
+++ b/Examples/Resources/SqlServerRole/1-AddServerRole.ps1
@@ -18,9 +18,9 @@ Configuration Example
         SqlServerRole Add_ServerRole_AdminSqlforBI
         {
             Ensure               = 'Present'
-            ServerRoleName       = "AdminSqlforBI"
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerRoleName       = 'AdminSqlforBI'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
     }

--- a/Examples/Resources/SqlServerRole/2-RemoveServerRole.ps1
+++ b/Examples/Resources/SqlServerRole/2-RemoveServerRole.ps1
@@ -18,9 +18,9 @@ Configuration Example
         SqlServerRole Remove_ServerRole
         {
             Ensure               = 'Absent'
-            ServerRoleName       = "serverRoleToDelete"
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            ServerRoleName       = 'serverRoleToDelete'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
     }

--- a/Examples/Resources/SqlServerRole/2-RemoveServerRole.ps1
+++ b/Examples/Resources/SqlServerRole/2-RemoveServerRole.ps1
@@ -1,7 +1,7 @@
 <#
 .EXAMPLE
     This example shows how to ensure that the server role named
-    serverRoleToDelete is not present on instance SQLServer\DSC.
+    serverRoleToDelete is not present on instance sqltest.company.local\DSC.
 #>
 
 Configuration Example
@@ -19,7 +19,7 @@ Configuration Example
         {
             Ensure               = 'Absent'
             ServerRoleName       = 'serverRoleToDelete'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }

--- a/Examples/Resources/SqlServerRole/3-AddMembersToServerRole.ps1
+++ b/Examples/Resources/SqlServerRole/3-AddMembersToServerRole.ps1
@@ -1,7 +1,7 @@
 <#
 .EXAMPLE
     This example shows how to ensure that the server role named
-    AdminSqlforBI is present on instance SQLServer\DSC and only logins
+    AdminSqlforBI is present on instance sqltest.company.local\DSC and only logins
     CONTOSO\SQLAdmin and CONTOSO\SQLAdminBI are members of this role.
 #>
 
@@ -21,7 +21,7 @@ Configuration Example
             Ensure               = 'Present'
             ServerRoleName       = 'AdminSqlforBI'
             Members              = 'CONTOSO\SQLAdmin', 'CONTOSO\SQLAdminBI'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }

--- a/Examples/Resources/SqlServerRole/3-AddMembersToServerRole.ps1
+++ b/Examples/Resources/SqlServerRole/3-AddMembersToServerRole.ps1
@@ -20,9 +20,9 @@ Configuration Example
         {
             Ensure               = 'Present'
             ServerRoleName       = 'AdminSqlforBI'
-            Members              = "CONTOSO\SQLAdmin", "CONTOSO\SQLAdminBI"
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            Members              = 'CONTOSO\SQLAdmin', 'CONTOSO\SQLAdminBI'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
     }

--- a/Examples/Resources/SqlServerRole/4-MembersToIncludeInServerRole.ps1
+++ b/Examples/Resources/SqlServerRole/4-MembersToIncludeInServerRole.ps1
@@ -20,9 +20,9 @@ Configuration Example
         {
             Ensure               = 'Present'
             ServerRoleName       = 'AdminSqlforBI'
-            MembersToInclude     = "CONTOSO\John", "CONTOSO\Kelly"
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            MembersToInclude     = 'CONTOSO\John', 'CONTOSO\Kelly'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
     }

--- a/Examples/Resources/SqlServerRole/4-MembersToIncludeInServerRole.ps1
+++ b/Examples/Resources/SqlServerRole/4-MembersToIncludeInServerRole.ps1
@@ -1,7 +1,7 @@
 <#
 .EXAMPLE
     This example shows how to ensure that the server role named
-    AdminSqlforBI is present on instance SQLServer\DSC and logins
+    AdminSqlforBI is present on instance sqltest.company.local\DSC and logins
     CONTOSO\John and CONTOSO\Kelly are added as members of this role.
 #>
 
@@ -21,7 +21,7 @@ Configuration Example
             Ensure               = 'Present'
             ServerRoleName       = 'AdminSqlforBI'
             MembersToInclude     = 'CONTOSO\John', 'CONTOSO\Kelly'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }

--- a/Examples/Resources/SqlServerRole/5-MembersToExcludeInServerRole.ps1
+++ b/Examples/Resources/SqlServerRole/5-MembersToExcludeInServerRole.ps1
@@ -20,9 +20,9 @@ Configuration Example
         {
             Ensure               = 'Present'
             ServerRoleName       = 'AdminSqlforBI'
-            MembersToExclude     = "CONTOSO\Mark", "CONTOSO\Lucy"
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
+            MembersToExclude     = 'CONTOSO\Mark', 'CONTOSO\Lucy'
+            ServerName           = 'SQLServer'
+            InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }
     }

--- a/Examples/Resources/SqlServerRole/5-MembersToExcludeInServerRole.ps1
+++ b/Examples/Resources/SqlServerRole/5-MembersToExcludeInServerRole.ps1
@@ -1,7 +1,7 @@
 <#
 .EXAMPLE
     This example shows how to ensure that the server role named
-    AdminSqlforBI is present on instance SQLServer\DSC and logins
+    AdminSqlforBI is present on instance sqltest.company.local\DSC and logins
     CONTOSO\Mark and CONTOSO\Lucy are not members of this role.
 #>
 
@@ -21,7 +21,7 @@ Configuration Example
             Ensure               = 'Present'
             ServerRoleName       = 'AdminSqlforBI'
             MembersToExclude     = 'CONTOSO\Mark', 'CONTOSO\Lucy'
-            ServerName           = 'SQLServer'
+            ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             PsDscRunAsCredential = $SysAdminAccount
         }

--- a/Examples/Resources/SqlServiceAccount/1-ConfigureServiceAccount-UserAccount.ps1
+++ b/Examples/Resources/SqlServiceAccount/1-ConfigureServiceAccount-UserAccount.ps1
@@ -17,9 +17,9 @@ Configuration Example
     Node localhost {
         SqlServiceAccount SetServiceAcccount_User
         {
-            SQLServer = 'TestServer'
-            SQLInstanceName = 'MSSQLSERVER'
-            ServiceType = 'DatabaseEngine'
+            ServerName     = 'TestServer'
+            InstanceName   = 'MSSQLSERVER'
+            ServiceType    = 'DatabaseEngine'
             ServiceAccount = $ServiceAccountCredential
             RestartService = $true
         }

--- a/Examples/Resources/SqlServiceAccount/2-ConfigureServiceAccount-VirtualAccount.ps1
+++ b/Examples/Resources/SqlServiceAccount/2-ConfigureServiceAccount-VirtualAccount.ps1
@@ -20,12 +20,12 @@ Configuration Example
     Node localhost {
         SqlServiceAccount SetServiceAcccount_User
         {
-            SQLServer = 'TestServer'
-            SQLInstanceName = 'DSC'
-            ServiceType = 'DatabaseEngine'
+            ServerName     = 'TestServer'
+            InstanceName   = 'DSC'
+            ServiceType    = 'DatabaseEngine'
             ServiceAccount = $ServiceAcccountCredential
             RestartService = $true
-            Force = $true
+            Force          = $true
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -290,11 +290,11 @@ group.
 
 * **`[String]` DatabaseName** _(Required)_: The name of the database(s) to add to
   the availability group. This accepts wildcards.
-* **`[String]` SQLServer** _(Key)_: Hostname of the SQL Server where the primary
+* **`[String]` ServerName** _(Key)_: Hostname of the SQL Server where the primary
   replica of the availability group lives. If the availability group is not
   currently on this server, the resource will attempt to connect to the server
   where the primary replica lives.
-* **`[String]` SQLInstanceName** _(Key)_: Name of the SQL instance where the primary
+* **`[String]` InstanceName** _(Key)_: Name of the SQL instance where the primary
   replica of the availability group lives. If the availability group is not currently
   on this instance, the resource will attempt to connect to the instance where the
   primary replica lives.
@@ -347,8 +347,8 @@ Always On Availability Group Replica.
 * **`[String]` Name** _(Key)_: The name of the availability group replica. For named
   instances this must be in the following format SQLServer\InstanceName.
 * **`[String]` AvailabilityGroupName** _(Key)_: The name of the availability group.
-* **`[String]` SQLServer** _(Required)_: Hostname of the SQL Server to be configured.
-* **`[String]` SQLInstanceName** _(Key)_: Name of the SQL instance to be configured.
+* **`[String]` ServerName** _(Required)_: Hostname of the SQL Server to be configured.
+* **`[String]` InstanceName** _(Key)_: Name of the SQL instance to be configured.
 * **`[String]` PrimaryReplicaSQLServer** _(Write)_: Hostname of the SQL Server where
   the primary replica is expected to be active. If the primary replica is not found
   here, the resource will attempt to find the host that holds the primary replica
@@ -413,8 +413,8 @@ Enables or disabled SQL Server Always On high availability and disaster recovery
 
 #### Parameters
 
-* **`[String]` SQLServer** _(Key)_: The hostname of the SQL Server to be configured.
-* **`[String]` SQLInstance** _(Key)_: The name of the SQL instance to be configured.
+* **`[String]` ServerName** _(Key)_: The hostname of the SQL Server to be configured.
+* **`[String]` InstanceName** _(Key)_: The name of the SQL instance to be configured.
 * **`[String]` Ensure** _(Required)_: An enumerated value that describes if the SQL
   Server should have Always On high availability and disaster recovery (HADR)
   property enabled ('Present') or disabled ('Absent'). { Present | Absent }.
@@ -451,7 +451,7 @@ No description.
   replica.
 * **`[String]` AvailabilityGroup** _(Key)_: The name of the availability group to
   which the availability group listener is or will be connected.
-* **`[String]` NodeName** _(Write)_: The host name or FQDN of the primary replica.
+* **`[String]` ServerName** _(Write)_: The host name or FQDN of the primary replica.
 * **`[String]` Ensure** _(Write)_: If the availability group listener should be present
   or absent. Default value is 'Present'. { *Present* | Absent }.
 * **`[String]` Name** _(Write)_: The name of the availability group listener, max
@@ -488,8 +488,8 @@ No description.
 
 #### Parameters
 
-* **`[String]` SQLServer** _(Key)_: The hostname of the SQL Server to be configured.
-* **`[String]` SQLInstanceName** _(Key)_: Name of the SQL instance to be configured.
+* **`[String]` ServerName** _(Key)_: The hostname of the SQL Server to be configured.
+* **`[String]` InstanceName** _(Key)_: Name of the SQL instance to be configured.
 * **`[String]` OptionName** _(Key)_: The name of the SQL configuration option to
   be checked. For all possible values reference [MSDN](https://msdn.microsoft.com/en-us/library/ms189631.aspx)
   or run sp_configure.
@@ -520,8 +520,8 @@ database, please read:
 
 #### Parameters
 
-* **`[String]` SQLServer** _(Key)_: The host name of the SQL Server to be configured.
-* **`[String]` SQLInstanceName** _(Key)_: The name of the SQL instance to be configured.
+* **`[String]` ServerName** _(Key)_: The host name of the SQL Server to be configured.
+* **`[String]` InstanceName** _(Key)_: The name of the SQL instance to be configured.
 * **`[String]` Name** _(Key)_: The name of database to be created or dropped.
 * **`[String]` Collation** _(Write)_: The name of the SQL collation to use
   for the new database. Defaults to server collation.
@@ -547,8 +547,8 @@ more information about database default locations, please read the article
 
 #### Parameters
 
-* **`[String]` SQLServer** _(Key)_: The host name of the SQL Server to be configured.
-* **`[String]` SQLInstanceName** _(Key)_: The name of the SQL instance to
+* **`[String]` ServerName** _(Key)_: The host name of the SQL Server to be configured.
+* **`[String]` InstanceName** _(Key)_: The name of the SQL instance to
   be configured.
 * **`[String]` Type** _(Key)_: The type of database default location to be
   configured. { Data | Log | Backup }
@@ -585,8 +585,8 @@ For more information about database owner, please read the article
 * **`[String]` Database** _(Key)_: The name of database to be configured.
 * **`[String]` Name** _(Required)_: The name of the login that will become a owner
   of the desired sql database.
-* **`[String]` SQLServer** _(Write)_: The host name of the SQL Server to be configured.
-* **`[String]` SQLInstance** _(Write)_: The name of the SQL instance to be configured.
+* **`[String]` ServerName** _(Write)_: The host name of the SQL Server to be configured.
+* **`[String]` InstanceName** _(Write)_: The name of the SQL instance to be configured.
 
 #### Examples
 
@@ -609,9 +609,9 @@ will also get their permission revoked.
 
 #### Parameters
 
-* **`[String]` SQLServer** _(Key)_: The host name of the SQL Server to be configured.
+* **`[String]` ServerName** _(Key)_: The host name of the SQL Server to be configured.
   Default values is '$env:COMPUTERNAME'.
-* **`[String]` SQLInstanceName** _(Key)_: The name of the SQL instance to be configured.
+* **`[String]` InstanceName** _(Key)_: The name of the SQL instance to be configured.
   Default value is 'MSSQLSERVER'.
 * **`[String]` Database** _(Key)_: The name of the database.
 * **`[String]` Name** _(Key)_: The name of the user that should be granted or denied
@@ -647,8 +647,8 @@ Read more about recovery model in this article
 #### Parameters
 
 * **`[String]` Name** _(Key)_: The SQL database name.
-* **`[String]` SQLServer** _(Key)_: The host name of the SQL Server to be configured.
-* **`[String]` SQLInstanceName** _(Key)_: The name of the SQL instance to be configured.
+* **`[String]` ServerName** _(Key)_: The host name of the SQL Server to be configured.
+* **`[String]` InstanceName** _(Key)_: The name of the SQL instance to be configured.
 * **`[String]` RecoveryModel** _(Required)_: The recovery model to use for the database.
   { Full | Simple | BulkLogged }.
 
@@ -670,8 +670,8 @@ Read more about database role in this article [CREATE ROLE (Transact-SQL)](https
 
 * **`[String]` Name** _(Key)_: The name of the login that will become a member, or
   removed as a member, of the role(s).
-* **`[String]` SQLServer** _(Key)_: The host name of the SQL Server to be configured.
-* **`[String]` SQLInstanceName** _(Key)_: The name of the SQL instance to be configured.
+* **`[String]` ServerName** _(Key)_: The host name of the SQL Server to be configured.
+* **`[String]` InstanceName** _(Key)_: The name of the SQL instance to be configured.
 * **`[String]` Database** _(Key)_: The database in which the login (user) and role(s)
   exist.
 * **`[String]` Ensure** _(Write)_: If 'Present' (the default value) then the login
@@ -712,9 +712,9 @@ the resource [**SqlServerEndpointPermission**](#xsqlserverendpointpermission).
   Default values is 'Present'. { *Present* | Absent }.
 * **`[Uint16]` Port** _(Write)_: The network port the endpoint is listening on.
   Default value is 5022.
-* **`[String]` SQLServer** _(Write)_: The host name of the SQL Server to be configured.
+* **`[String]` ServerName** _(Write)_: The host name of the SQL Server to be configured.
   Default value is $env:COMPUTERNAME.
-* **`[String]` SQLInstanceName** _(Key)_: The name of the SQL instance to be configured.
+* **`[String]` InstanceName** _(Key)_: The name of the SQL instance to be configured.
 * **`[String]` IpAddress** _(Write)_: The network IP address the endpoint is listening
   on. Defaults to '0.0.0.0' which means listen on any valid IP address.
 
@@ -734,7 +734,7 @@ This resource is used to give connect permission to an endpoint for a user (logi
 #### Parameters
 
 * **`[String]` InstanceName** _(Key)_: The name of the SQL instance to be configured.
-* **`[String]` NodeName** _(Required)_: The host name of the SQL Server to be configured.
+* **`[String]` ServerName** _(Required)_: The host name of the SQL Server to be configured.
 * **`[String]` Ensure** _(Write)_: If the permission should be present or absent.
   Default value is 'Present'. { *Present* | Absent }.
 * **`[String]` Name** _(Required)_: The name of the endpoint.
@@ -768,7 +768,7 @@ This resource is used to set the state of an endpoint.
 #### Parameters
 
 * **`[String]` InstanceName** _(Key)_: The name of the SQL instance to be configured.
-* **`[String]` NodeName** _(Write)_: The host name of the SQL Server to be configured.
+* **`[String]` ServerName** _(Write)_: The host name of the SQL Server to be configured.
   Default value is $env:COMPUTERNAME.
 * **`[String]` Name** _(Key)_: The name of the endpoint.
 * **`[String]` State** _(Write)_: The state of the endpoint. Valid states are Started,
@@ -876,8 +876,8 @@ No description.
 
 #### Parameters
 
-* **`[String]` SQLServer** _(Key)_:The hostname of the SQL Server to be configured.
-* **`[String]` SQLInstanceName** _(Key)_: Name of the SQL instance to be configured.
+* **`[String]` ServerName** _(Key)_:The hostname of the SQL Server to be configured.
+* **`[String]` InstanceName** _(Key)_: Name of the SQL instance to be configured.
 * **`[String]` Name** _(Key)_: The name of the login.
 * **`[String]` Ensure** _(Write)_: The specified login is Present or Absent.
   { *Present* | Absent }.
@@ -929,8 +929,8 @@ Read more about max degree of parallelism in this article
 
 #### Parameters
 
-* **`[String]` SQLInstance** (Key): The name of the SQL instance to be configured.
-* **`[String]` SQLServer** _(Write)_: The host name of the SQL Server to be configured.
+* **`[String]` InstanceName** (Key): The name of the SQL instance to be configured.
+* **`[String]` ServerName** _(Write)_: The host name of the SQL Server to be configured.
   Default value is $env:COMPUTERNAME.
 * **`[String]` Ensure** _(Write)_: When set to 'Present' then max degree of parallelism
   will be set to either the value in parameter MaxDop or dynamically configured
@@ -1003,8 +1003,8 @@ SQL Max Memory = TotalPhysicalMemory - (NumOfSQLThreads\*ThreadStackSize) -
 
 #### Parameters
 
-* **`[String]` SQLInstance** _(Key)_: The name of the SQL instance to be configured.
-* **`[String]` SQLServer** _(Write)_: The host name of the SQL Server to be configured.
+* **`[String]` InstanceName** _(Key)_: The name of the SQL instance to be configured.
+* **`[String]` ServerName** _(Write)_: The host name of the SQL Server to be configured.
   Default value is $env:COMPUTERNAME.
 * **`[Boolean]` DynamicAlloc** _(Write)_: If set to $true then max memory will be
   dynamically configured. When this is set parameter is set to $true, the parameter
@@ -1052,7 +1052,7 @@ Read more about the network settings in the article
 * **`[String]` InstanceName** _(Key)_: The name of the SQL instance to be configured.
 * **`[String]` ProtocolName** _(Required)_: The name of network protocol to be configured.
   Only tcp is currently supported. { tcp }.
-* **`[String]` SQLServer** _(Write)_: The host name of the SQL Server to be configured.
+* **`[String]` ServerName** _(Write)_: The host name of the SQL Server to be configured.
   Default value is $env:COMPUTERNAME.
 * **`[Boolean]` IsEnabled** _(Write)_: Enables or disables the network protocol.
 * **`[Boolean]` TcpDynamicPort** _(Write)_: Specifies whether the SQL Server
@@ -1093,7 +1093,7 @@ AlterAnyEndPoint and ViewServerState.
 * **`[String]` Principal** _(Key)_: The login to which permission will be set.
 * **`[String]` Ensure** _(Write)_: If the permission should be present or absent.
   Default value is 'Present'. { Present | Absent }.
-* **`[String]` NodeName** _(Write)_: The host name of the SQL Server to be configured.
+* **`[String]` ServerName** _(Write)_: The host name of the SQL Server to be configured.
   Default value is $env:COMPUTERNAME.
 * **`[String[]]` Permission** _(Write)_: The permission to set for the login. Valid
   values are ConnectSql, AlterAnyAvailabilityGroup, ViewServerState or AlterAnyEndPoint.
@@ -1158,8 +1158,8 @@ server roles, please read the below articles.
 #### Parameters
 
 * **`[String]` ServerRoleName** _(Key)_: The name of of SQL role to add or remove.
-* **`[String]` SQLServer** _(Key)_: The host name of the SQL Server to be configured.
-* **`[String]` SQLInstanceName** _(Key)_: The name of the SQL instance to be configured.
+* **`[String]` ServerName** _(Key)_: The host name of the SQL Server to be configured.
+* **`[String]` InstanceName** _(Key)_: The name of the SQL instance to be configured.
 * **`[String]` Ensure** _(Write)_: An enumerated value that describes if the server
   role is added (Present) or dropped (Absent). Default value is 'Present'.
   { *Present* | Absent }.
@@ -1328,9 +1328,9 @@ Manage the service account for SQL Server services.
 
 #### Parameters
 
-* **`[String]` SQLServer** (Key): The host name of the SQL Server to be configured.
-* **`[String]` SQLInstanceName** (Key): The name of the SQL instance to be configured.
-* **`[String]` ServiceType** (Key): The service type for **SQLInstanceName**.
+* **`[String]` ServerName** (Key): The host name of the SQL Server to be configured.
+* **`[String]` InstanceName** (Key): The name of the SQL instance to be configured.
+* **`[String]` ServiceType** (Key): The service type for **InstanceName**.
   { DatabaseEngine | SQLServerAgent | Search | IntegrationServices
   | AnalysisServices | ReportingServices | SQLServerBrowser
   | NotificationServices }

--- a/README.md
+++ b/README.md
@@ -212,8 +212,8 @@ It will also manage the Availability Group replica on the specified node.
 #### Parameters
 
 * **`[String]` Name** _(Key)_: The name of the availability group.
-* **`[String]` SQLServer** _(Required)_: Hostname of the SQL Server to be configured.
-* **`[String]` SQLInstanceName** _(Key)_: Name of the SQL instance to be configured.
+* **`[String]` ServerName** _(Required)_: Hostname of the SQL Server to be configured.
+* **`[String]` InstanceName** _(Key)_: Name of the SQL instance to be configured.
 * **`[String]` Ensure** _(Write)_: Specifies if the availability group should be
   present or absent. Default is Present. { *Present* | Absent }
 * **`[String]` AutomatedBackupPreference** _(Write)_: Specifies the automated backup

--- a/Tests/Integration/MSFT_SqlAlwaysOnService.config.ps1
+++ b/Tests/Integration/MSFT_SqlAlwaysOnService.config.ps1
@@ -126,8 +126,8 @@ Configuration MSFT_SqlAlwaysOnService_EnableAlwaysOn_Config
         SqlAlwaysOnService 'Integration_Test'
         {
             Ensure               = 'Present'
-            SQLServer            = $Node.ComputerName
-            SQLInstanceName      = $Node.InstanceName
+            ServerName           = $Node.ComputerName
+            InstanceName         = $Node.InstanceName
             RestartTimeout       = $Node.RestartTimeout
 
             PsDscRunAsCredential = $SqlInstallCredential
@@ -157,8 +157,8 @@ Configuration MSFT_SqlAlwaysOnService_DisableAlwaysOn_Config
         SqlAlwaysOnService 'Integration_Test'
         {
             Ensure               = 'Absent'
-            SQLServer            = $Node.ComputerName
-            SQLInstanceName      = $Node.InstanceName
+            ServerName           = $Node.ComputerName
+            InstanceName         = $Node.InstanceName
             RestartTimeout       = $Node.RestartTimeout
 
             PsDscRunAsCredential = $SqlInstallCredential

--- a/Tests/Integration/MSFT_SqlDatabaseDefaultLocation.config.ps1
+++ b/Tests/Integration/MSFT_SqlDatabaseDefaultLocation.config.ps1
@@ -44,15 +44,15 @@ Configuration MSFT_SqlDatabaseDefaultLocation_Data_Config
 
         SqlDatabaseDefaultLocation 'Integration_Test'
         {
-            Type  = 'Data'
-            Path  = $Node.DataFilePath
+            Type                 = 'Data'
+            Path                 = $Node.DataFilePath
             RestartService       = $true
-            SQLServer            = $Node.ComputerName
-            SQLInstanceName      = $Node.InstanceName
+            ServerName           = $Node.ComputerName
+            InstanceName         = $Node.InstanceName
 
             PsDscRunAsCredential = $SqlInstallCredential
 
-            DependsOn = '[File]SQLDataPath'
+            DependsOn            = '[File]SQLDataPath'
         }
     }
 }
@@ -82,15 +82,15 @@ Configuration MSFT_SqlDatabaseDefaultLocation_Log_Config
 
         SqlDatabaseDefaultLocation 'Integration_Test'
         {
-            Type  = 'Log'
-            Path  = $Node.LogFilePath
+            Type                 = 'Log'
+            Path                 = $Node.LogFilePath
             RestartService       = $true
-            SQLServer            = $Node.ComputerName
-            SQLInstanceName      = $Node.InstanceName
+            ServerName           = $Node.ComputerName
+            InstanceName         = $Node.InstanceName
 
             PsDscRunAsCredential = $SqlInstallCredential
 
-            DependsOn = '[File]SQLLogPath'
+            DependsOn            = '[File]SQLLogPath'
         }
     }
 }
@@ -120,15 +120,15 @@ Configuration MSFT_SqlDatabaseDefaultLocation_Backup_Config
 
         SqlDatabaseDefaultLocation 'Integration_Test'
         {
-            Type  = 'Backup'
-            Path  = $Node.BackupFilePath
+            Type                 = 'Backup'
+            Path                 = $Node.BackupFilePath
             RestartService       = $false
-            SQLServer            = $Node.ComputerName
-            SQLInstanceName      = $Node.InstanceName
+            ServerName           = $Node.ComputerName
+            InstanceName         = $Node.InstanceName
 
             PsDscRunAsCredential = $SqlInstallCredential
 
-            DependsOn = '[File]SQLBackupPath'
+            DependsOn            = '[File]SQLBackupPath'
         }
     }
 }

--- a/Tests/TestHelpers/CommonTestHelper.psm1
+++ b/Tests/TestHelpers/CommonTestHelper.psm1
@@ -6,7 +6,7 @@
         The major version of the SQL instance.
 
     .PARAMETER ModuleName
-        The name of the module to load the stubs for. Default is 'SQLServer'.
+        The name of the module to load the stubs for. Default is 'SqlServer'.
 #>
 function Import-SQLModuleStub
 {
@@ -18,15 +18,15 @@ function Import-SQLModuleStub
         $SQLVersion,
 
         [Parameter(ParameterSetName = 'Module')]
-        [ValidateSet('SQLPS','SQLServer')]
+        [ValidateSet('SQLPS','SqlServer')]
         [System.String]
-        $ModuleName = 'SQLServer'
+        $ModuleName = 'SqlServer'
     )
 
     # Translate the module names to their appropriate stub name
     $modulesAndStubs = @{
         SQLPS = 'SQLPSStub'
-        SQLServer = 'SQLServerStub'
+        SqlServer = 'SqlServerStub'
     }
 
     # Determine which module to ensure is loaded based on the parameters passed
@@ -38,7 +38,7 @@ function Import-SQLModuleStub
         }
         elseif ( $SQLVersion -ge 13 )
         {
-            $ModuleName = 'SQLServer'
+            $ModuleName = 'SqlServer'
         }
     }
 
@@ -46,7 +46,9 @@ function Import-SQLModuleStub
     $stubModuleName = $modulesAndStubs.$ModuleName
 
     # Ensure none of the other stub modules are loaded
-    [System.Array] $otherStubModules = $modulesAndStubs.Values | Where-Object -FilterScript { $_ -ne $stubModuleName }
+    [System.Array] $otherStubModules = $modulesAndStubs.Values | Where-Object -FilterScript {
+        $_ -ne $stubModuleName
+    }
 
     if ( Get-Module -Name $otherStubModules )
     {

--- a/Tests/Unit/MSFT_SqlAG.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAG.Tests.ps1
@@ -49,7 +49,7 @@ try
         }
 
         # Define the values that could be passed into the ServerName parameter
-        $mockServerNameParameters = @{
+        $mockSqlServerParameters = @{
             Server1 = @{
                 FQDN = 'Server1.contoso.com'
                 #IP = '192.168.1.1'
@@ -64,7 +64,7 @@ try
         }
 
         # Define the values that could be passed into the InstanceName parameter
-        $mockInstanceNameParameters = @(
+        $mockSqlInstanceNameParameters = @(
             'MSSQLSERVER',
             'NamedInstance'
         )
@@ -189,38 +189,38 @@ try
 
         foreach ( $majorVersionToTest in $majorVersionsToTest )
         {
-            foreach ( $mockServerName in $mockServerNameParameters.GetEnumerator() )
+            foreach ( $mockSqlServer in $mockSqlServerParameters.GetEnumerator() )
             {
                 # Determine with SQL Server mock will be used
-                $mockServerNameToBeUsed = $mockServerName.Key
+                $mockSqlServerToBeUsed = $mockSqlServer.Key
 
-                foreach ( $mockServerNameParameter in $mockServerName.Value.Values )
+                foreach ( $mockSqlServerParameter in $mockSqlServer.Value.Values )
                 {
-                    foreach ( $mockInstanceNameParameter in $mockInstanceNameParameters )
+                    foreach ( $mockSqlInstanceNameParameter in $mockSqlInstanceNameParameters )
                     {
                         # Build the domain instance name
-                        if ( $mockInstanceNameParameter -eq 'MSSQLSERVER' )
+                        if ( $mockSqlInstanceNameParameter -eq 'MSSQLSERVER' )
                         {
-                            $domainInstanceNameProperty = $mockServerNameParameter
+                            $domainInstanceNameProperty = $mockSqlServerParameter
                         }
                         else
                         {
-                            $domainInstanceNameProperty = '{0}\{1}' -f $mockServerNameParameter,$mockInstanceNameParameter
+                            $domainInstanceNameProperty = '{0}\{1}' -f $mockSqlServerParameter,$mockSqlInstanceNameParameter
                         }
 
-                        if ( $mockServerNameToBeUsed -eq 'Server1' )
+                        if ( $mockSqlServerToBeUsed -eq 'Server1' )
                         {
                             $getTargetResourceAbsentTestCases += @{
                                 Name = $mockNameParameters.AbsentAvailabilityGroup
-                                ServerName = $mockServerNameParameter
-                                InstanceName = $mockInstanceNameParameter
+                                ServerName = $mockSqlServerParameter
+                                InstanceName = $mockSqlInstanceNameParameter
                                 Version = $majorVersionToTest
                             }
 
                             $getTargetResourcePresentTestCases += @{
                                 Name = $mockNameParameters.PresentAvailabilityGroup
-                                ServerName = $mockServerNameParameter
-                                InstanceName = $mockInstanceNameParameter
+                                ServerName = $mockSqlServerParameter
+                                InstanceName = $mockSqlInstanceNameParameter
                                 Version = $majorVersionToTest
                             }
 
@@ -230,8 +230,8 @@ try
                                     ErrorResult = $createAvailabilityGroupFailureToTest.Value
                                     Ensure = 'Present'
                                     Name = $createAvailabilityGroupFailureToTest.Key
-                                    ServerName = $mockServerNameParameter
-                                    InstanceName = $mockInstanceNameParameter
+                                    ServerName = $mockSqlServerParameter
+                                    InstanceName = $mockSqlInstanceNameParameter
                                     Version = $majorVersionToTest
                                 }
                             }
@@ -240,8 +240,8 @@ try
                                 Ensure = 'Present'
                                 Name = $mockNameParameters.AbsentAvailabilityGroup
                                 Result = 'DatabaseMirroringEndpointNotFound'
-                                ServerName = $mockServerNameParameter
-                                InstanceName = $mockInstanceNameParameter
+                                ServerName = $mockSqlServerParameter
+                                InstanceName = $mockSqlInstanceNameParameter
                                 Version = $majorVersionToTest
                             }
 
@@ -249,21 +249,21 @@ try
                                 Ensure = 'Present'
                                 Name = $mockNameParameters.AbsentAvailabilityGroup
                                 Result = 'HadrNotEnabled'
-                                ServerName = $mockServerNameParameter
-                                InstanceName = $mockInstanceNameParameter
+                                ServerName = $mockSqlServerParameter
+                                InstanceName = $mockSqlInstanceNameParameter
                                 Version = $majorVersionToTest
                             }
 
                             $setTargetResourceRemoveAvailabilityGroupTestCases += @{
                                 Ensure = 'Absent'
                                 Name = $mockNameParameters.PresentAvailabilityGroup
-                                ServerName = $mockServerNameParameter
-                                InstanceName = $mockInstanceNameParameter
+                                ServerName = $mockSqlServerParameter
+                                InstanceName = $mockSqlInstanceNameParameter
                                 Version = $majorVersionToTest
                             }
                         }
 
-                        switch ( $mockServerNameToBeUsed )
+                        switch ( $mockSqlServerToBeUsed )
                         {
                             'Server1'
                             {
@@ -282,8 +282,8 @@ try
                             ErrorResult = $setTargetResourceRemoveAvailabilityGroupErrorTestCaseErrorResult
                             Ensure = 'Absent'
                             Name = $setTargetResourceRemoveAvailabilityGroupErrorTestCaseName
-                            ServerName = $mockServerNameParameter
-                            InstanceName = $mockInstanceNameParameter
+                            ServerName = $mockSqlServerParameter
+                            InstanceName = $mockSqlInstanceNameParameter
                             Version = $majorVersionToTest
                         }
 
@@ -293,8 +293,8 @@ try
                                 Ensure = 'Present'
                                 Name = $mockNameParameters.PresentAvailabilityGroup
                                 ProcessOnlyOnActiveNode = $processOnlyOnActiveNode
-                                ServerName = $mockServerNameParameter
-                                InstanceName = $mockInstanceNameParameter
+                                ServerName = $mockSqlServerParameter
+                                InstanceName = $mockSqlInstanceNameParameter
                                 Version = $majorVersionToTest
                             }
                         }
@@ -306,8 +306,8 @@ try
                                 Ensure = $ensureCaseToTest
                                 Name = $mockNameParameters.AbsentAvailabilityGroup
                                 Result = ( $ensureCaseToTest -eq 'Absent' )
-                                ServerName = $mockServerNameParameter
-                                InstanceName = $mockInstanceNameParameter
+                                ServerName = $mockSqlServerParameter
+                                InstanceName = $mockSqlInstanceNameParameter
                                 Version = $majorVersionToTest
                             }
 
@@ -315,8 +315,8 @@ try
                                 Ensure = $ensureCaseToTest
                                 Name = $mockNameParameters.PresentAvailabilityGroup
                                 Result = ( $ensureCaseToTest -eq 'Present' )
-                                ServerName = $mockServerNameParameter
-                                InstanceName = $mockInstanceNameParameter
+                                ServerName = $mockSqlServerParameter
+                                InstanceName = $mockSqlInstanceNameParameter
                                 Version = $majorVersionToTest
                             }
                         }
@@ -371,7 +371,7 @@ try
                                 }
                             }
 
-                            if ( $mockServerNameToBeUsed -eq 'Server1' )
+                            if ( $mockSqlServerToBeUsed -eq 'Server1' )
                             {
                                 $setTargetResourceCreateAvailabilityGroupWithParameterTestCases += @{
                                     DomainInstanceName = $domainInstanceNameProperty
@@ -379,8 +379,8 @@ try
                                     Name = $mockNameParameters.AbsentAvailabilityGroup
                                     ParameterName = $resourceParameter.Key
                                     ParameterValue = $testCaseParameterValue
-                                    ServerName = $mockServerNameParameter
-                                    InstanceName = $mockInstanceNameParameter
+                                    ServerName = $mockSqlServerParameter
+                                    InstanceName = $mockSqlInstanceNameParameter
                                     Version = $majorVersionToTest
                                 }
                             }
@@ -391,8 +391,8 @@ try
                                 ParameterName = $resourceParameter.Key
                                 ParameterValue = $testCaseParameterValue
                                 Result = $false
-                                ServerName = $mockServerNameParameter
-                                InstanceName = $mockInstanceNameParameter
+                                ServerName = $mockSqlServerParameter
+                                InstanceName = $mockSqlInstanceNameParameter
                                 Version = $majorVersionToTest
                             }
 
@@ -402,8 +402,8 @@ try
                                 ParameterName = $resourceParameter.Key
                                 ParameterValue = $testCaseParameterValue
                                 Result = $false
-                                ServerName = $mockServerNameParameter
-                                InstanceName = $mockInstanceNameParameter
+                                ServerName = $mockSqlServerParameter
+                                InstanceName = $mockSqlInstanceNameParameter
                                 Version = $majorVersionToTest
                             }
                         }
@@ -430,8 +430,8 @@ try
                                 EndpointPropertyValue = $endpointPropertyValue
                                 Ensure = 'Present'
                                 Name = $mockNameParameters.PresentAvailabilityGroup
-                                ServerName = $mockServerNameParameter
-                                InstanceName = $mockInstanceNameParameter
+                                ServerName = $mockSqlServerParameter
+                                InstanceName = $mockSqlInstanceNameParameter
                                 Version = $majorVersionToTest
                             }
 
@@ -441,8 +441,8 @@ try
                                 Ensure = 'Present'
                                 Name = $mockNameParameters.PresentAvailabilityGroup
                                 Result = $false
-                                ServerName = $mockServerNameParameter
-                                InstanceName = $mockInstanceNameParameter
+                                ServerName = $mockSqlServerParameter
+                                InstanceName = $mockSqlInstanceNameParameter
                                 Version = $majorVersionToTest
                             }
                         }
@@ -479,16 +479,16 @@ try
             # If this mock function is called from the Get-PrimaryReplicaServerObject command mock
             if ( [string]::IsNullOrEmpty($SQLServer) -and [string]::IsNullOrEmpty($SQLInstanceName) -and $AvailabilityGroup -and $ServerObject )
             {
-                $SQLServer,$InstanceName = $AvailabilityGroup.PrimaryReplicaServerName.Split('\')
+                $SQLServer,$SQLInstanceName = $AvailabilityGroup.PrimaryReplicaServerName.Split('\')
             }
 
             # Determine which SQL Server mock data we will use
-            $mockServerName = ( $mockServerNameParameters.GetEnumerator() | Where-Object -FilterScript { $_.Value.Values -contains $SQLServer } ).Name
-            if ( [string]::IsNullOrEmpty($mockServerName) )
+            $mockSqlServer = ( $mockSqlServerParameters.GetEnumerator() | Where-Object -FilterScript { $_.Value.Values -contains $SQLServer } ).Name
+            if ( [string]::IsNullOrEmpty($mockSqlServer) )
             {
-                $mockServerName = $SQLServer
+                $mockSqlServer = $SQLServer
             }
-            $mockCurrentServerObjectProperties = $mockServerObjectProperies.$mockServerName
+            $mockCurrentServerObjectProperties = $mockServerObjectProperies.$mockSqlServer
 
             # Build the domain instance name
             if ( ( $SQLInstanceName -eq 'MSSQLSERVER' ) -or [string]::IsNullOrEmpty($SQLInstanceName) )
@@ -688,12 +688,12 @@ try
 
             Context 'When the Availability Group is Absent' {
 
-                It 'Should not return an Availability Group when Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $getTargetResourceAbsentTestCases {
+                It 'Should not return an Availability Group when Name is "<Name>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $getTargetResourceAbsentTestCases {
                     param
                     (
                         $Name,
-                        $ServerName,
-                        $InstanceName,
+                        $SQLServer,
+                        $SQLInstanceName,
                         $Version
                     )
 
@@ -702,8 +702,8 @@ try
 
                     $getTargetResourceParameters = @{
                         Name = $Name
-                        ServerName = $ServerName
-                        InstanceName = $InstanceName
+                        ServerName = $SQLServer
+                        InstanceName = $SQLInstanceName
                     }
 
                     $result = Get-TargetResource @getTargetResourceParameters
@@ -715,12 +715,12 @@ try
             }
 
             Context 'When the Availability Group is Present' {
-                It 'Should return the correct Availability Group properties when Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $getTargetResourcePresentTestCases {
+                It 'Should return the correct Availability Group properties when Name is "<Name>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $getTargetResourcePresentTestCases {
                     param
                     (
                         $Name,
-                        $ServerName,
-                        $InstanceName,
+                        $SQLServer,
+                        $SQLInstanceName,
                         $Version
                     )
 
@@ -729,27 +729,27 @@ try
 
                     $getTargetResourceParameters = @{
                         Name = $Name
-                        ServerName = $ServerName
-                        InstanceName = $InstanceName
+                        ServerName = $SQLServer
+                        InstanceName = $SQLInstanceName
                     }
 
                     # Determine which SQL Server mock data will be used
-                    $mockServerName = ( $mockServerNameParameters.GetEnumerator() | Where-Object -FilterScript { $_.Value.Values -contains $ServerName } ).Name
+                    $mockSqlServer = ( $mockSqlServerParameters.GetEnumerator() | Where-Object -FilterScript { $_.Value.Values -contains $SQLServer } ).Name
 
                     $result = Get-TargetResource @getTargetResourceParameters
 
                     $result.Name | Should -Be $Name
-                    $result.ServerName | Should -Be $ServerName
-                    $result.InstanceName | Should -Be $InstanceName
+                    $result.ServerName | Should -Be $SQLServer
+                    $result.InstanceName | Should -Be $SQLInstanceName
                     $result.Ensure | Should -Be 'Present'
                     $result.AutomatedBackupPreference | Should -Be $mockAvailabilityGroupProperties.AutomatedBackupPreference
-                    $result.AvailabilityMode | Should -Be $mockAvailabilityGroupReplicaProperties.$mockServerName.AvailabilityMode
-                    $result.BackupPriority | Should -Be $mockAvailabilityGroupReplicaProperties.$mockServerName.BackupPriority
-                    $result.ConnectionModeInPrimaryRole | Should -Be $mockAvailabilityGroupReplicaProperties.$mockServerName.ConnectionModeInPrimaryRole
-                    $result.ConnectionModeInSecondaryRole | Should -Be $mockAvailabilityGroupReplicaProperties.$mockServerName.ConnectionModeInSecondaryRole
-                    $result.EndpointURL | Should -Be "$($mockAvailabilityGroupReplicaProperties.$mockServerName.EndpointProtocol)://$($mockAvailabilityGroupReplicaProperties.$mockServerName.EndpointHostName):$($mockAvailabilityGroupReplicaProperties.$mockServerName.EndpointPort)"
+                    $result.AvailabilityMode | Should -Be $mockAvailabilityGroupReplicaProperties.$mockSqlServer.AvailabilityMode
+                    $result.BackupPriority | Should -Be $mockAvailabilityGroupReplicaProperties.$mockSqlServer.BackupPriority
+                    $result.ConnectionModeInPrimaryRole | Should -Be $mockAvailabilityGroupReplicaProperties.$mockSqlServer.ConnectionModeInPrimaryRole
+                    $result.ConnectionModeInSecondaryRole | Should -Be $mockAvailabilityGroupReplicaProperties.$mockSqlServer.ConnectionModeInSecondaryRole
+                    $result.EndpointURL | Should -Be "$($mockAvailabilityGroupReplicaProperties.$mockSqlServer.EndpointProtocol)://$($mockAvailabilityGroupReplicaProperties.$mockSqlServer.EndpointHostName):$($mockAvailabilityGroupReplicaProperties.$mockSqlServer.EndpointPort)"
                     $result.FailureConditionLevel | Should -Be $mockAvailabilityGroupProperties.FailureConditionLevel
-                    $result.FailoverMode | Should -Be $mockAvailabilityGroupReplicaProperties.$mockServerName.FailoverMode
+                    $result.FailoverMode | Should -Be $mockAvailabilityGroupReplicaProperties.$mockSqlServer.FailoverMode
                     $result.HealthCheckTimeout | Should -Be $mockAvailabilityGroupProperties.HealthCheckTimeout
 
                     if ( $Version -ge 13 )
@@ -794,7 +794,7 @@ try
             }
 
             Context 'When the Availability Group is Absent and the desired state is Present and a parameter is supplied' {
-                It 'Should create the availability group "<Name>" with the parameter "<ParameterName>" set to "<ParameterValue>" when Ensure is "<Ensure>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceCreateAvailabilityGroupWithParameterTestCases {
+                It 'Should create the availability group "<Name>" with the parameter "<ParameterName>" set to "<ParameterValue>" when Ensure is "<Ensure>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceCreateAvailabilityGroupWithParameterTestCases {
                     param
                     (
                         $DomainInstanceName,
@@ -802,8 +802,8 @@ try
                         $Name,
                         $ParameterName,
                         $ParameterValue,
-                        $ServerName,
-                        $InstanceName,
+                        $SQLServer,
+                        $SQLInstanceName,
                         $Version
                     )
 
@@ -813,8 +813,8 @@ try
                     $setTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        ServerName = $ServerName
-                        InstanceName = $InstanceName
+                        ServerName = $SQLServer
+                        InstanceName = $SQLInstanceName
                         $ParameterName = $ParameterValue
                     }
 
@@ -839,14 +839,14 @@ try
             }
 
             Context 'When the Availability Group is Absent, the desired state is Present, and creating the Availability Group fails' {
-                It 'Should throw "<ErrorResult>" when creating the availability group "<Name>" fails, Ensure is "<Ensure>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceCreateAvailabilityGroupFailedTestCases {
+                It 'Should throw "<ErrorResult>" when creating the availability group "<Name>" fails, Ensure is "<Ensure>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceCreateAvailabilityGroupFailedTestCases {
                     param
                     (
                         $ErrorResult,
                         $Ensure,
                         $Name,
-                        $ServerName,
-                        $InstanceName,
+                        $SQLServer,
+                        $SQLInstanceName,
                         $Version
                     )
 
@@ -869,8 +869,8 @@ try
                     $setTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        ServerName = $ServerName
-                        InstanceName = $InstanceName
+                        ServerName = $SQLServer
+                        InstanceName = $SQLInstanceName
                     }
 
                     { Set-TargetResource @setTargetResourceParameters } | Should -Throw "$($ErrorResult)"
@@ -894,7 +894,7 @@ try
             }
 
             Context 'When the Availability Group is Present and a value is passed to a parameter' {
-                It 'Should set "<ParameterName>" to "<ParameterValue>" when Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourcePropertyIncorrectTestCases {
+                It 'Should set "<ParameterName>" to "<ParameterValue>" when Name is "<Name>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourcePropertyIncorrectTestCases {
                     param
                     (
                         $Ensure,
@@ -902,8 +902,8 @@ try
                         $ParameterName,
                         $ParameterValue,
                         $Result,
-                        $ServerName,
-                        $InstanceName,
+                        $SQLServer,
+                        $SQLInstanceName,
                         $Version
                     )
 
@@ -913,8 +913,8 @@ try
                     $setTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        ServerName = $ServerName
-                        InstanceName = $InstanceName
+                        ServerName = $SQLServer
+                        InstanceName = $SQLInstanceName
                         $ParameterName = $ParameterValue
                     }
 
@@ -951,13 +951,13 @@ try
             }
 
             Context 'When the Availability Group is Present and the desired state is Absent' {
-                It 'Should remove the Availability Group "<Name>" when Ensure is "<Ensure>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceRemoveAvailabilityGroupTestCases {
+                It 'Should remove the Availability Group "<Name>" when Ensure is "<Ensure>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceRemoveAvailabilityGroupTestCases {
                     param
                     (
                         $Ensure,
                         $Name,
-                        $ServerName,
-                        $InstanceName,
+                        $SQLServer,
+                        $SQLInstanceName,
                         $Version
                     )
 
@@ -967,8 +967,8 @@ try
                     $setTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        ServerName = $ServerName
-                        InstanceName = $InstanceName
+                        ServerName = $SQLServer
+                        InstanceName = $SQLInstanceName
                     }
 
                     { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
@@ -992,14 +992,14 @@ try
             }
 
             Context 'When the Availability Group is Present and throws an error when removal is attempted' {
-                It 'Should throw "<ErrorResult>" when Ensure is "<Ensure>", Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceRemoveAvailabilityGroupErrorTestCases {
+                It 'Should throw "<ErrorResult>" when Ensure is "<Ensure>", Name is "<Name>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceRemoveAvailabilityGroupErrorTestCases {
                     param
                     (
                         $ErrorResult,
                         $Ensure,
                         $Name,
-                        $ServerName,
-                        $InstanceName,
+                        $SQLServer,
+                        $SQLInstanceName,
                         $Version
                     )
 
@@ -1022,8 +1022,8 @@ try
                     $setTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        ServerName = $ServerName
-                        InstanceName = $InstanceName
+                        ServerName = $SQLServer
+                        InstanceName = $SQLInstanceName
                     }
 
                     { Set-TargetResource @setTargetResourceParameters } | Should -Throw "$($ErrorResult)"
@@ -1055,14 +1055,14 @@ try
                     $mockIsHadrEnabled = $false
                 }
 
-                It 'Should throw "<Result>" when Ensure is "<Ensure>", Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceHadrDisabledTestCases {
+                It 'Should throw "<Result>" when Ensure is "<Ensure>", Name is "<Name>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceHadrDisabledTestCases {
                     param
                     (
                         $Ensure,
                         $Name,
                         $Result,
-                        $ServerName,
-                        $InstanceName,
+                        $SQLServer,
+                        $SQLInstanceName,
                         $Version
                     )
 
@@ -1072,8 +1072,8 @@ try
                     $setTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        ServerName = $ServerName
-                        InstanceName = $InstanceName
+                        ServerName = $SQLServer
+                        InstanceName = $SQLInstanceName
                     }
 
                     { Set-TargetResource @setTargetResourceParameters } | Should -Throw $Result
@@ -1105,14 +1105,14 @@ try
                     $mockIsDatabaseMirroringEndpointPresent = $false
                 }
 
-                It 'Should throw "<Result>" when Ensure is "<Ensure>", Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceEndpointMissingTestCases {
+                It 'Should throw "<Result>" when Ensure is "<Ensure>", Name is "<Name>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceEndpointMissingTestCases {
                     param
                     (
                         $Ensure,
                         $Name,
                         $Result,
-                        $ServerName,
-                        $InstanceName,
+                        $SQLServer,
+                        $SQLInstanceName,
                         $Version
                     )
 
@@ -1122,8 +1122,8 @@ try
                     $setTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        ServerName = $ServerName
-                        InstanceName = $InstanceName
+                        ServerName = $SQLServer
+                        InstanceName = $SQLInstanceName
                     }
 
                     { Set-TargetResource @setTargetResourceParameters } | Should -Throw $Result
@@ -1159,15 +1159,15 @@ try
                     $mockAvailabilityGroupReplicaPropertiesServer2Original = $mockAvailabilityGroupReplicaProperties.Server2.Clone()
                 }
 
-                It 'Should set "<EndpointPropertyName>" to "<EndpointPropertyValue>" when Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourcesEndpointUrlTestCases {
+                It 'Should set "<EndpointPropertyName>" to "<EndpointPropertyValue>" when Name is "<Name>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourcesEndpointUrlTestCases {
                     param
                     (
                         $EndpointPropertyName,
                         $EndpointPropertyValue,
                         $Ensure,
                         $Name,
-                        $ServerName,
-                        $InstanceName,
+                        $SQLServer,
+                        $SQLInstanceName,
                         $Version
                     )
 
@@ -1180,8 +1180,8 @@ try
                     $setTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        ServerName = $ServerName
-                        InstanceName = $InstanceName
+                        ServerName = $SQLServer
+                        InstanceName = $SQLInstanceName
                     }
 
                     { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
@@ -1214,14 +1214,14 @@ try
             }
 
             Context 'When the Availability Group is Absent' {
-                It 'Should be "<Result>" when Ensure is "<Ensure>", Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourceAbsentTestCases {
+                It 'Should be "<Result>" when Ensure is "<Ensure>", Name is "<Name>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourceAbsentTestCases {
                     param
                     (
                         $Ensure,
                         $Name,
                         $Result,
-                        $ServerName,
-                        $InstanceName,
+                        $SQLServer,
+                        $SQLInstanceName,
                         $Version
                     )
 
@@ -1231,8 +1231,8 @@ try
                     $testTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        ServerName = $ServerName
-                        InstanceName = $InstanceName
+                        ServerName = $SQLServer
+                        InstanceName = $SQLInstanceName
                     }
 
                     Test-TargetResource @testTargetResourceParameters | Should -Be $Result
@@ -1243,14 +1243,14 @@ try
             }
 
             Context 'When the Availability Group is Present and the default parameters are passed' {
-                It 'Should be "<Result>" when Ensure is "<Ensure>", Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourcePresentTestCases {
+                It 'Should be "<Result>" when Ensure is "<Ensure>", Name is "<Name>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourcePresentTestCases {
                     param
                     (
                         $Ensure,
                         $Name,
                         $Result,
-                        $ServerName,
-                        $InstanceName,
+                        $SQLServer,
+                        $SQLInstanceName,
                         $Version
                     )
 
@@ -1260,8 +1260,8 @@ try
                     $testTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        ServerName = $ServerName
-                        InstanceName = $InstanceName
+                        ServerName = $SQLServer
+                        InstanceName = $SQLInstanceName
                     }
 
                     Test-TargetResource @testTargetResourceParameters | Should -Be $Result
@@ -1272,7 +1272,7 @@ try
             }
 
             Context 'When the Availability Group is Present and a value is passed to a parameter' {
-                It 'Should be "<Result>" when "<ParameterName>" is "<ParameterValue>", Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourcePropertyIncorrectTestCases {
+                It 'Should be "<Result>" when "<ParameterName>" is "<ParameterValue>", Name is "<Name>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourcePropertyIncorrectTestCases {
                     param
                     (
                         $Ensure,
@@ -1280,8 +1280,8 @@ try
                         $ParameterName,
                         $ParameterValue,
                         $Result,
-                        $ServerName,
-                        $InstanceName,
+                        $SQLServer,
+                        $SQLInstanceName,
                         $Version
                     )
 
@@ -1291,8 +1291,8 @@ try
                     $testTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        ServerName = $ServerName
-                        InstanceName = $InstanceName
+                        ServerName = $SQLServer
+                        InstanceName = $SQLInstanceName
                         $ParameterName = $ParameterValue
                     }
 
@@ -1316,7 +1316,7 @@ try
                     $mockAvailabilityGroupReplicaPropertiesServer2Original = $mockAvailabilityGroupReplicaProperties.Server2.Clone()
                 }
 
-                It 'Should be "<Result>" when "<EndpointPropertyName>" is "<EndpointPropertyValue>", Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourceEndpointIncorrectTestCases {
+                It 'Should be "<Result>" when "<EndpointPropertyName>" is "<EndpointPropertyValue>", Name is "<Name>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourceEndpointIncorrectTestCases {
                     param
                     (
                         $EndpointPropertyName,
@@ -1324,8 +1324,8 @@ try
                         $Ensure,
                         $Name,
                         $Result,
-                        $ServerName,
-                        $InstanceName,
+                        $SQLServer,
+                        $SQLInstanceName,
                         $Version
                     )
 
@@ -1338,8 +1338,8 @@ try
                     $testTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        ServerName = $ServerName
-                        InstanceName = $InstanceName
+                        ServerName = $SQLServer
+                        InstanceName = $SQLInstanceName
                     }
 
                     Test-TargetResource @testTargetResourceParameters | Should -Be $Result
@@ -1359,14 +1359,14 @@ try
                     $mockProcessOnlyOnActiveNode = $false
                 }
 
-                It 'Should be "true" when ProcessOnlyOnActiveNode is "<ProcessOnlyOnActiveNode>", Ensure is "<Ensure>", Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourceProcessOnlyOnActiveNodeTestCases {
+                It 'Should be "true" when ProcessOnlyOnActiveNode is "<ProcessOnlyOnActiveNode>", Ensure is "<Ensure>", Name is "<Name>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourceProcessOnlyOnActiveNodeTestCases {
                     param
                     (
                         $Ensure,
                         $Name,
                         $ProcessOnlyOnActiveNode,
-                        $ServerName,
-                        $InstanceName,
+                        $SQLServer,
+                        $SQLInstanceName,
                         $Version
                     )
 
@@ -1377,8 +1377,8 @@ try
                         Ensure = $Ensure
                         Name = $Name
                         ProcessOnlyOnActiveNode = $ProcessOnlyOnActiveNode
-                        ServerName = $ServerName
-                        InstanceName = $InstanceName
+                        ServerName = $SQLServer
+                        InstanceName = $SQLInstanceName
                     }
 
                     Test-TargetResource @testTargetResourceParameters | Should Be $true

--- a/Tests/Unit/MSFT_SqlAG.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAG.Tests.ps1
@@ -48,8 +48,8 @@ try
             RemoveAvailabilityGroupFailed = 'AvailabilityGroup3'
         }
 
-        # Define the values that could be passed into the SQLServer parameter
-        $mockSqlServerParameters = @{
+        # Define the values that could be passed into the ServerName parameter
+        $mockServerNameParameters = @{
             Server1 = @{
                 FQDN = 'Server1.contoso.com'
                 #IP = '192.168.1.1'
@@ -63,8 +63,8 @@ try
             }
         }
 
-        # Define the values that could be passed into the SQLInstanceName parameter
-        $mockSqlInstanceNameParameters = @(
+        # Define the values that could be passed into the InstanceName parameter
+        $mockInstanceNameParameters = @(
             'MSSQLSERVER',
             'NamedInstance'
         )
@@ -166,7 +166,7 @@ try
         ( Get-Command -Name Test-TargetResource ).Parameters.Values | Where-Object -FilterScript {
             (
                 # Ignore these specific parameters. These get tested enough.
-                @('Ensure', 'Name', 'SQLServer', 'SQLInstanceName', 'DtcSupportEnabled', 'ProcessOnlyOnActiveNode') -notcontains $_.Name
+                @('Ensure', 'Name', 'ServerName', 'InstanceName', 'DtcSupportEnabled', 'ProcessOnlyOnActiveNode') -notcontains $_.Name
             ) -and (
                 # Ignore the CmdletBinding parameters
                 $_.Attributes.TypeId.Name -notcontains 'AliasAttribute'
@@ -189,38 +189,38 @@ try
 
         foreach ( $majorVersionToTest in $majorVersionsToTest )
         {
-            foreach ( $mockSqlServer in $mockSqlServerParameters.GetEnumerator() )
+            foreach ( $mockServerName in $mockServerNameParameters.GetEnumerator() )
             {
                 # Determine with SQL Server mock will be used
-                $mockSqlServerToBeUsed = $mockSqlServer.Key
+                $mockServerNameToBeUsed = $mockServerName.Key
 
-                foreach ( $mockSqlServerParameter in $mockSqlServer.Value.Values )
+                foreach ( $mockServerNameParameter in $mockServerName.Value.Values )
                 {
-                    foreach ( $mockSqlInstanceNameParameter in $mockSqlInstanceNameParameters )
+                    foreach ( $mockInstanceNameParameter in $mockInstanceNameParameters )
                     {
                         # Build the domain instance name
-                        if ( $mockSqlInstanceNameParameter -eq 'MSSQLSERVER' )
+                        if ( $mockInstanceNameParameter -eq 'MSSQLSERVER' )
                         {
-                            $domainInstanceNameProperty = $mockSqlServerParameter
+                            $domainInstanceNameProperty = $mockServerNameParameter
                         }
                         else
                         {
-                            $domainInstanceNameProperty = '{0}\{1}' -f $mockSqlServerParameter,$mockSqlInstanceNameParameter
+                            $domainInstanceNameProperty = '{0}\{1}' -f $mockServerNameParameter,$mockInstanceNameParameter
                         }
 
-                        if ( $mockSqlServerToBeUsed -eq 'Server1' )
+                        if ( $mockServerNameToBeUsed -eq 'Server1' )
                         {
                             $getTargetResourceAbsentTestCases += @{
                                 Name = $mockNameParameters.AbsentAvailabilityGroup
-                                SQLServer = $mockSqlServerParameter
-                                SQLInstanceName = $mockSqlInstanceNameParameter
+                                ServerName = $mockServerNameParameter
+                                InstanceName = $mockInstanceNameParameter
                                 Version = $majorVersionToTest
                             }
 
                             $getTargetResourcePresentTestCases += @{
                                 Name = $mockNameParameters.PresentAvailabilityGroup
-                                SQLServer = $mockSqlServerParameter
-                                SQLInstanceName = $mockSqlInstanceNameParameter
+                                ServerName = $mockServerNameParameter
+                                InstanceName = $mockInstanceNameParameter
                                 Version = $majorVersionToTest
                             }
 
@@ -230,8 +230,8 @@ try
                                     ErrorResult = $createAvailabilityGroupFailureToTest.Value
                                     Ensure = 'Present'
                                     Name = $createAvailabilityGroupFailureToTest.Key
-                                    SQLServer = $mockSqlServerParameter
-                                    SQLInstanceName = $mockSqlInstanceNameParameter
+                                    ServerName = $mockServerNameParameter
+                                    InstanceName = $mockInstanceNameParameter
                                     Version = $majorVersionToTest
                                 }
                             }
@@ -240,8 +240,8 @@ try
                                 Ensure = 'Present'
                                 Name = $mockNameParameters.AbsentAvailabilityGroup
                                 Result = 'DatabaseMirroringEndpointNotFound'
-                                SQLServer = $mockSqlServerParameter
-                                SQLInstanceName = $mockSqlInstanceNameParameter
+                                ServerName = $mockServerNameParameter
+                                InstanceName = $mockInstanceNameParameter
                                 Version = $majorVersionToTest
                             }
 
@@ -249,21 +249,21 @@ try
                                 Ensure = 'Present'
                                 Name = $mockNameParameters.AbsentAvailabilityGroup
                                 Result = 'HadrNotEnabled'
-                                SQLServer = $mockSqlServerParameter
-                                SQLInstanceName = $mockSqlInstanceNameParameter
+                                ServerName = $mockServerNameParameter
+                                InstanceName = $mockInstanceNameParameter
                                 Version = $majorVersionToTest
                             }
 
                             $setTargetResourceRemoveAvailabilityGroupTestCases += @{
                                 Ensure = 'Absent'
                                 Name = $mockNameParameters.PresentAvailabilityGroup
-                                SQLServer = $mockSqlServerParameter
-                                SQLInstanceName = $mockSqlInstanceNameParameter
+                                ServerName = $mockServerNameParameter
+                                InstanceName = $mockInstanceNameParameter
                                 Version = $majorVersionToTest
                             }
                         }
 
-                        switch ( $mockSqlServerToBeUsed )
+                        switch ( $mockServerNameToBeUsed )
                         {
                             'Server1'
                             {
@@ -282,8 +282,8 @@ try
                             ErrorResult = $setTargetResourceRemoveAvailabilityGroupErrorTestCaseErrorResult
                             Ensure = 'Absent'
                             Name = $setTargetResourceRemoveAvailabilityGroupErrorTestCaseName
-                            SQLServer = $mockSqlServerParameter
-                            SQLInstanceName = $mockSqlInstanceNameParameter
+                            ServerName = $mockServerNameParameter
+                            InstanceName = $mockInstanceNameParameter
                             Version = $majorVersionToTest
                         }
 
@@ -293,8 +293,8 @@ try
                                 Ensure = 'Present'
                                 Name = $mockNameParameters.PresentAvailabilityGroup
                                 ProcessOnlyOnActiveNode = $processOnlyOnActiveNode
-                                SQLServer = $mockSqlServerParameter
-                                SQLInstanceName = $mockSqlInstanceNameParameter
+                                ServerName = $mockServerNameParameter
+                                InstanceName = $mockInstanceNameParameter
                                 Version = $majorVersionToTest
                             }
                         }
@@ -306,8 +306,8 @@ try
                                 Ensure = $ensureCaseToTest
                                 Name = $mockNameParameters.AbsentAvailabilityGroup
                                 Result = ( $ensureCaseToTest -eq 'Absent' )
-                                SQLServer = $mockSqlServerParameter
-                                SQLInstanceName = $mockSqlInstanceNameParameter
+                                ServerName = $mockServerNameParameter
+                                InstanceName = $mockInstanceNameParameter
                                 Version = $majorVersionToTest
                             }
 
@@ -315,8 +315,8 @@ try
                                 Ensure = $ensureCaseToTest
                                 Name = $mockNameParameters.PresentAvailabilityGroup
                                 Result = ( $ensureCaseToTest -eq 'Present' )
-                                SQLServer = $mockSqlServerParameter
-                                SQLInstanceName = $mockSqlInstanceNameParameter
+                                ServerName = $mockServerNameParameter
+                                InstanceName = $mockInstanceNameParameter
                                 Version = $majorVersionToTest
                             }
                         }
@@ -371,7 +371,7 @@ try
                                 }
                             }
 
-                            if ( $mockSqlServerToBeUsed -eq 'Server1' )
+                            if ( $mockServerNameToBeUsed -eq 'Server1' )
                             {
                                 $setTargetResourceCreateAvailabilityGroupWithParameterTestCases += @{
                                     DomainInstanceName = $domainInstanceNameProperty
@@ -379,8 +379,8 @@ try
                                     Name = $mockNameParameters.AbsentAvailabilityGroup
                                     ParameterName = $resourceParameter.Key
                                     ParameterValue = $testCaseParameterValue
-                                    SQLServer = $mockSqlServerParameter
-                                    SQLInstanceName = $mockSqlInstanceNameParameter
+                                    ServerName = $mockServerNameParameter
+                                    InstanceName = $mockInstanceNameParameter
                                     Version = $majorVersionToTest
                                 }
                             }
@@ -391,8 +391,8 @@ try
                                 ParameterName = $resourceParameter.Key
                                 ParameterValue = $testCaseParameterValue
                                 Result = $false
-                                SQLServer = $mockSqlServerParameter
-                                SQLInstanceName = $mockSqlInstanceNameParameter
+                                ServerName = $mockServerNameParameter
+                                InstanceName = $mockInstanceNameParameter
                                 Version = $majorVersionToTest
                             }
 
@@ -402,8 +402,8 @@ try
                                 ParameterName = $resourceParameter.Key
                                 ParameterValue = $testCaseParameterValue
                                 Result = $false
-                                SQLServer = $mockSqlServerParameter
-                                SQLInstanceName = $mockSqlInstanceNameParameter
+                                ServerName = $mockServerNameParameter
+                                InstanceName = $mockInstanceNameParameter
                                 Version = $majorVersionToTest
                             }
                         }
@@ -430,8 +430,8 @@ try
                                 EndpointPropertyValue = $endpointPropertyValue
                                 Ensure = 'Present'
                                 Name = $mockNameParameters.PresentAvailabilityGroup
-                                SQLServer = $mockSqlServerParameter
-                                SQLInstanceName = $mockSqlInstanceNameParameter
+                                ServerName = $mockServerNameParameter
+                                InstanceName = $mockInstanceNameParameter
                                 Version = $majorVersionToTest
                             }
 
@@ -441,8 +441,8 @@ try
                                 Ensure = 'Present'
                                 Name = $mockNameParameters.PresentAvailabilityGroup
                                 Result = $false
-                                SQLServer = $mockSqlServerParameter
-                                SQLInstanceName = $mockSqlInstanceNameParameter
+                                ServerName = $mockServerNameParameter
+                                InstanceName = $mockInstanceNameParameter
                                 Version = $majorVersionToTest
                             }
                         }
@@ -479,16 +479,16 @@ try
             # If this mock function is called from the Get-PrimaryReplicaServerObject command mock
             if ( [string]::IsNullOrEmpty($SQLServer) -and [string]::IsNullOrEmpty($SQLInstanceName) -and $AvailabilityGroup -and $ServerObject )
             {
-                $SQLServer,$SQLInstanceName = $AvailabilityGroup.PrimaryReplicaServerName.Split('\')
+                $SQLServer,$InstanceName = $AvailabilityGroup.PrimaryReplicaServerName.Split('\')
             }
 
             # Determine which SQL Server mock data we will use
-            $mockSqlServer = ( $mockSqlServerParameters.GetEnumerator() | Where-Object -FilterScript { $_.Value.Values -contains $SQLServer } ).Name
-            if ( [string]::IsNullOrEmpty($mockSqlServer) )
+            $mockServerName = ( $mockServerNameParameters.GetEnumerator() | Where-Object -FilterScript { $_.Value.Values -contains $SQLServer } ).Name
+            if ( [string]::IsNullOrEmpty($mockServerName) )
             {
-                $mockSqlServer = $SQLServer
+                $mockServerName = $SQLServer
             }
-            $mockCurrentServerObjectProperties = $mockServerObjectProperies.$mockSqlServer
+            $mockCurrentServerObjectProperties = $mockServerObjectProperies.$mockServerName
 
             # Build the domain instance name
             if ( ( $SQLInstanceName -eq 'MSSQLSERVER' ) -or [string]::IsNullOrEmpty($SQLInstanceName) )
@@ -688,12 +688,12 @@ try
 
             Context 'When the Availability Group is Absent' {
 
-                It 'Should not return an Availability Group when Name is "<Name>", SQLServer is "<SQLServer>", SQLInstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $getTargetResourceAbsentTestCases {
+                It 'Should not return an Availability Group when Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $getTargetResourceAbsentTestCases {
                     param
                     (
                         $Name,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -702,8 +702,8 @@ try
 
                     $getTargetResourceParameters = @{
                         Name = $Name
-                        SQLServer = $SQLServer
-                        SQLInstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                     }
 
                     $result = Get-TargetResource @getTargetResourceParameters
@@ -715,12 +715,12 @@ try
             }
 
             Context 'When the Availability Group is Present' {
-                It 'Should return the correct Availability Group properties when Name is "<Name>", SQLServer is "<SQLServer>", SQLInstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $getTargetResourcePresentTestCases {
+                It 'Should return the correct Availability Group properties when Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $getTargetResourcePresentTestCases {
                     param
                     (
                         $Name,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -729,27 +729,27 @@ try
 
                     $getTargetResourceParameters = @{
                         Name = $Name
-                        SQLServer = $SQLServer
-                        SQLInstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                     }
 
                     # Determine which SQL Server mock data will be used
-                    $mockSqlServer = ( $mockSqlServerParameters.GetEnumerator() | Where-Object -FilterScript { $_.Value.Values -contains $SQLServer } ).Name
+                    $mockServerName = ( $mockServerNameParameters.GetEnumerator() | Where-Object -FilterScript { $_.Value.Values -contains $ServerName } ).Name
 
                     $result = Get-TargetResource @getTargetResourceParameters
 
                     $result.Name | Should -Be $Name
-                    $result.SQLServer | Should -Be $SQLServer
-                    $result.SQLInstanceName | Should -Be $SQLInstanceName
+                    $result.ServerName | Should -Be $ServerName
+                    $result.InstanceName | Should -Be $InstanceName
                     $result.Ensure | Should -Be 'Present'
                     $result.AutomatedBackupPreference | Should -Be $mockAvailabilityGroupProperties.AutomatedBackupPreference
-                    $result.AvailabilityMode | Should -Be $mockAvailabilityGroupReplicaProperties.$mockSqlServer.AvailabilityMode
-                    $result.BackupPriority | Should -Be $mockAvailabilityGroupReplicaProperties.$mockSqlServer.BackupPriority
-                    $result.ConnectionModeInPrimaryRole | Should -Be $mockAvailabilityGroupReplicaProperties.$mockSqlServer.ConnectionModeInPrimaryRole
-                    $result.ConnectionModeInSecondaryRole | Should -Be $mockAvailabilityGroupReplicaProperties.$mockSqlServer.ConnectionModeInSecondaryRole
-                    $result.EndpointURL | Should -Be "$($mockAvailabilityGroupReplicaProperties.$mockSqlServer.EndpointProtocol)://$($mockAvailabilityGroupReplicaProperties.$mockSqlServer.EndpointHostName):$($mockAvailabilityGroupReplicaProperties.$mockSqlServer.EndpointPort)"
+                    $result.AvailabilityMode | Should -Be $mockAvailabilityGroupReplicaProperties.$mockServerName.AvailabilityMode
+                    $result.BackupPriority | Should -Be $mockAvailabilityGroupReplicaProperties.$mockServerName.BackupPriority
+                    $result.ConnectionModeInPrimaryRole | Should -Be $mockAvailabilityGroupReplicaProperties.$mockServerName.ConnectionModeInPrimaryRole
+                    $result.ConnectionModeInSecondaryRole | Should -Be $mockAvailabilityGroupReplicaProperties.$mockServerName.ConnectionModeInSecondaryRole
+                    $result.EndpointURL | Should -Be "$($mockAvailabilityGroupReplicaProperties.$mockServerName.EndpointProtocol)://$($mockAvailabilityGroupReplicaProperties.$mockServerName.EndpointHostName):$($mockAvailabilityGroupReplicaProperties.$mockServerName.EndpointPort)"
                     $result.FailureConditionLevel | Should -Be $mockAvailabilityGroupProperties.FailureConditionLevel
-                    $result.FailoverMode | Should -Be $mockAvailabilityGroupReplicaProperties.$mockSqlServer.FailoverMode
+                    $result.FailoverMode | Should -Be $mockAvailabilityGroupReplicaProperties.$mockServerName.FailoverMode
                     $result.HealthCheckTimeout | Should -Be $mockAvailabilityGroupProperties.HealthCheckTimeout
 
                     if ( $Version -ge 13 )
@@ -794,7 +794,7 @@ try
             }
 
             Context 'When the Availability Group is Absent and the desired state is Present and a parameter is supplied' {
-                It 'Should create the availability group "<Name>" with the parameter "<ParameterName>" set to "<ParameterValue>" when Ensure is "<Ensure>", SQLServer is "<SQLServer>", SQLInstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceCreateAvailabilityGroupWithParameterTestCases {
+                It 'Should create the availability group "<Name>" with the parameter "<ParameterName>" set to "<ParameterValue>" when Ensure is "<Ensure>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceCreateAvailabilityGroupWithParameterTestCases {
                     param
                     (
                         $DomainInstanceName,
@@ -802,8 +802,8 @@ try
                         $Name,
                         $ParameterName,
                         $ParameterValue,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -813,8 +813,8 @@ try
                     $setTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        SQLServer = $SQLServer
-                        SQLInstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                         $ParameterName = $ParameterValue
                     }
 
@@ -839,14 +839,14 @@ try
             }
 
             Context 'When the Availability Group is Absent, the desired state is Present, and creating the Availability Group fails' {
-                It 'Should throw "<ErrorResult>" when creating the availability group "<Name>" fails, Ensure is "<Ensure>", SQLServer is "<SQLServer>", SQLInstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceCreateAvailabilityGroupFailedTestCases {
+                It 'Should throw "<ErrorResult>" when creating the availability group "<Name>" fails, Ensure is "<Ensure>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceCreateAvailabilityGroupFailedTestCases {
                     param
                     (
                         $ErrorResult,
                         $Ensure,
                         $Name,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -869,8 +869,8 @@ try
                     $setTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        SQLServer = $SQLServer
-                        SQLInstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                     }
 
                     { Set-TargetResource @setTargetResourceParameters } | Should -Throw "$($ErrorResult)"
@@ -894,7 +894,7 @@ try
             }
 
             Context 'When the Availability Group is Present and a value is passed to a parameter' {
-                It 'Should set "<ParameterName>" to "<ParameterValue>" when Name is "<Name>", SQLServer is "<SQLServer>", SQLInstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourcePropertyIncorrectTestCases {
+                It 'Should set "<ParameterName>" to "<ParameterValue>" when Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourcePropertyIncorrectTestCases {
                     param
                     (
                         $Ensure,
@@ -902,8 +902,8 @@ try
                         $ParameterName,
                         $ParameterValue,
                         $Result,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -913,8 +913,8 @@ try
                     $setTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        SQLServer = $SQLServer
-                        SQLInstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                         $ParameterName = $ParameterValue
                     }
 
@@ -951,13 +951,13 @@ try
             }
 
             Context 'When the Availability Group is Present and the desired state is Absent' {
-                It 'Should remove the Availability Group "<Name>" when Ensure is "<Ensure>", SQLServer is "<SQLServer>", SQLInstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceRemoveAvailabilityGroupTestCases {
+                It 'Should remove the Availability Group "<Name>" when Ensure is "<Ensure>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceRemoveAvailabilityGroupTestCases {
                     param
                     (
                         $Ensure,
                         $Name,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -967,8 +967,8 @@ try
                     $setTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        SQLServer = $SQLServer
-                        SQLInstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                     }
 
                     { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
@@ -992,14 +992,14 @@ try
             }
 
             Context 'When the Availability Group is Present and throws an error when removal is attempted' {
-                It 'Should throw "<ErrorResult>" when Ensure is "<Ensure>", Name is "<Name>", SQLServer is "<SQLServer>", SQLInstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceRemoveAvailabilityGroupErrorTestCases {
+                It 'Should throw "<ErrorResult>" when Ensure is "<Ensure>", Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceRemoveAvailabilityGroupErrorTestCases {
                     param
                     (
                         $ErrorResult,
                         $Ensure,
                         $Name,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -1022,8 +1022,8 @@ try
                     $setTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        SQLServer = $SQLServer
-                        SQLInstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                     }
 
                     { Set-TargetResource @setTargetResourceParameters } | Should -Throw "$($ErrorResult)"
@@ -1055,14 +1055,14 @@ try
                     $mockIsHadrEnabled = $false
                 }
 
-                It 'Should throw "<Result>" when Ensure is "<Ensure>", Name is "<Name>", SQLServer is "<SQLServer>", SQLInstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceHadrDisabledTestCases {
+                It 'Should throw "<Result>" when Ensure is "<Ensure>", Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceHadrDisabledTestCases {
                     param
                     (
                         $Ensure,
                         $Name,
                         $Result,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -1072,8 +1072,8 @@ try
                     $setTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        SQLServer = $SQLServer
-                        SQLInstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                     }
 
                     { Set-TargetResource @setTargetResourceParameters } | Should -Throw $Result
@@ -1105,14 +1105,14 @@ try
                     $mockIsDatabaseMirroringEndpointPresent = $false
                 }
 
-                It 'Should throw "<Result>" when Ensure is "<Ensure>", Name is "<Name>", SQLServer is "<SQLServer>", SQLInstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceEndpointMissingTestCases {
+                It 'Should throw "<Result>" when Ensure is "<Ensure>", Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceEndpointMissingTestCases {
                     param
                     (
                         $Ensure,
                         $Name,
                         $Result,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -1122,8 +1122,8 @@ try
                     $setTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        SQLServer = $SQLServer
-                        SQLInstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                     }
 
                     { Set-TargetResource @setTargetResourceParameters } | Should -Throw $Result
@@ -1159,15 +1159,15 @@ try
                     $mockAvailabilityGroupReplicaPropertiesServer2Original = $mockAvailabilityGroupReplicaProperties.Server2.Clone()
                 }
 
-                It 'Should set "<EndpointPropertyName>" to "<EndpointPropertyValue>" when Name is "<Name>", SQLServer is "<SQLServer>", SQLInstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourcesEndpointUrlTestCases {
+                It 'Should set "<EndpointPropertyName>" to "<EndpointPropertyValue>" when Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourcesEndpointUrlTestCases {
                     param
                     (
                         $EndpointPropertyName,
                         $EndpointPropertyValue,
                         $Ensure,
                         $Name,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -1180,8 +1180,8 @@ try
                     $setTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        SQLServer = $SQLServer
-                        SQLInstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                     }
 
                     { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
@@ -1214,14 +1214,14 @@ try
             }
 
             Context 'When the Availability Group is Absent' {
-                It 'Should be "<Result>" when Ensure is "<Ensure>", Name is "<Name>", SQLServer is "<SQLServer>", SQLInstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourceAbsentTestCases {
+                It 'Should be "<Result>" when Ensure is "<Ensure>", Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourceAbsentTestCases {
                     param
                     (
                         $Ensure,
                         $Name,
                         $Result,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -1231,8 +1231,8 @@ try
                     $testTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        SQLServer = $SQLServer
-                        SQLInstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                     }
 
                     Test-TargetResource @testTargetResourceParameters | Should -Be $Result
@@ -1243,14 +1243,14 @@ try
             }
 
             Context 'When the Availability Group is Present and the default parameters are passed' {
-                It 'Should be "<Result>" when Ensure is "<Ensure>", Name is "<Name>", SQLServer is "<SQLServer>", SQLInstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourcePresentTestCases {
+                It 'Should be "<Result>" when Ensure is "<Ensure>", Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourcePresentTestCases {
                     param
                     (
                         $Ensure,
                         $Name,
                         $Result,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -1260,8 +1260,8 @@ try
                     $testTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        SQLServer = $SQLServer
-                        SQLInstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                     }
 
                     Test-TargetResource @testTargetResourceParameters | Should -Be $Result
@@ -1272,7 +1272,7 @@ try
             }
 
             Context 'When the Availability Group is Present and a value is passed to a parameter' {
-                It 'Should be "<Result>" when "<ParameterName>" is "<ParameterValue>", Name is "<Name>", SQLServer is "<SQLServer>", SQLInstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourcePropertyIncorrectTestCases {
+                It 'Should be "<Result>" when "<ParameterName>" is "<ParameterValue>", Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourcePropertyIncorrectTestCases {
                     param
                     (
                         $Ensure,
@@ -1280,8 +1280,8 @@ try
                         $ParameterName,
                         $ParameterValue,
                         $Result,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -1291,8 +1291,8 @@ try
                     $testTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        SQLServer = $SQLServer
-                        SQLInstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                         $ParameterName = $ParameterValue
                     }
 
@@ -1316,7 +1316,7 @@ try
                     $mockAvailabilityGroupReplicaPropertiesServer2Original = $mockAvailabilityGroupReplicaProperties.Server2.Clone()
                 }
 
-                It 'Should be "<Result>" when "<EndpointPropertyName>" is "<EndpointPropertyValue>", Name is "<Name>", SQLServer is "<SQLServer>", SQLInstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourceEndpointIncorrectTestCases {
+                It 'Should be "<Result>" when "<EndpointPropertyName>" is "<EndpointPropertyValue>", Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourceEndpointIncorrectTestCases {
                     param
                     (
                         $EndpointPropertyName,
@@ -1324,8 +1324,8 @@ try
                         $Ensure,
                         $Name,
                         $Result,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -1338,8 +1338,8 @@ try
                     $testTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        SQLServer = $SQLServer
-                        SQLInstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                     }
 
                     Test-TargetResource @testTargetResourceParameters | Should -Be $Result
@@ -1359,14 +1359,14 @@ try
                     $mockProcessOnlyOnActiveNode = $false
                 }
 
-                It 'Should be "true" when ProcessOnlyOnActiveNode is "<ProcessOnlyOnActiveNode>", Ensure is "<Ensure>", Name is "<Name>", SQLServer is "<SQLServer>", SQLInstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourceProcessOnlyOnActiveNodeTestCases {
+                It 'Should be "true" when ProcessOnlyOnActiveNode is "<ProcessOnlyOnActiveNode>", Ensure is "<Ensure>", Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourceProcessOnlyOnActiveNodeTestCases {
                     param
                     (
                         $Ensure,
                         $Name,
                         $ProcessOnlyOnActiveNode,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -1377,8 +1377,8 @@ try
                         Ensure = $Ensure
                         Name = $Name
                         ProcessOnlyOnActiveNode = $ProcessOnlyOnActiveNode
-                        SQLServer = $SQLServer
-                        SQLInstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                     }
 
                     Test-TargetResource @testTargetResourceParameters | Should Be $true

--- a/Tests/Unit/MSFT_SqlAG.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAG.Tests.ps1
@@ -688,12 +688,12 @@ try
 
             Context 'When the Availability Group is Absent' {
 
-                It 'Should not return an Availability Group when Name is "<Name>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $getTargetResourceAbsentTestCases {
+                It 'Should not return an Availability Group when Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $getTargetResourceAbsentTestCases {
                     param
                     (
                         $Name,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -702,8 +702,8 @@ try
 
                     $getTargetResourceParameters = @{
                         Name = $Name
-                        ServerName = $SQLServer
-                        InstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                     }
 
                     $result = Get-TargetResource @getTargetResourceParameters
@@ -715,12 +715,12 @@ try
             }
 
             Context 'When the Availability Group is Present' {
-                It 'Should return the correct Availability Group properties when Name is "<Name>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $getTargetResourcePresentTestCases {
+                It 'Should return the correct Availability Group properties when Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $getTargetResourcePresentTestCases {
                     param
                     (
                         $Name,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -729,18 +729,18 @@ try
 
                     $getTargetResourceParameters = @{
                         Name = $Name
-                        ServerName = $SQLServer
-                        InstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                     }
 
                     # Determine which SQL Server mock data will be used
-                    $mockSqlServer = ( $mockSqlServerParameters.GetEnumerator() | Where-Object -FilterScript { $_.Value.Values -contains $SQLServer } ).Name
+                    $mockSqlServer = ( $mockSqlServerParameters.GetEnumerator() | Where-Object -FilterScript { $_.Value.Values -contains $ServerName } ).Name
 
                     $result = Get-TargetResource @getTargetResourceParameters
 
                     $result.Name | Should -Be $Name
-                    $result.ServerName | Should -Be $SQLServer
-                    $result.InstanceName | Should -Be $SQLInstanceName
+                    $result.ServerName | Should -Be $ServerName
+                    $result.InstanceName | Should -Be $InstanceName
                     $result.Ensure | Should -Be 'Present'
                     $result.AutomatedBackupPreference | Should -Be $mockAvailabilityGroupProperties.AutomatedBackupPreference
                     $result.AvailabilityMode | Should -Be $mockAvailabilityGroupReplicaProperties.$mockSqlServer.AvailabilityMode
@@ -794,7 +794,7 @@ try
             }
 
             Context 'When the Availability Group is Absent and the desired state is Present and a parameter is supplied' {
-                It 'Should create the availability group "<Name>" with the parameter "<ParameterName>" set to "<ParameterValue>" when Ensure is "<Ensure>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceCreateAvailabilityGroupWithParameterTestCases {
+                It 'Should create the availability group "<Name>" with the parameter "<ParameterName>" set to "<ParameterValue>" when Ensure is "<Ensure>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceCreateAvailabilityGroupWithParameterTestCases {
                     param
                     (
                         $DomainInstanceName,
@@ -802,8 +802,8 @@ try
                         $Name,
                         $ParameterName,
                         $ParameterValue,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -813,8 +813,8 @@ try
                     $setTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        ServerName = $SQLServer
-                        InstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                         $ParameterName = $ParameterValue
                     }
 
@@ -839,14 +839,14 @@ try
             }
 
             Context 'When the Availability Group is Absent, the desired state is Present, and creating the Availability Group fails' {
-                It 'Should throw "<ErrorResult>" when creating the availability group "<Name>" fails, Ensure is "<Ensure>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceCreateAvailabilityGroupFailedTestCases {
+                It 'Should throw "<ErrorResult>" when creating the availability group "<Name>" fails, Ensure is "<Ensure>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceCreateAvailabilityGroupFailedTestCases {
                     param
                     (
                         $ErrorResult,
                         $Ensure,
                         $Name,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -869,8 +869,8 @@ try
                     $setTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        ServerName = $SQLServer
-                        InstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                     }
 
                     { Set-TargetResource @setTargetResourceParameters } | Should -Throw "$($ErrorResult)"
@@ -894,7 +894,7 @@ try
             }
 
             Context 'When the Availability Group is Present and a value is passed to a parameter' {
-                It 'Should set "<ParameterName>" to "<ParameterValue>" when Name is "<Name>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourcePropertyIncorrectTestCases {
+                It 'Should set "<ParameterName>" to "<ParameterValue>" when Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourcePropertyIncorrectTestCases {
                     param
                     (
                         $Ensure,
@@ -902,8 +902,8 @@ try
                         $ParameterName,
                         $ParameterValue,
                         $Result,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -913,8 +913,8 @@ try
                     $setTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        ServerName = $SQLServer
-                        InstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                         $ParameterName = $ParameterValue
                     }
 
@@ -951,13 +951,13 @@ try
             }
 
             Context 'When the Availability Group is Present and the desired state is Absent' {
-                It 'Should remove the Availability Group "<Name>" when Ensure is "<Ensure>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceRemoveAvailabilityGroupTestCases {
+                It 'Should remove the Availability Group "<Name>" when Ensure is "<Ensure>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceRemoveAvailabilityGroupTestCases {
                     param
                     (
                         $Ensure,
                         $Name,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -967,8 +967,8 @@ try
                     $setTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        ServerName = $SQLServer
-                        InstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                     }
 
                     { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
@@ -992,14 +992,14 @@ try
             }
 
             Context 'When the Availability Group is Present and throws an error when removal is attempted' {
-                It 'Should throw "<ErrorResult>" when Ensure is "<Ensure>", Name is "<Name>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceRemoveAvailabilityGroupErrorTestCases {
+                It 'Should throw "<ErrorResult>" when Ensure is "<Ensure>", Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceRemoveAvailabilityGroupErrorTestCases {
                     param
                     (
                         $ErrorResult,
                         $Ensure,
                         $Name,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -1022,8 +1022,8 @@ try
                     $setTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        ServerName = $SQLServer
-                        InstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                     }
 
                     { Set-TargetResource @setTargetResourceParameters } | Should -Throw "$($ErrorResult)"
@@ -1055,14 +1055,14 @@ try
                     $mockIsHadrEnabled = $false
                 }
 
-                It 'Should throw "<Result>" when Ensure is "<Ensure>", Name is "<Name>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceHadrDisabledTestCases {
+                It 'Should throw "<Result>" when Ensure is "<Ensure>", Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceHadrDisabledTestCases {
                     param
                     (
                         $Ensure,
                         $Name,
                         $Result,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -1072,8 +1072,8 @@ try
                     $setTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        ServerName = $SQLServer
-                        InstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                     }
 
                     { Set-TargetResource @setTargetResourceParameters } | Should -Throw $Result
@@ -1105,14 +1105,14 @@ try
                     $mockIsDatabaseMirroringEndpointPresent = $false
                 }
 
-                It 'Should throw "<Result>" when Ensure is "<Ensure>", Name is "<Name>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceEndpointMissingTestCases {
+                It 'Should throw "<Result>" when Ensure is "<Ensure>", Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourceEndpointMissingTestCases {
                     param
                     (
                         $Ensure,
                         $Name,
                         $Result,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -1122,8 +1122,8 @@ try
                     $setTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        ServerName = $SQLServer
-                        InstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                     }
 
                     { Set-TargetResource @setTargetResourceParameters } | Should -Throw $Result
@@ -1159,15 +1159,15 @@ try
                     $mockAvailabilityGroupReplicaPropertiesServer2Original = $mockAvailabilityGroupReplicaProperties.Server2.Clone()
                 }
 
-                It 'Should set "<EndpointPropertyName>" to "<EndpointPropertyValue>" when Name is "<Name>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourcesEndpointUrlTestCases {
+                It 'Should set "<EndpointPropertyName>" to "<EndpointPropertyValue>" when Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $setTargetResourcesEndpointUrlTestCases {
                     param
                     (
                         $EndpointPropertyName,
                         $EndpointPropertyValue,
                         $Ensure,
                         $Name,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -1180,8 +1180,8 @@ try
                     $setTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        ServerName = $SQLServer
-                        InstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                     }
 
                     { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
@@ -1214,14 +1214,14 @@ try
             }
 
             Context 'When the Availability Group is Absent' {
-                It 'Should be "<Result>" when Ensure is "<Ensure>", Name is "<Name>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourceAbsentTestCases {
+                It 'Should be "<Result>" when Ensure is "<Ensure>", Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourceAbsentTestCases {
                     param
                     (
                         $Ensure,
                         $Name,
                         $Result,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -1231,8 +1231,8 @@ try
                     $testTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        ServerName = $SQLServer
-                        InstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                     }
 
                     Test-TargetResource @testTargetResourceParameters | Should -Be $Result
@@ -1243,14 +1243,14 @@ try
             }
 
             Context 'When the Availability Group is Present and the default parameters are passed' {
-                It 'Should be "<Result>" when Ensure is "<Ensure>", Name is "<Name>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourcePresentTestCases {
+                It 'Should be "<Result>" when Ensure is "<Ensure>", Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourcePresentTestCases {
                     param
                     (
                         $Ensure,
                         $Name,
                         $Result,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -1260,8 +1260,8 @@ try
                     $testTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        ServerName = $SQLServer
-                        InstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                     }
 
                     Test-TargetResource @testTargetResourceParameters | Should -Be $Result
@@ -1272,7 +1272,7 @@ try
             }
 
             Context 'When the Availability Group is Present and a value is passed to a parameter' {
-                It 'Should be "<Result>" when "<ParameterName>" is "<ParameterValue>", Name is "<Name>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourcePropertyIncorrectTestCases {
+                It 'Should be "<Result>" when "<ParameterName>" is "<ParameterValue>", Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourcePropertyIncorrectTestCases {
                     param
                     (
                         $Ensure,
@@ -1280,8 +1280,8 @@ try
                         $ParameterName,
                         $ParameterValue,
                         $Result,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -1291,8 +1291,8 @@ try
                     $testTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        ServerName = $SQLServer
-                        InstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                         $ParameterName = $ParameterValue
                     }
 
@@ -1316,7 +1316,7 @@ try
                     $mockAvailabilityGroupReplicaPropertiesServer2Original = $mockAvailabilityGroupReplicaProperties.Server2.Clone()
                 }
 
-                It 'Should be "<Result>" when "<EndpointPropertyName>" is "<EndpointPropertyValue>", Name is "<Name>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourceEndpointIncorrectTestCases {
+                It 'Should be "<Result>" when "<EndpointPropertyName>" is "<EndpointPropertyValue>", Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourceEndpointIncorrectTestCases {
                     param
                     (
                         $EndpointPropertyName,
@@ -1324,8 +1324,8 @@ try
                         $Ensure,
                         $Name,
                         $Result,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -1338,8 +1338,8 @@ try
                     $testTargetResourceParameters = @{
                         Ensure = $Ensure
                         Name = $Name
-                        ServerName = $SQLServer
-                        InstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                     }
 
                     Test-TargetResource @testTargetResourceParameters | Should -Be $Result
@@ -1359,14 +1359,14 @@ try
                     $mockProcessOnlyOnActiveNode = $false
                 }
 
-                It 'Should be "true" when ProcessOnlyOnActiveNode is "<ProcessOnlyOnActiveNode>", Ensure is "<Ensure>", Name is "<Name>", ServerName is "<SQLServer>", InstanceName is "<SQLInstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourceProcessOnlyOnActiveNodeTestCases {
+                It 'Should be "true" when ProcessOnlyOnActiveNode is "<ProcessOnlyOnActiveNode>", Ensure is "<Ensure>", Name is "<Name>", ServerName is "<ServerName>", InstanceName is "<InstanceName>", and the SQL version is "<Version>"' -TestCases $testTargetResourceProcessOnlyOnActiveNodeTestCases {
                     param
                     (
                         $Ensure,
                         $Name,
                         $ProcessOnlyOnActiveNode,
-                        $SQLServer,
-                        $SQLInstanceName,
+                        $ServerName,
+                        $InstanceName,
                         $Version
                     )
 
@@ -1377,8 +1377,8 @@ try
                         Ensure = $Ensure
                         Name = $Name
                         ProcessOnlyOnActiveNode = $ProcessOnlyOnActiveNode
-                        ServerName = $SQLServer
-                        InstanceName = $SQLInstanceName
+                        ServerName = $ServerName
+                        InstanceName = $InstanceName
                     }
 
                     Test-TargetResource @testTargetResourceParameters | Should Be $true

--- a/Tests/Unit/MSFT_SqlAGDatabase.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAGDatabase.Tests.ps1
@@ -363,8 +363,8 @@ WITH NORECOVERY'
             BeforeEach {
                 $getTargetResourceParameters = @{
                     DatabaseName = $mockDatabaseNameParameter.Clone()
-                    SqlServer = 'Server1'
-                    SQLInstanceName = 'MSSQLSERVER'
+                    ServerName = 'Server1'
+                    InstanceName = 'MSSQLSERVER'
                     AvailabilityGroupName = 'AvailabilityGroup1'
                     BackupPath = $($mockBackupPath)
                 }
@@ -376,8 +376,8 @@ WITH NORECOVERY'
 
                     $result = Get-TargetResource @getTargetResourceParameters
 
-                    $result.SqlServer | Should -Be $getTargetResourceParameters.SqlServer
-                    $result.SQLInstanceName | Should -Be $getTargetResourceParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $getTargetResourceParameters.ServerName
+                    $result.InstanceName | Should -Be $getTargetResourceParameters.InstanceName
                     $result.AvailabilityGroupName | Should -BeNullOrEmpty
                     $result.DatabaseName | Should -BeNullOrEmpty
 
@@ -390,8 +390,8 @@ WITH NORECOVERY'
 
                     $result = Get-TargetResource @getTargetResourceParameters
 
-                    $result.SqlServer | Should -Be $getTargetResourceParameters.SqlServer
-                    $result.SQLInstanceName | Should -Be $getTargetResourceParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $getTargetResourceParameters.ServerName
+                    $result.InstanceName | Should -Be $getTargetResourceParameters.InstanceName
                     $result.AvailabilityGroupName | Should -Be $mockAvailabilityGroupWithoutDatabasesObject.Name
                     $result.DatabaseName | Should -BeNullOrEmpty
 
@@ -402,8 +402,8 @@ WITH NORECOVERY'
                 It 'Should return databases when there are databases in the availability group' {
                     $result = Get-TargetResource @getTargetResourceParameters
 
-                    $result.SqlServer | Should -Be $getTargetResourceParameters.SqlServer
-                    $result.SQLInstanceName | Should -Be $getTargetResourceParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $getTargetResourceParameters.ServerName
+                    $result.InstanceName | Should -Be $getTargetResourceParameters.InstanceName
                     $result.AvailabilityGroupName | Should -Be $mockAvailabilityGroupObject.Name
 
                     foreach ( $resultDatabaseName in $result.DatabaseName )
@@ -439,8 +439,8 @@ WITH NORECOVERY'
             BeforeEach {
                 $mockSetTargetResourceParameters = @{
                     DatabaseName = $($mockDatabaseNameParameter)
-                    SQLServer = $($mockServerObject.DomainInstanceName)
-                    SQLInstanceName = $('MSSQLSERVER')
+                    ServerName = $($mockServerObject.DomainInstanceName)
+                    InstanceName = $('MSSQLSERVER')
                     AvailabilityGroupName = $($mockAvailabilityGroupObjectName)
                     BackupPath = $($mockBackupPath)
                     Ensure = 'Present'
@@ -1150,8 +1150,8 @@ WITH NORECOVERY'
             BeforeEach {
                 $mockTestTargetResourceParameters = @{
                     DatabaseName = $mockDatabaseNameParameter.Clone()
-                    SqlServer = $mockServerObject.DomainInstanceName
-                    SQLInstanceName = 'MSSQLSERVER'
+                    ServerName = $mockServerObject.DomainInstanceName
+                    InstanceName = 'MSSQLSERVER'
                     AvailabilityGroupName = $mockAvailabilityGroupObject.Name
                     BackupPath = $($mockBackupPath)
                     Ensure = 'Present'

--- a/Tests/Unit/MSFT_SqlAGListener.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAGListener.Tests.ps1
@@ -1,14 +1,14 @@
-$script:DSCModuleName      = 'SqlServerDsc'
-$script:DSCResourceName    = 'MSFT_SqlAGListener'
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlAGListener'
 
 #region HEADER
 
 # Unit Test Template Version: 1.2.0
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -20,12 +20,14 @@ $TestEnvironment = Initialize-TestEnvironment `
 
 #endregion HEADER
 
-function Invoke-TestSetup {
+function Invoke-TestSetup
+{
     # Loading stub cmdlets
     Import-Module -Name ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SQLPSStub.psm1 ) -Force -Global
 }
 
-function Invoke-TestCleanup {
+function Invoke-TestCleanup
+{
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
 }
 
@@ -44,7 +46,7 @@ try
         $mockUnknownPortNumber = 9001
 
         # Static parameter values
-        $mockNodeName = 'localhost'
+        $mockServerName = 'localhost'
         $mockInstanceName = 'MSSQLSERVER'
         $mockDynamicAvailabilityGroup = $mockKnownAvailabilityGroup
         $mockDynamicListenerName = $mockKnownListenerName
@@ -55,39 +57,39 @@ try
         $mockConnectSql = {
             return New-Object Object |
                 Add-Member ScriptProperty AvailabilityGroups {
-                    return @(
-                        @{
-                            $mockDynamicAvailabilityGroup = New-Object Object |
-                                Add-Member ScriptProperty AvailabilityGroupListeners {
-                                    @(
-                                        @{
-                                            $mockDynamicListenerName = New-Object Object |
-                                                Add-Member NoteProperty PortNumber $mockDynamicPortNumber -PassThru |
-                                                Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
-                                                    return @(
-                                                        # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                                        (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                                            Add-Member NoteProperty IsDHCP $mockDynamicIsDhcp -PassThru |
-                                                            Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                                                            Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
-                                                        )
-                                                    )
-                                                } -PassThru |
-                                                Add-Member ScriptMethod Drop {
-                                                    $script:mockMethodDropRan = $true
-                                                } -PassThru -Force
-                                        }
-                                    )
-                                } -PassThru -Force
-                        }
-                    )
-                } -PassThru -Force
+                return @(
+                    @{
+                        $mockDynamicAvailabilityGroup = New-Object Object |
+                            Add-Member ScriptProperty AvailabilityGroupListeners {
+                            @(
+                                @{
+                                    $mockDynamicListenerName = New-Object Object |
+                                        Add-Member NoteProperty PortNumber $mockDynamicPortNumber -PassThru |
+                                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                                        return @(
+                                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                                    Add-Member NoteProperty IsDHCP $mockDynamicIsDhcp -PassThru |
+                                                    Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                                            )
+                                        )
+                                    } -PassThru |
+                                        Add-Member ScriptMethod Drop {
+                                        $script:mockMethodDropRan = $true
+                                    } -PassThru -Force
+                                }
+                            )
+                        } -PassThru -Force
+                    }
+                )
+            } -PassThru -Force
         }
 
         $defaultParameters = @{
-            InstanceName = $mockInstanceName
-            NodeName = $mockNodeName
-            Name = $mockKnownListenerName
+            InstanceName      = $mockInstanceName
+            ServerName        = $mockServerName
+            Name              = $mockKnownListenerName
             AvailabilityGroup = $mockKnownAvailabilityGroup
         }
 
@@ -111,7 +113,7 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.NodeName | Should -Be $testParameters.NodeName
+                    $result.ServerName | Should -Be $testParameters.ServerName
                     $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.Name | Should -Be $testParameters.Name
                     $result.AvailabilityGroup | Should -Be $testParameters.AvailabilityGroup
@@ -146,7 +148,7 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.NodeName | Should -Be $testParameters.NodeName
+                    $result.ServerName | Should -Be $testParameters.ServerName
                     $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.Name | Should -Be $testParameters.Name
                     $result.AvailabilityGroup | Should -Be $testParameters.AvailabilityGroup
@@ -183,7 +185,7 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.NodeName | Should -Be $testParameters.NodeName
+                    $result.ServerName | Should -Be $testParameters.ServerName
                     $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.Name | Should -Be $testParameters.Name
                     $result.AvailabilityGroup | Should -Be $testParameters.AvailabilityGroup
@@ -249,15 +251,15 @@ try
                     return New-Object Object |
                         Add-Member NoteProperty PortNumber 5030 -PassThru |
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
-                            return @(
-                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                        return @(
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $false -PassThru |
                                     Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
-                                )
                             )
-                        } -PassThru -Force
+                        )
+                    } -PassThru -Force
                 } -Verifiable
 
                 It 'Should return that desired state is absent when wanted desired state is to be Absent' {
@@ -307,15 +309,15 @@ try
                     return New-Object Object |
                         Add-Member NoteProperty PortNumber 5555 -PassThru |
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
-                            return @(
-                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                        return @(
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $false -PassThru |
                                     Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
-                                )
                             )
-                        } -PassThru -Force
+                        )
+                    } -PassThru -Force
                 } -Verifiable
 
                 It 'Should return that desired state is absent when port is different' {
@@ -337,15 +339,15 @@ try
                     return New-Object Object |
                         Add-Member NoteProperty PortNumber 5030 -PassThru |
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
-                            return @(
-                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                        return @(
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $true -PassThru |
                                     Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
-                                )
                             )
-                        } -PassThru -Force
+                        )
+                    } -PassThru -Force
                 } -Verifiable
 
                 It 'Should return that desired state is absent when DHCP is present but should be absent' {
@@ -374,15 +376,15 @@ try
                     return New-Object Object |
                         Add-Member NoteProperty PortNumber 5555 -PassThru |
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
-                            return @(
-                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                        return @(
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $true -PassThru |
                                     Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
-                                )
                             )
-                        } -PassThru -Force
+                        )
+                    } -PassThru -Force
                 } -Verifiable
 
                 It 'Should return that desired state is absent when port is the only set parameter' {
@@ -415,15 +417,15 @@ try
                     return New-Object Object |
                         Add-Member NoteProperty PortNumber 5030 -PassThru |
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
-                            return @(
-                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                        return @(
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $false -PassThru |
                                     Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
-                                )
                             )
-                        } -PassThru -Force
+                        )
+                    } -PassThru -Force
                 } -Verifiable
 
                 It 'Should return that desired state is present when wanted desired state is to be Present, without DHCP' {
@@ -463,15 +465,15 @@ try
                     return New-Object Object |
                         Add-Member NoteProperty PortNumber 5030 -PassThru |
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
-                            return @(
-                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                        return @(
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $true -PassThru |
                                     Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
-                                )
                             )
-                        } -PassThru -Force
+                        )
+                    } -PassThru -Force
                 } -Verifiable
 
                 It 'Should return that desired state is present when wanted desired state is to be Present, with DHCP' {
@@ -606,7 +608,7 @@ try
                 $mockDynamicPortNumber = $mockKnownPortNumber
 
                 It 'Should call the cmdlet Add-SqlAvailabilityGroupListenerStaticIp, when adding another IP address, and system is not in desired state' {
-                    $testParameters['IpAddress'] = @('192.168.0.1/255.255.255.0','10.0.0.1/255.255.252.0')
+                    $testParameters['IpAddress'] = @('192.168.0.1/255.255.255.0', '10.0.0.1/255.255.252.0')
                     $testParameters['Port'] = 5030
                     $testParameters['DHCP'] = $false
 
@@ -698,12 +700,12 @@ try
 
                     Mock -CommandName Get-TargetResource -MockWith {
                         return @{
-                            Ensure = 'Present'
-                            Name = $mockUnknownListenerName
+                            Ensure            = 'Present'
+                            Name              = $mockUnknownListenerName
                             AvailabilityGroup = $mockKnownAvailabilityGroup
-                            IpAddress = '192.168.0.1/255.255.255.0'
-                            Port = $mockKnownPortNumber
-                            DHCP = $false
+                            IpAddress         = '192.168.0.1/255.255.255.0'
+                            Port              = $mockKnownPortNumber
+                            DHCP              = $false
                         }
                     }
 
@@ -721,12 +723,12 @@ try
 
                     Mock -CommandName Get-TargetResource -MockWith {
                         return @{
-                            Ensure = 'Present'
-                            Name = $mockUnknownListenerName
+                            Ensure            = 'Present'
+                            Name              = $mockUnknownListenerName
                             AvailabilityGroup = $mockUnknownAvailabilityGroup
-                            IpAddress = '192.168.0.1/255.255.255.0'
-                            Port = $mockKnownPortNumber
-                            DHCP = $false
+                            IpAddress         = '192.168.0.1/255.255.255.0'
+                            Port              = $mockKnownPortNumber
+                            DHCP              = $false
                         }
                     }
 

--- a/Tests/Unit/MSFT_SqlAGReplica.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAGReplica.Tests.ps1
@@ -37,21 +37,21 @@ try
 
         #region parameter mocks
 
-        $mockSqlServer = 'Server1'
-        $mockSqlInstanceName = 'MSSQLSERVER'
+        $mockServerName = 'Server1'
+        $mockInstanceName = 'MSSQLSERVER'
         $mockPrimaryReplicaSQLServer = 'Server2'
         $mockPrimaryReplicaSQLInstanceName = 'MSSQLSERVER'
         $mockAvailabilityGroupName = 'AG_AllServers'
-        $mockAvailabilityGroupReplicaName = $mockSqlServer
+        $mockAvailabilityGroupReplicaName = $mockServerName
         $mockEnsure = 'Present'
         $mockAvailabilityMode = 'AsynchronousCommit'
         $mockBackupPriority = 50
         $mockConnectionModeInPrimaryRole = 'AllowAllConnections'
         $mockConnectionModeInSecondaryRole = 'AllowNoConnections'
-        $mockEndpointHostName = $mockSqlServer
+        $mockEndpointHostName = $mockServerName
         $mockFailoverMode = 'Manual'
-        $mockReadOnlyRoutingConnectionUrl = "TCP://$($mockSqlServer).domain.com:1433"
-        $mockReadOnlyRoutingList = @($mockSqlServer)
+        $mockReadOnlyRoutingConnectionUrl = "TCP://$($mockServerName).domain.com:1433"
+        $mockReadOnlyRoutingList = @($mockServerName)
         $mockProcessOnlyOnActiveNode = $false
 
         #endregion
@@ -85,16 +85,16 @@ try
         $mockAllLoginsAbsent = @{}
 
         $mockNtServiceClusSvcPresent = @{
-            $mockNtServiceClusSvcName = ( New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login($mockSqlServer, $mockNtServiceClusSvcName) )
+            $mockNtServiceClusSvcName = ( New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login($mockServerName, $mockNtServiceClusSvcName) )
         }
 
         $mockNtAuthoritySystemPresent = @{
-            $mockNtAuthoritySystemName = ( New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login($mockSqlServer, $mockNtAuthoritySystemName) )
+            $mockNtAuthoritySystemName = ( New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login($mockServerName, $mockNtAuthoritySystemName) )
         }
 
         $mockAllLoginsPresent = @{
-            $mockNtServiceClusSvcName  = ( New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login($mockSqlServer, $mockNtServiceClusSvcName) )
-            $mockNtAuthoritySystemName = ( New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login($mockSqlServer, $mockNtAuthoritySystemName) )
+            $mockNtServiceClusSvcName  = ( New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login($mockServerName, $mockNtServiceClusSvcName) )
+            $mockNtAuthoritySystemName = ( New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login($mockServerName, $mockNtAuthoritySystemName) )
         }
 
         #endregion
@@ -535,8 +535,8 @@ try
                 $getTargetResourceParameters = @{
                     Name                  = $mockAvailabilityGroupReplicaName
                     AvailabilityGroupName = $mockAvailabilityGroupName
-                    SQLServer             = $mockSqlServer
-                    SQLInstanceName       = $mockSqlInstanceName
+                    ServerName            = $mockServerName
+                    InstanceName          = $mockInstanceName
                 }
 
                 $mockDatabaseMirroringEndpoint = $true
@@ -565,9 +565,9 @@ try
                     $getTargetResourceResult.Name | Should -BeNullOrEmpty
                     $getTargetResourceResult.ReadOnlyRoutingConnectionUrl | Should -BeNullOrEmpty
                     $getTargetResourceResult.ReadOnlyRoutingList | Should -BeNullOrEmpty
-                    $getTargetResourceResult.SQLServer | Should -Be $mockSqlServer
-                    $getTargetResourceResult.SQLInstanceName | Should -Be $mockSqlInstanceName
-                    $getTargetResourceResult.SQLServerNetName | Should -Be $mockSqlServer
+                    $getTargetResourceResult.ServerName | Should -Be $mockServerName
+                    $getTargetResourceResult.InstanceName | Should -Be $mockInstanceName
+                    $getTargetResourceResult.SQLServerNetName | Should -Be $mockServerName
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 }
@@ -590,12 +590,12 @@ try
                     $getTargetResourceResult.EndpointPort | Should -Be $mockendpointPort
                     $getTargetResourceResult.Ensure | Should -Be $mockEnsure
                     $getTargetResourceResult.FailoverMode | Should -Be $mockFailoverMode
-                    $getTargetResourceResult.Name | Should -Be $mockSqlServer
+                    $getTargetResourceResult.Name | Should -Be $mockServerName
                     $getTargetResourceResult.ReadOnlyRoutingConnectionUrl | Should -Be $mockReadOnlyRoutingConnectionUrl
-                    $getTargetResourceResult.ReadOnlyRoutingList | Should -Be $mockSqlServer
-                    $getTargetResourceResult.SQLServer | Should -Be $mockSqlServer
-                    $getTargetResourceResult.SQLInstanceName | Should -Be $mockSqlInstanceName
-                    $getTargetResourceResult.SQLServerNetName | Should -Be $mockSqlServer
+                    $getTargetResourceResult.ReadOnlyRoutingList | Should -Be $mockServerName
+                    $getTargetResourceResult.ServerName | Should -Be $mockServerName
+                    $getTargetResourceResult.InstanceName | Should -Be $mockInstanceName
+                    $getTargetResourceResult.SQLServerNetName | Should -Be $mockServerName
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 }
@@ -649,10 +649,10 @@ try
 
                 BeforeEach {
                     $setTargetResourceParameters = @{
-                        Name                  = $mockSqlServer
+                        Name                  = $mockServerName
                         AvailabilityGroupName = $mockAvailabilityGroupName
-                        SQLServer             = $mockSqlServer
-                        SQLInstanceName       = $mockSqlInstanceName
+                        ServerName            = $mockServerName
+                        InstanceName          = $mockInstanceName
                         Ensure                = 'Absent'
                     }
                 }
@@ -733,10 +733,10 @@ try
 
                 BeforeEach {
                     $setTargetResourceParameters = @{
-                        Name                          = $mockSqlServer
+                        Name                          = $mockServerName
                         AvailabilityGroupName         = $mockAvailabilityGroup2Name
-                        SQLServer                     = $mockSqlServer
-                        SQLInstanceName               = $mockSqlInstanceName
+                        ServerName                    = $mockServerName
+                        InstanceName                  = $mockInstanceName
                         PrimaryReplicaSQLServer       = $mockPrimaryReplicaSQLServer
                         PrimaryReplicaSQLInstanceName = $mockPrimaryReplicaSQLInstanceName
                         Ensure                        = $mockEnsure
@@ -1072,10 +1072,10 @@ try
                     $mockAlternateEndpointProtocol = $false
 
                     $setTargetResourceParameters = @{
-                        Name                          = $mockSqlServer
+                        Name                          = $mockServerName
                         AvailabilityGroupName         = $mockAvailabilityGroupName
-                        SQLServer                     = $mockSqlServer
-                        SQLInstanceName               = $mockSqlInstanceName
+                        ServerName                    = $mockServerName
+                        InstanceName                  = $mockInstanceName
                         PrimaryReplicaSQLServer       = $mockPrimaryReplicaSQLServer
                         PrimaryReplicaSQLInstanceName = $mockPrimaryReplicaSQLInstanceName
                         Ensure                        = $mockEnsure
@@ -1274,10 +1274,10 @@ try
                 $mockDatabaseMirroringEndpoint = $true
 
                 $testTargetResourceParameters = @{
-                    Name                          = $mockSqlServer
+                    Name                          = $mockServerName
                     AvailabilityGroupName         = $mockAvailabilityGroupName
-                    SQLServer                     = $mockSqlServer
-                    SQLInstanceName               = $mockSqlInstanceName
+                    ServerName                    = $mockServerName
+                    InstanceName                  = $mockInstanceName
                     PrimaryReplicaSQLServer       = $mockPrimaryReplicaSQLServer
                     PrimaryReplicaSQLInstanceName = $mockPrimaryReplicaSQLInstanceName
                     Ensure                        = $mockEnsure

--- a/Tests/Unit/MSFT_SqlAlwaysOnService.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAlwaysOnService.Tests.ps1
@@ -1,12 +1,12 @@
-$script:DSCModuleName      = 'SqlServerDsc'
-$script:DSCResourceName    = 'MSFT_SqlAlwaysOnService'
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlAlwaysOnService'
 
 # Unit Test Template Version: 1.1.0
 [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -16,27 +16,27 @@ $TestEnvironment = Initialize-TestEnvironment `
     -TestType Unit
 
 $disableHadr = @{
-    Ensure = 'Absent'
-    SQLServer = 'Server01'
-    SQLInstanceName = 'MSSQLSERVER'
+    Ensure       = 'Absent'
+    ServerName   = 'Server01'
+    InstanceName = 'MSSQLSERVER'
 }
 
 $enableHadr = @{
-    Ensure = 'Present'
-    SQLServer = 'Server01'
-    SQLInstanceName = 'MSSQLSERVER'
+    Ensure       = 'Present'
+    ServerName   = 'Server01'
+    InstanceName = 'MSSQLSERVER'
 }
 
 $disableHadrNamedInstance = @{
-    Ensure = 'Absent'
-    SQLServer = 'Server01'
-    SQLInstanceName = 'NamedInstance'
+    Ensure       = 'Absent'
+    ServerName   = 'Server01'
+    InstanceName = 'NamedInstance'
 }
 
 $enableHadrNamedInstance = @{
-    Ensure = 'Present'
-    SQLServer = 'Server01'
-    SQLInstanceName = 'NamedInstance'
+    Ensure       = 'Present'
+    ServerName   = 'Server01'
+    InstanceName = 'NamedInstance'
 }
 
 # Begin Testing
@@ -139,7 +139,7 @@ try
 
             It 'Should disable SQL Always On when Ensure is set to Absent' {
                 Mock -CommandName Connect-SQL -MockWith {
-                return New-Object PSObject -Property @{
+                    return New-Object PSObject -Property @{
                         IsHadrEnabled = $false
                     }
                 } -ModuleName $script:DSCResourceName -Verifiable

--- a/Tests/Unit/MSFT_SqlDatabase.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabase.Tests.ps1
@@ -1,14 +1,14 @@
-$script:DSCModuleName      = 'SqlServerDsc'
-$script:DSCResourceName    = 'MSFT_SqlDatabase'
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlDatabase'
 
 #region HEADER
 
 # Unit Test Template Version: 1.2.0
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -20,11 +20,13 @@ $TestEnvironment = Initialize-TestEnvironment `
 
 #endregion HEADER
 
-function Invoke-TestSetup {
+function Invoke-TestSetup
+{
     # Loading mocked classes
 }
 
-function Invoke-TestCleanup {
+function Invoke-TestCleanup
+{
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
 }
 
@@ -34,20 +36,20 @@ try
     Invoke-TestSetup
 
     InModuleScope $script:DSCResourceName {
-        $mockSqlServerName                   = 'localhost'
-        $mockSqlServerInstanceName           = 'MSSQLSERVER'
-        $mockSqlDatabaseName                 = 'AdventureWorks'
+        $mockServerName = 'localhost'
+        $mockInstanceName = 'MSSQLSERVER'
+        $mockSqlDatabaseName = 'AdventureWorks'
         $mockInvalidOperationForCreateMethod = $false
-        $mockInvalidOperationForDropMethod   = $false
-        $mockInvalidOperationForAlterMethod  = $false
-        $mockExpectedDatabaseNameToCreate    = 'Contoso'
-        $mockExpectedDatabaseNameToDrop      = 'Sales'
-        $mockSqlDatabaseCollation            = 'SQL_Latin1_General_CP1_CI_AS'
+        $mockInvalidOperationForDropMethod = $false
+        $mockInvalidOperationForAlterMethod = $false
+        $mockExpectedDatabaseNameToCreate = 'Contoso'
+        $mockExpectedDatabaseNameToDrop = 'Sales'
+        $mockSqlDatabaseCollation = 'SQL_Latin1_General_CP1_CI_AS'
 
         # Default parameters that are used for the It-blocks
         $mockDefaultParameters = @{
-            SQLInstanceName = $mockSqlServerInstanceName
-            SQLServer       = $mockSqlServerName
+            InstanceName = $mockInstanceName
+            ServerName   = $mockServerName
         }
 
         #region Function mocks
@@ -56,48 +58,48 @@ try
             return @(
                 (
                     New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockSqlServerInstanceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockSqlServerName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockInstanceName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockServerName -PassThru |
                         Add-Member -MemberType NoteProperty -Name Collation -Value $mockSqlDatabaseCollation -PassThru |
                         Add-Member -MemberType ScriptMethod -Name EnumCollations -Value {
-                            return @(
-                                ( New-Object Object |
+                        return @(
+                            ( New-Object Object |
                                     Add-Member -MemberType NoteProperty Name -Value $mockSqlDatabaseCollation -PassThru
-                                ),
-                                ( New-Object Object |
+                            ),
+                            ( New-Object Object |
                                     Add-Member -MemberType NoteProperty Name -Value 'SQL_Latin1_General_CP1_CS_AS' -PassThru
-                                ),
-                                ( New-Object Object |
+                            ),
+                            ( New-Object Object |
                                     Add-Member -MemberType NoteProperty Name -Value 'SQL_Latin1_General_Pref_CP850_CI_AS' -PassThru
-                                )
                             )
-                        } -PassThru -Force |
+                        )
+                    } -PassThru -Force |
                         Add-Member -MemberType ScriptProperty -Name Databases -Value {
-                            return @{
-                                    $mockSqlDatabaseName = ( New-Object Object |
+                        return @{
+                            $mockSqlDatabaseName = ( New-Object Object |
                                     Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlDatabaseName -PassThru |
                                     Add-Member -MemberType NoteProperty -Name Collation -Value $mockSqlDatabaseCollation -PassThru |
                                     Add-Member -MemberType ScriptMethod -Name Drop -Value {
-                                        if ($mockInvalidOperationForDropMethod)
-                                        {
-                                            throw 'Mock Drop Method was called with invalid operation.'
-                                        }
+                                    if ($mockInvalidOperationForDropMethod)
+                                    {
+                                        throw 'Mock Drop Method was called with invalid operation.'
+                                    }
 
-                                        if ( $this.Name -ne $mockExpectedDatabaseNameToDrop )
-                                        {
-                                            throw "Called mocked Drop() method without dropping the right database. Expected '{0}'. But was '{1}'." `
-                                                  -f $mockExpectedDatabaseNameToDrop, $this.Name
-                                        }
-                                    } -PassThru |
+                                    if ( $this.Name -ne $mockExpectedDatabaseNameToDrop )
+                                    {
+                                        throw "Called mocked Drop() method without dropping the right database. Expected '{0}'. But was '{1}'." `
+                                            -f $mockExpectedDatabaseNameToDrop, $this.Name
+                                    }
+                                } -PassThru |
                                     Add-Member -MemberType ScriptMethod -Name Alter -Value {
-                                        if ($mockInvalidOperationForAlterMethod)
-                                        {
-                                            throw 'Mock Alter Method was called with invalid operation.'
-                                        }
-                                    } -PassThru
-                                    )
-                                }
-                            } -PassThru -Force
+                                    if ($mockInvalidOperationForAlterMethod)
+                                    {
+                                        throw 'Mock Alter Method was called with invalid operation.'
+                                    }
+                                } -PassThru
+                            )
+                        }
+                    } -PassThru -Force
                 )
             )
         }
@@ -109,23 +111,23 @@ try
                         Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlDatabaseName -PassThru |
                         Add-Member -MemberType NoteProperty -Name Collation -Value '' -PassThru |
                         Add-Member -MemberType ScriptMethod -Name Create -Value {
-                            if ($mockInvalidOperationForCreateMethod)
-                            {
-                                throw 'Mock Create Method was called with invalid operation.'
-                            }
+                        if ($mockInvalidOperationForCreateMethod)
+                        {
+                            throw 'Mock Create Method was called with invalid operation.'
+                        }
 
-                            if ( $this.Name -ne $mockExpectedDatabaseNameToCreate )
-                            {
-                                throw "Called mocked Create() method without adding the right database. Expected '{0}'. But was '{1}'." `
-                                        -f $mockExpectedDatabaseNameToCreate, $this.Name
-                            }
-                        } -PassThru -Force
+                        if ( $this.Name -ne $mockExpectedDatabaseNameToCreate )
+                        {
+                            throw "Called mocked Create() method without adding the right database. Expected '{0}'. But was '{1}'." `
+                                -f $mockExpectedDatabaseNameToCreate, $this.Name
+                        }
+                    } -PassThru -Force
                 )
             )
         }
         #endregion
 
-        Describe "MSFT_SqlDatabase\Get-TargetResource" -Tag 'Get'{
+        Describe "MSFT_SqlDatabase\Get-TargetResource" -Tag 'Get' {
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
             }
@@ -133,7 +135,7 @@ try
             Context 'When the system is not in the desired state' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    Name = 'UnknownDatabase'
+                    Name      = 'UnknownDatabase'
                     Collation = 'SQL_Latin1_General_CP1_CI_AS'
                 }
 
@@ -144,8 +146,8 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.SQLServer | Should -Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should -Be $testParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.Name | Should -Be $testParameters.Name
                     $result.Collation | Should -Be $testParameters.Collation
                 }
@@ -160,7 +162,7 @@ try
 
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    Name = 'AdventureWorks'
+                    Name      = 'AdventureWorks'
                     Collation = 'SQL_Latin1_General_CP1_CI_AS'
                 }
 
@@ -171,8 +173,8 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.SQLServer | Should -Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should -Be $testParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.Name | Should -Be $testParameters.Name
                     $result.Collation | Should -Be $testParameters.Collation
                 }
@@ -185,7 +187,7 @@ try
             Assert-VerifiableMock
         }
 
-        Describe "MSFT_SqlDatabase\Test-TargetResource" -Tag 'Test'{
+        Describe "MSFT_SqlDatabase\Test-TargetResource" -Tag 'Test' {
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
             }
@@ -194,8 +196,8 @@ try
                 It 'Should return the state as false when desired database does not exist' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name    = 'UnknownDatabase'
-                        Ensure  = 'Present'
+                        Name      = 'UnknownDatabase'
+                        Ensure    = 'Present'
                         Collation = 'SQL_Latin1_General_CP1_CS_AS'
                     }
 
@@ -206,8 +208,8 @@ try
                 It 'Should return the state as false when desired database exists but has the incorrect collation' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name    = 'AdventureWorks'
-                        Ensure  = 'Present'
+                        Name      = 'AdventureWorks'
+                        Ensure    = 'Present'
                         Collation = 'SQL_Latin1_General_CP1_CS_AS'
                     }
 
@@ -224,8 +226,8 @@ try
                 It 'Should return the state as false when non-desired database exist' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name    = 'AdventureWorks'
-                        Ensure  = 'Absent'
+                        Name   = 'AdventureWorks'
+                        Ensure = 'Absent'
                     }
 
                     $result = Test-TargetResource @testParameters
@@ -241,8 +243,8 @@ try
                 It 'Should return the state as true when desired database exist' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name    = 'AdventureWorks'
-                        Ensure  = 'Present'
+                        Name      = 'AdventureWorks'
+                        Ensure    = 'Present'
                         Collation = 'SQL_Latin1_General_CP1_CI_AS'
                     }
 
@@ -253,8 +255,8 @@ try
                 It 'Should return the state as true when desired database exists and has the correct collation' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name    = 'AdventureWorks'
-                        Ensure  = 'Present'
+                        Name      = 'AdventureWorks'
+                        Ensure    = 'Present'
                         Collation = 'SQL_Latin1_General_CP1_CI_AS'
                     }
 
@@ -271,8 +273,8 @@ try
                 It 'Should return the state as true when desired database does not exist' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name    = 'UnknownDatabase'
-                        Ensure  = 'Absent'
+                        Name   = 'UnknownDatabase'
+                        Ensure = 'Absent'
                     }
 
                     $result = Test-TargetResource @testParameters
@@ -287,7 +289,7 @@ try
             Assert-VerifiableMock
         }
 
-        Describe "MSFT_SqlDatabase\Set-TargetResource" -Tag 'Set'{
+        Describe "MSFT_SqlDatabase\Set-TargetResource" -Tag 'Set' {
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
                 Mock -CommandName New-Object -MockWith $mockNewObjectDatabase -ParameterFilter {
@@ -295,15 +297,15 @@ try
                 } -Verifiable
             }
 
-            $mockSqlDatabaseName                = 'Contoso'
-            $mockExpectedDatabaseNameToCreate   = 'Contoso'
+            $mockSqlDatabaseName = 'Contoso'
+            $mockExpectedDatabaseNameToCreate = 'Contoso'
 
             Context 'When the system is not in the desired state and Ensure is set to Present' {
                 It 'Should not throw when creating the database' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name    = 'NewDatabase'
-                        Ensure  = 'Present'
+                        Name   = 'NewDatabase'
+                        Ensure = 'Present'
                     }
 
                     { Set-TargetResource @testParameters } | Should -Not -Throw
@@ -312,8 +314,8 @@ try
                 It 'Should not throw when changing the database collation' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name    = 'Contoso'
-                        Ensure  = 'Present'
+                        Name      = 'Contoso'
+                        Ensure    = 'Present'
                         Collation = 'SQL_Latin1_General_CP1_CS_AS'
                     }
 
@@ -332,14 +334,14 @@ try
             }
 
             $mockExpectedDatabaseNameToDrop = 'Sales'
-            $mockSqlDatabaseName            = 'Sales'
+            $mockSqlDatabaseName = 'Sales'
 
             Context 'When the system is not in the desired state and Ensure is set to Absent' {
                 It 'Should not throw when dropping the database' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name    = 'Sales'
-                        Ensure  = 'Absent'
+                        Name   = 'Sales'
+                        Ensure = 'Absent'
                     }
 
                     { Set-TargetResource @testParameters } | Should -Not -Throw
@@ -351,18 +353,18 @@ try
             }
 
             $mockInvalidOperationForCreateMethod = $true
-            $mockInvalidOperationForAlterMethod  = $true
+            $mockInvalidOperationForAlterMethod = $true
 
             Context 'When the system is not in the desired state and Ensure is set to Present' {
                 It 'Should throw the correct error when Create() method was called with invalid operation' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name    = 'NewDatabase'
-                        Ensure  = 'Present'
+                        Name   = 'NewDatabase'
+                        Ensure = 'Present'
                     }
 
                     $throwInvalidOperation = ('InnerException: Exception calling "Create" ' + `
-                                              'with "0" argument(s): "Mock Create Method was called with invalid operation."')
+                            'with "0" argument(s): "Mock Create Method was called with invalid operation."')
 
                     { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
                 }
@@ -370,12 +372,12 @@ try
                 It 'Should throw the correct error when invalid collation is specified' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name    = 'Sales'
-                        Ensure  = 'Present'
+                        Name      = 'Sales'
+                        Ensure    = 'Present'
                         Collation = 'InvalidCollation'
                     }
 
-                    $throwInvalidOperation = ("The specified collation '{3}' is not a valid collation for database {2} on {0}\{1}." -f $mockSqlServerName, $mockSqlServerInstanceName, $testParameters.Name, $testParameters.Collation)
+                    $throwInvalidOperation = ("The specified collation '{3}' is not a valid collation for database {2} on {0}\{1}." -f $mockServerName, $mockInstanceName, $testParameters.Name, $testParameters.Collation)
 
                     { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
                 }
@@ -397,14 +399,14 @@ try
             Context 'When the system is not in the desired state and Ensure is set to Absent' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    Name    = 'AdventureWorks'
-                    Ensure  = 'Absent'
+                    Name      = 'AdventureWorks'
+                    Ensure    = 'Absent'
                     Collation = 'SQL_Latin1_General_CP1_CS_AS'
                 }
 
                 It 'Should throw the correct error when Drop() method was called with invalid operation' {
                     $throwInvalidOperation = ('InnerException: Exception calling "Drop" ' + `
-                                              'with "0" argument(s): "Mock Drop Method was called with invalid operation."')
+                            'with "0" argument(s): "Mock Drop Method was called with invalid operation."')
 
                     { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
                 }

--- a/Tests/Unit/MSFT_SqlDatabaseOwner.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabaseOwner.Tests.ps1
@@ -1,14 +1,14 @@
-$script:DSCModuleName      = 'SqlServerDsc'
-$script:DSCResourceName    = 'MSFT_SqlDatabaseOwner'
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlDatabaseOwner'
 
 #region HEADER
 
 # Unit Test Template Version: 1.2.0
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -20,10 +20,12 @@ $TestEnvironment = Initialize-TestEnvironment `
 
 #endregion HEADER
 
-function Invoke-TestSetup {
+function Invoke-TestSetup
+{
 }
 
-function Invoke-TestCleanup {
+function Invoke-TestCleanup
+{
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
 }
 
@@ -33,19 +35,19 @@ try
     Invoke-TestSetup
 
     InModuleScope $script:DSCResourceName {
-        $mockSqlServerName                      = 'localhost'
-        $mockSqlServerInstanceName              = 'MSSQLSERVER'
-        $mockSqlDatabaseName                    = 'AdventureWorks'
-        $mockSqlServerLogin                     = 'Zebes\SamusAran'
-        $mockSqlServerLoginType                 = 'WindowsUser'
-        $mockDatabaseOwner                      = 'Elysia\Chozo'
-        $mockInvalidOperationForSetOwnerMethod  = $false
-        $mockExpectedDatabaseOwner              = 'Elysia\Chozo'
+        $mockServerName = 'localhost'
+        $mockInstanceName = 'MSSQLSERVER'
+        $mockSqlDatabaseName = 'AdventureWorks'
+        $mockSqlServerLogin = 'Zebes\SamusAran'
+        $mockSqlServerLoginType = 'WindowsUser'
+        $mockDatabaseOwner = 'Elysia\Chozo'
+        $mockInvalidOperationForSetOwnerMethod = $false
+        $mockExpectedDatabaseOwner = 'Elysia\Chozo'
 
         # Default parameters that are used for the It-blocks
         $mockDefaultParameters = @{
-            SQLInstanceName = $mockSqlServerInstanceName
-            SQLServer       = $mockSqlServerName
+            InstanceName = $mockInstanceName
+            ServerName   = $mockServerName
         }
 
         #region Function mocks
@@ -53,43 +55,43 @@ try
             return @(
                 (
                     New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockSqlServerInstanceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockSqlServerName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockInstanceName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockServerName -PassThru |
                         Add-Member -MemberType ScriptProperty -Name Databases -Value {
-                            return @{
-                                $mockSqlDatabaseName = @((
+                        return @{
+                            $mockSqlDatabaseName = @((
                                     New-Object Object |
                                         Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlDatabaseName -PassThru |
                                         Add-Member -MemberType NoteProperty -Name Owner -Value $mockDatabaseOwner -PassThru |
                                         Add-Member -MemberType ScriptMethod -Name SetOwner -Value {
-                                            if ($mockInvalidOperationForSetOwnerMethod)
-                                            {
-                                                throw 'Mock of method SetOwner() was called with invalid operation.'
-                                            }
+                                        if ($mockInvalidOperationForSetOwnerMethod)
+                                        {
+                                            throw 'Mock of method SetOwner() was called with invalid operation.'
+                                        }
 
-                                            if ( $this.Owner -ne $mockExpectedDatabaseOwner )
-                                            {
-                                                throw "Called mocked SetOwner() method without setting the right login. Expected '{0}'. But was '{1}'." `
-                                                        -f $mockExpectedDatabaseOwner, $this.Owner
-                                            }
-                                        } -PassThru -Force
-                                    ))
-                                }
-                            } -PassThru -Force |
+                                        if ( $this.Owner -ne $mockExpectedDatabaseOwner )
+                                        {
+                                            throw "Called mocked SetOwner() method without setting the right login. Expected '{0}'. But was '{1}'." `
+                                                -f $mockExpectedDatabaseOwner, $this.Owner
+                                        }
+                                    } -PassThru -Force
+                                ))
+                        }
+                    } -PassThru -Force |
                         Add-Member -MemberType ScriptProperty -Name Logins -Value {
-                            return @{
-                                $mockSqlServerLogin = @((
+                        return @{
+                            $mockSqlServerLogin = @((
                                     New-Object Object |
                                         Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru
                                 ))
-                            }
-                        } -PassThru -Force
+                        }
+                    } -PassThru -Force
                 )
             )
         }
         #endregion
 
-        Describe "MSFT_SqlDatabaseOwner\Get-TargetResource" -Tag 'Get'{
+        Describe "MSFT_SqlDatabaseOwner\Get-TargetResource" -Tag 'Get' {
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
             }
@@ -98,12 +100,12 @@ try
                 It 'Should throw the correct error' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Database    = 'unknownDatabaseName'
-                        Name        = $mockSqlServerLogin
+                        Database = 'unknownDatabaseName'
+                        Name     = $mockSqlServerLogin
                     }
 
                     $throwInvalidOperation = ("Database 'unknownDatabaseName' does not exist " + `
-                                              "on SQL server 'localhost\MSSQLSERVER'.")
+                            "on SQL server 'localhost\MSSQLSERVER'.")
 
                     { Get-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
                 }
@@ -117,8 +119,8 @@ try
                 It 'Should not throw' {
                     $testParameters = $defaultParameters
                     $testParameters += @{
-                        Database    = $mockSqlDatabaseName
-                        Name        = $mockSqlServerLogin
+                        Database = $mockSqlDatabaseName
+                        Name     = $mockSqlServerLogin
                     }
 
                     $result = Get-TargetResource @testParameters
@@ -129,8 +131,8 @@ try
                 }
 
                 It 'Should return the same values as passed as parameters' {
-                    $result.SQLServer | Should -Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should -Be $testParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.Database | Should -Be $testParameters.Database
                 }
 
@@ -142,7 +144,7 @@ try
             Assert-VerifiableMock
         }
 
-        Describe "MSFT_SqlDatabaseOwner\Test-TargetResource" -Tag 'Test'{
+        Describe "MSFT_SqlDatabaseOwner\Test-TargetResource" -Tag 'Test' {
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
             }
@@ -151,8 +153,8 @@ try
                 It 'Should return the state as false when desired login is not the database owner' {
                     $testParameters = $defaultParameters
                     $testParameters += @{
-                        Database    = $mockSqlDatabaseName
-                        Name        = $mockSqlServerLogin
+                        Database = $mockSqlDatabaseName
+                        Name     = $mockSqlServerLogin
                     }
 
                     $result = Test-TargetResource @testParameters
@@ -170,8 +172,8 @@ try
                     $mockSqlServerLogin = 'Zebes\SamusAran'
                     $testParameters = $defaultParameters
                     $testParameters += @{
-                        Database    = $mockSqlDatabaseName
-                        Name        = $mockSqlServerLogin
+                        Database = $mockSqlDatabaseName
+                        Name     = $mockSqlServerLogin
                     }
 
                     $result = Test-TargetResource @testParameters
@@ -186,7 +188,7 @@ try
             Assert-VerifiableMock
         }
 
-        Describe "MSFT_SqlDatabaseOwner\Set-TargetResource" -Tag 'Set'{
+        Describe "MSFT_SqlDatabaseOwner\Set-TargetResource" -Tag 'Set' {
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
             }
@@ -195,12 +197,12 @@ try
                 It 'Should throw the correct error' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Database    = 'unknownDatabaseName'
-                        Name        = $mockSqlServerLogin
+                        Database = 'unknownDatabaseName'
+                        Name     = $mockSqlServerLogin
                     }
 
                     $throwInvalidOperation = ("Database 'unknownDatabaseName' does not exist " + `
-                                              "on SQL server 'localhost\MSSQLSERVER'.")
+                            "on SQL server 'localhost\MSSQLSERVER'.")
 
                     { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
                 }
@@ -214,12 +216,12 @@ try
                 It 'Should throw the correct error' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Database    = $mockSqlDatabaseName
-                        Name        = 'John'
+                        Database = $mockSqlDatabaseName
+                        Name     = 'John'
                     }
 
                     $throwInvalidOperation = ("Login 'John' does not exist on " + `
-                                              "SQL server 'localhost\MSSQLSERVER'.")
+                            "SQL server 'localhost\MSSQLSERVER'.")
 
                     { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
                 }
@@ -235,8 +237,8 @@ try
                     $mockDatabaseOwner = $mockSqlServerLogin
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Database    = $mockSqlDatabaseName
-                        Name        = $mockSqlServerLogin
+                        Database = $mockSqlDatabaseName
+                        Name     = $mockSqlServerLogin
                     }
 
                     { Set-TargetResource @testParameters } | Should -Not -Throw
@@ -252,15 +254,15 @@ try
                     $mockExpectedDatabaseOwner = $mockSqlServerLogin
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Database    = $mockSqlDatabaseName
-                        Name        = $mockSqlServerLogin
+                        Database = $mockSqlDatabaseName
+                        Name     = $mockSqlServerLogin
                     }
 
                     $throwInvalidOperation = ('Failed to set owner named Zebes\SamusAran of the database ' + `
-                                              'named AdventureWorks on localhost\MSSQLSERVER. InnerException: ' + `
-                                              'Exception calling "SetOwner" with "1" argument(s): "Called mocked ' + `
-                                              'SetOwner() method without setting the right login. ' + `
-                                              "Expected 'Zebes\SamusAran'. But was 'Elysia\Chozo'.")
+                            'named AdventureWorks on localhost\MSSQLSERVER. InnerException: ' + `
+                            'Exception calling "SetOwner" with "1" argument(s): "Called mocked ' + `
+                            'SetOwner() method without setting the right login. ' + `
+                            "Expected 'Zebes\SamusAran'. But was 'Elysia\Chozo'.")
 
                     { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
                 }
@@ -272,18 +274,18 @@ try
 
             Context 'When the system is not in the desired state' {
                 It 'Should throw the correct error when the method SetOwner() was called' {
-                    $mockInvalidOperationForSetOwnerMethod  = $true
+                    $mockInvalidOperationForSetOwnerMethod = $true
                     $mockExpectedDatabaseOwner = $mockSqlServerLogin
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Database    = $mockSqlDatabaseName
-                        Name        = $mockSqlServerLogin
+                        Database = $mockSqlDatabaseName
+                        Name     = $mockSqlServerLogin
                     }
 
                     $throwInvalidOperation = ('Failed to set owner named Zebes\SamusAran of the database ' + `
-                                              'named AdventureWorks on localhost\MSSQLSERVER. InnerException: ' + `
-                                              'Exception calling "SetOwner" with "1" argument(s): "Mock ' + `
-                                              'of method SetOwner() was called with invalid operation.')
+                            'named AdventureWorks on localhost\MSSQLSERVER. InnerException: ' + `
+                            'Exception calling "SetOwner" with "1" argument(s): "Mock ' + `
+                            'of method SetOwner() was called with invalid operation.')
 
                     { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
                 }

--- a/Tests/Unit/MSFT_SqlDatabasePermission.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabasePermission.Tests.ps1
@@ -1,14 +1,14 @@
-$script:DSCModuleName      = 'SqlServerDsc'
-$script:DSCResourceName    = 'MSFT_SqlDatabasePermission'
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlDatabasePermission'
 
 #region HEADER
 
 # Unit Test Template Version: 1.2.0
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -20,12 +20,14 @@ $TestEnvironment = Initialize-TestEnvironment `
 
 #endregion HEADER
 
-function Invoke-TestSetup {
+function Invoke-TestSetup
+{
     # Loading mocked classes
     Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
 }
 
-function Invoke-TestCleanup {
+function Invoke-TestCleanup
+{
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
 }
 
@@ -35,16 +37,16 @@ try
     Invoke-TestSetup
 
     InModuleScope $script:DSCResourceName {
-        $mockSqlServerName                            = 'localhost'
-        $mockSqlServerInstanceName                    = 'MSSQLSERVER'
-        $mockSqlDatabaseName                          = 'AdventureWorks'
-        $mockSqlServerLogin                           = 'Zebes\SamusAran'
-        $mockSqlServerLoginUnknown                    = 'Elysia\Chozo'
-        $mockLoginType                                = 'WindowsUser'
-        $mockInvalidOperationEnumDatabasePermissions  = $false
-        $mockInvalidOperationForCreateMethod          = $false
-        $mockExpectedSqlServerLogin                   = 'Zebes\SamusAran'
-        $mockSqlPermissionState                       = 'Grant'
+        $mockServerName = 'localhost'
+        $mockInstanceName = 'MSSQLSERVER'
+        $mockSqlDatabaseName = 'AdventureWorks'
+        $mockSqlServerLogin = 'Zebes\SamusAran'
+        $mockSqlServerLoginUnknown = 'Elysia\Chozo'
+        $mockLoginType = 'WindowsUser'
+        $mockInvalidOperationEnumDatabasePermissions = $false
+        $mockInvalidOperationForCreateMethod = $false
+        $mockExpectedSqlServerLogin = 'Zebes\SamusAran'
+        $mockSqlPermissionState = 'Grant'
 
         $mockSqlPermissionType01 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.DatabasePermissionSet -ArgumentList ($true, $false)
         $mockSqlPermissionType02 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.DatabasePermissionSet -ArgumentList ($false, $true)
@@ -56,8 +58,8 @@ try
 
         # Default parameters that are used for the It-blocks
         $mockDefaultParameters = @{
-            SQLInstanceName = $mockSqlServerInstanceName
-            SQLServer       = $mockSqlServerName
+            InstanceName = $mockInstanceName
+            ServerName   = $mockServerName
         }
 
         #region Function mocks
@@ -65,135 +67,135 @@ try
             return @(
                 (
                     New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockSqlServerInstanceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockSqlServerName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockInstanceName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockServerName -PassThru |
                         Add-Member -MemberType ScriptProperty -Name Databases -Value {
-                            return @{
-                                $mockSqlDatabaseName = @((
+                        return @{
+                            $mockSqlDatabaseName = @((
                                     New-Object Object |
                                         Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlDatabaseName -PassThru |
                                         Add-Member -MemberType ScriptProperty -Name Users -Value {
-                                            return @{
-                                                $mockSqlServerLogin = @((
+                                        return @{
+                                            $mockSqlServerLogin = @((
                                                     New-Object Object |
                                                         Add-Member -MemberType ScriptMethod -Name IsMember -Value {
-                                                                return $true
-                                                        } -PassThru
+                                                        return $true
+                                                    } -PassThru
                                                 ))
-                                            }
-                                        } -PassThru |
+                                        }
+                                    } -PassThru |
                                         Add-Member -MemberType ScriptMethod -Name EnumDatabasePermissions -Value {
-                                            param
-                                            (
-                                                [Parameter()]
-                                                [System.String]
-                                                $SqlServerLogin
-                                            )
-                                            if ($mockInvalidOperationEnumDatabasePermissions)
-                                            {
-                                                throw 'Mock EnumDatabasePermissions Method was called with invalid operation.'
-                                            }
+                                        param
+                                        (
+                                            [Parameter()]
+                                            [System.String]
+                                            $SqlServerLogin
+                                        )
+                                        if ($mockInvalidOperationEnumDatabasePermissions)
+                                        {
+                                            throw 'Mock EnumDatabasePermissions Method was called with invalid operation.'
+                                        }
 
-                                            if ( $SqlServerLogin -eq $mockExpectedSqlServerLogin )
-                                            {
-                                                $mockEnumDatabasePermissions = @()
-                                                $mockEnumDatabasePermissions += New-Object Object |
-                                                        Add-Member -MemberType NoteProperty -Name PermissionType -Value $mockSqlPermissionType01 -PassThru |
-                                                        Add-Member -MemberType NoteProperty -Name PermissionState -Value $mockSqlPermissionState -PassThru |
-                                                        Add-Member -MemberType NoteProperty -Name Grantee -Value $mockExpectedSqlServerLogin -PassThru |
-                                                        Add-Member -MemberType NoteProperty -Name GrantorType -Value 'User' -PassThru |
-                                                        Add-Member -MemberType NoteProperty -Name ObjectClass -Value 'Database' -PassThru |
-                                                        Add-Member -MemberType NoteProperty -Name ObjectName -Value $mockSqlDatabaseName -PassThru
-                                                $mockEnumDatabasePermissions += New-Object Object |
-                                                        Add-Member -MemberType NoteProperty -Name PermissionType -Value $mockSqlPermissionType02 -PassThru |
-                                                        Add-Member -MemberType NoteProperty -Name PermissionState -Value $mockSqlPermissionState -PassThru |
-                                                        Add-Member -MemberType NoteProperty -Name Grantee -Value $mockExpectedSqlServerLogin -PassThru |
-                                                        Add-Member -MemberType NoteProperty -Name GrantorType -Value 'User' -PassThru |
-                                                        Add-Member -MemberType NoteProperty -Name ObjectClass -Value 'Database' -PassThru |
-                                                        Add-Member -MemberType NoteProperty -Name ObjectName -Value $mockSqlDatabaseName -PassThru
+                                        if ( $SqlServerLogin -eq $mockExpectedSqlServerLogin )
+                                        {
+                                            $mockEnumDatabasePermissions = @()
+                                            $mockEnumDatabasePermissions += New-Object Object |
+                                                Add-Member -MemberType NoteProperty -Name PermissionType -Value $mockSqlPermissionType01 -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name PermissionState -Value $mockSqlPermissionState -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name Grantee -Value $mockExpectedSqlServerLogin -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name GrantorType -Value 'User' -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name ObjectClass -Value 'Database' -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name ObjectName -Value $mockSqlDatabaseName -PassThru
+                                            $mockEnumDatabasePermissions += New-Object Object |
+                                                Add-Member -MemberType NoteProperty -Name PermissionType -Value $mockSqlPermissionType02 -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name PermissionState -Value $mockSqlPermissionState -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name Grantee -Value $mockExpectedSqlServerLogin -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name GrantorType -Value 'User' -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name ObjectClass -Value 'Database' -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name ObjectName -Value $mockSqlDatabaseName -PassThru
 
-                                                $mockEnumDatabasePermissions
-                                            }
-                                            else
-                                            {
-                                                return $null
-                                            }
-                                        } -PassThru |
+                                            $mockEnumDatabasePermissions
+                                        }
+                                        else
+                                        {
+                                            return $null
+                                        }
+                                    } -PassThru |
                                         Add-Member -MemberType ScriptMethod -Name Grant -Value {
-                                            param
-                                            (
-                                                [Parameter()]
-                                                [System.Object]
-                                                $permissionSet,
+                                        param
+                                        (
+                                            [Parameter()]
+                                            [System.Object]
+                                            $permissionSet,
 
-                                                [Parameter()]
-                                                [System.String]
-                                                $SqlServerLogin
-                                            )
+                                            [Parameter()]
+                                            [System.String]
+                                            $SqlServerLogin
+                                        )
 
-                                            $script:mockMethodGrantRan = $true
+                                        $script:mockMethodGrantRan = $true
 
-                                            if ( $SqlServerLogin -ne $mockExpectedSqlServerLogin )
-                                            {
-                                                throw "Called mocked Grant() method without setting the right login name. Expected '{0}'. But was '{1}'." `
-                                                      -f $mockExpectedSqlServerLogin, $SqlServerLogin
-                                            }
-                                        } -PassThru |
+                                        if ( $SqlServerLogin -ne $mockExpectedSqlServerLogin )
+                                        {
+                                            throw "Called mocked Grant() method without setting the right login name. Expected '{0}'. But was '{1}'." `
+                                                -f $mockExpectedSqlServerLogin, $SqlServerLogin
+                                        }
+                                    } -PassThru |
                                         Add-Member -MemberType ScriptMethod -Name Revoke -Value {
-                                            param
-                                            (
-                                                [Parameter()]
-                                                [System.Object]
-                                                $permissionSet,
+                                        param
+                                        (
+                                            [Parameter()]
+                                            [System.Object]
+                                            $permissionSet,
 
-                                                [Parameter()]
-                                                [System.String]
-                                                $SqlServerLogin
-                                            )
+                                            [Parameter()]
+                                            [System.String]
+                                            $SqlServerLogin
+                                        )
 
-                                            $script:mockMethodRevokeRan = $true
+                                        $script:mockMethodRevokeRan = $true
 
-                                            if ( $SqlServerLogin -ne $mockExpectedSqlServerLogin )
-                                            {
-                                                throw "Called mocked Revoke() method without setting the right login name. Expected '{0}'. But was '{1}'." `
-                                                      -f $mockExpectedSqlServerLogin, $SqlServerLogin
-                                            }
-                                        } -PassThru |
+                                        if ( $SqlServerLogin -ne $mockExpectedSqlServerLogin )
+                                        {
+                                            throw "Called mocked Revoke() method without setting the right login name. Expected '{0}'. But was '{1}'." `
+                                                -f $mockExpectedSqlServerLogin, $SqlServerLogin
+                                        }
+                                    } -PassThru |
                                         Add-Member -MemberType ScriptMethod -Name Deny -Value {
-                                            param
-                                            (
-                                                [Parameter()]
-                                                [System.Object]
-                                                $permissionSet,
+                                        param
+                                        (
+                                            [Parameter()]
+                                            [System.Object]
+                                            $permissionSet,
 
-                                                [Parameter()]
-                                                [System.String]
-                                                $SqlServerLogin
-                                            )
+                                            [Parameter()]
+                                            [System.String]
+                                            $SqlServerLogin
+                                        )
 
-                                            $script:mockMethodDenyRan = $true
+                                        $script:mockMethodDenyRan = $true
 
-                                            if ( $SqlServerLogin -ne $mockExpectedSqlServerLogin )
-                                            {
-                                                throw "Called mocked Deny() method without setting the right login name. Expected '{0}'. But was '{1}'." `
-                                                      -f $mockExpectedSqlServerLogin, $SqlServerLogin
-                                            }
-                                        } -PassThru -Force
-                                    ))
-                                }
-                            } -PassThru -Force |
+                                        if ( $SqlServerLogin -ne $mockExpectedSqlServerLogin )
+                                        {
+                                            throw "Called mocked Deny() method without setting the right login name. Expected '{0}'. But was '{1}'." `
+                                                -f $mockExpectedSqlServerLogin, $SqlServerLogin
+                                        }
+                                    } -PassThru -Force
+                                ))
+                        }
+                    } -PassThru -Force |
                         Add-Member -MemberType ScriptProperty -Name Logins -Value {
-                            return @{
-                                $mockSqlServerLogin = @((
+                        return @{
+                            $mockSqlServerLogin        = @((
                                     New-Object Object |
                                         Add-Member -MemberType NoteProperty -Name LoginType -Value $mockLoginType -PassThru
                                 ))
-                                $mockSqlServerLoginUnknown= @((
+                            $mockSqlServerLoginUnknown = @((
                                     New-Object Object |
                                         Add-Member -MemberType NoteProperty -Name LoginType -Value $mockLoginType -PassThru
                                 ))
-                            }
-                        } -PassThru -Force
+                        }
+                    } -PassThru -Force
                 )
             )
         }
@@ -205,25 +207,25 @@ try
                         Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlServerLoginUnknown -PassThru |
                         Add-Member -MemberType NoteProperty -Name Login -Value $mockSqlServerLoginUnknown -PassThru |
                         Add-Member -MemberType ScriptMethod -Name Create -Value {
-                            $script:mockMethodCreateLoginRan = $true
+                        $script:mockMethodCreateLoginRan = $true
 
-                            if ($mockInvalidOperationForCreateMethod)
-                            {
-                                throw 'Mock Create Method was called with invalid operation.'
-                            }
-                            if ( $this.Name -ne $mockExpectedSqlServerLogin )
-                            {
-                                throw "Called mocked Create() method without adding the right user. Expected '{0}'. But was '{1}'." `
-                                        -f $mockExpectedSqlServerLogin, $this.Name
-                            }
-                        } -PassThru -Force
+                        if ($mockInvalidOperationForCreateMethod)
+                        {
+                            throw 'Mock Create Method was called with invalid operation.'
+                        }
+                        if ( $this.Name -ne $mockExpectedSqlServerLogin )
+                        {
+                            throw "Called mocked Create() method without adding the right user. Expected '{0}'. But was '{1}'." `
+                                -f $mockExpectedSqlServerLogin, $this.Name
+                        }
+                    } -PassThru -Force
                 )
             )
         }
 
         #endregion
 
-        Describe "MSFT_SqlDatabasePermission\Get-TargetResource" -Tag 'Get'{
+        Describe "MSFT_SqlDatabasePermission\Get-TargetResource" -Tag 'Get' {
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
             }
@@ -232,14 +234,14 @@ try
                 It 'Should throw the correct error' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Database    = 'unknownDatabaseName'
-                        Name        = $mockSqlServerLogin
+                        Database        = 'unknownDatabaseName'
+                        Name            = $mockSqlServerLogin
                         PermissionState = 'Grant'
-                        Permissions = @( 'Connect','Update' )
+                        Permissions     = @( 'Connect', 'Update' )
                     }
 
                     $throwInvalidOperation = ("Database 'unknownDatabaseName' does not exist " + `
-                                              "on SQL server 'localhost\MSSQLSERVER'.")
+                            "on SQL server 'localhost\MSSQLSERVER'.")
 
                     { Get-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
 
@@ -251,14 +253,14 @@ try
                 It 'Should throw the correct error' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Database    = $mockSqlDatabaseName
-                        Name        = 'unknownLoginName'
+                        Database        = $mockSqlDatabaseName
+                        Name            = 'unknownLoginName'
                         PermissionState = 'Grant'
-                        Permissions = @( 'Connect','Update' )
+                        Permissions     = @( 'Connect', 'Update' )
                     }
 
                     $throwInvalidOperation = ("Login 'unknownLoginName' does not exist " + `
-                                              "on SQL server 'localhost\MSSQLSERVER'.")
+                            "on SQL server 'localhost\MSSQLSERVER'.")
 
                     { Get-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
 
@@ -271,14 +273,14 @@ try
                     $mockInvalidOperationEnumDatabasePermissions = $true
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Database    = $mockSqlDatabaseName
-                        Name        = $mockSqlServerLogin
+                        Database        = $mockSqlDatabaseName
+                        Name            = $mockSqlServerLogin
                         PermissionState = 'Grant'
-                        Permissions = @( 'Connect','Update' )
+                        Permissions     = @( 'Connect', 'Update' )
                     }
 
                     $throwInvalidOperation = ('Failed to get permission for login named Zebes\SamusAran of ' + `
-                                              'the database named AdventureWorks on localhost\MSSQLSERVER.')
+                            'the database named AdventureWorks on localhost\MSSQLSERVER.')
 
                     { Get-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
 
@@ -289,10 +291,10 @@ try
             Context 'When the system is in the desired state and ensure is set to Absent' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    Database    = $mockSqlDatabaseName
-                    Name        = $mockSqlServerLogin
+                    Database        = $mockSqlDatabaseName
+                    Name            = $mockSqlServerLogin
                     PermissionState = 'Grant'
-                    Permissions = @( 'Connect','Update','Select' )
+                    Permissions     = @( 'Connect', 'Update', 'Select' )
                 }
 
                 It 'Should return the state as absent when the desired permission does not exist' {
@@ -304,8 +306,8 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.SQLServer | Should -Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should -Be $testParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.ServerRoleName | Should -Be $testParameters.ServerRoleName
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
@@ -315,10 +317,10 @@ try
             Context 'When the system is not in the desired state and ensure is set to Absent' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    Database    = $mockSqlDatabaseName
-                    Name        = $mockSqlServerLogin
+                    Database        = $mockSqlDatabaseName
+                    Name            = $mockSqlServerLogin
                     PermissionState = 'Grant'
-                    Permissions = @( 'Connect','Update' )
+                    Permissions     = @( 'Connect', 'Update' )
                 }
 
                 It 'Should not return the state as absent when the desired permission does not exist' {
@@ -330,8 +332,8 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.SQLServer | Should -Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should -Be $testParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.ServerRoleName | Should -Be $testParameters.ServerRoleName
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
@@ -341,10 +343,10 @@ try
             Context 'When the system is in the desired state and ensure is set to Present' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    Database    = $mockSqlDatabaseName
-                    Name        = $mockSqlServerLogin
+                    Database        = $mockSqlDatabaseName
+                    Name            = $mockSqlServerLogin
                     PermissionState = 'Grant'
-                    Permissions = @( 'Connect','Update' )
+                    Permissions     = @( 'Connect', 'Update' )
                 }
 
                 It 'Should return the state as absent when the desired permission does not exist' {
@@ -356,8 +358,8 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.SQLServer | Should -Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should -Be $testParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.ServerRoleName | Should -Be $testParameters.ServerRoleName
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
@@ -367,10 +369,10 @@ try
             Context 'When the system is not in the desired state and ensure is set to Present' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    Database    = $mockSqlDatabaseName
-                    Name        = $mockSqlServerLogin
+                    Database        = $mockSqlDatabaseName
+                    Name            = $mockSqlServerLogin
                     PermissionState = 'Grant'
-                    Permissions = @( 'Connect','Update','Select' )
+                    Permissions     = @( 'Connect', 'Update', 'Select' )
                 }
 
                 It 'Should not return the state as absent when the desired permission does not exist' {
@@ -382,8 +384,8 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.SQLServer | Should -Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should -Be $testParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.ServerRoleName | Should -Be $testParameters.ServerRoleName
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
@@ -393,7 +395,7 @@ try
             Assert-VerifiableMock
         }
 
-        Describe "MSFT_SqlDatabasePermission\Test-TargetResource" -Tag 'Test'{
+        Describe "MSFT_SqlDatabasePermission\Test-TargetResource" -Tag 'Test' {
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
             }
@@ -402,15 +404,15 @@ try
                 It 'Should throw the correct error' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Database    = 'unknownDatabaseName'
-                        Name        = $mockSqlServerLogin
+                        Database        = 'unknownDatabaseName'
+                        Name            = $mockSqlServerLogin
                         PermissionState = 'Grant'
-                        Permissions = @( 'Connect','Update' )
-                        Ensure      = 'Present'
+                        Permissions     = @( 'Connect', 'Update' )
+                        Ensure          = 'Present'
                     }
 
                     $throwInvalidOperation = ("Database 'unknownDatabaseName' does not exist " + `
-                                              "on SQL server 'localhost\MSSQLSERVER'.")
+                            "on SQL server 'localhost\MSSQLSERVER'.")
 
                     { Test-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
 
@@ -422,15 +424,15 @@ try
                 It 'Should throw the correct error' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Database    = $mockSqlDatabaseName
-                        Name        = 'unknownLoginName'
+                        Database        = $mockSqlDatabaseName
+                        Name            = 'unknownLoginName'
                         PermissionState = 'Grant'
-                        Permissions = @( 'Connect','Update' )
-                        Ensure      = 'Present'
+                        Permissions     = @( 'Connect', 'Update' )
+                        Ensure          = 'Present'
                     }
 
                     $throwInvalidOperation = ("Login 'unknownLoginName' does not exist " + `
-                                              "on SQL server 'localhost\MSSQLSERVER'.")
+                            "on SQL server 'localhost\MSSQLSERVER'.")
 
                     { Test-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
 
@@ -443,15 +445,15 @@ try
                     $mockInvalidOperationEnumDatabasePermissions = $true
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Database    = $mockSqlDatabaseName
-                        Name        = $mockSqlServerLogin
+                        Database        = $mockSqlDatabaseName
+                        Name            = $mockSqlServerLogin
                         PermissionState = 'Grant'
-                        Permissions = @( 'Connect','Update' )
-                        Ensure      = 'Present'
+                        Permissions     = @( 'Connect', 'Update' )
+                        Ensure          = 'Present'
                     }
 
                     $throwInvalidOperation = ('Failed to get permission for login named Zebes\SamusAran of ' + `
-                                              'the database named AdventureWorks on localhost\MSSQLSERVER.')
+                            'the database named AdventureWorks on localhost\MSSQLSERVER.')
 
                     { Test-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
 
@@ -463,11 +465,11 @@ try
                 It 'Should return the state as true when the desired permission does not exist' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Database    = $mockSqlDatabaseName
-                        Name        = $mockSqlServerLogin
+                        Database        = $mockSqlDatabaseName
+                        Name            = $mockSqlServerLogin
                         PermissionState = 'Grant'
-                        Permissions = @( 'Connect','Update','Select' )
-                        Ensure = 'Absent'
+                        Permissions     = @( 'Connect', 'Update', 'Select' )
+                        Ensure          = 'Absent'
                     }
 
                     Test-TargetResource @testParameters | Should -Be $true
@@ -480,11 +482,11 @@ try
                 It 'Should return the state as false when the desired permission does not exist' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Database    = $mockSqlDatabaseName
-                        Name        = $mockSqlServerLogin
+                        Database        = $mockSqlDatabaseName
+                        Name            = $mockSqlServerLogin
                         PermissionState = 'Grant'
-                        Permissions = @( 'Connect','Update' )
-                        Ensure = 'Absent'
+                        Permissions     = @( 'Connect', 'Update' )
+                        Ensure          = 'Absent'
                     }
 
                     Test-TargetResource @testParameters | Should -Be $false
@@ -497,11 +499,11 @@ try
                 It 'Should return the state as false when the desired permission does not exist' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Database    = $mockSqlDatabaseName
-                        Name        = $mockSqlServerLogin
+                        Database        = $mockSqlDatabaseName
+                        Name            = $mockSqlServerLogin
                         PermissionState = 'Grant'
-                        Permissions = @( 'Connect','Update','Select' )
-                        Ensure = 'Present'
+                        Permissions     = @( 'Connect', 'Update', 'Select' )
+                        Ensure          = 'Present'
                     }
 
                     Test-TargetResource @testParameters | Should -Be $false
@@ -514,11 +516,11 @@ try
                 It 'Should return the state as true when the desired permission does exist' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Database    = $mockSqlDatabaseName
-                        Name        = $mockSqlServerLogin
+                        Database        = $mockSqlDatabaseName
+                        Name            = $mockSqlServerLogin
                         PermissionState = 'Grant'
-                        Permissions = @( 'Connect','Update' )
-                        Ensure = 'Present'
+                        Permissions     = @( 'Connect', 'Update' )
+                        Ensure          = 'Present'
                     }
 
                     Test-TargetResource @testParameters | Should -Be $true
@@ -530,7 +532,7 @@ try
             Assert-VerifiableMock
         }
 
-        Describe "MSFT_SqlDatabasePermission\Set-TargetResource" -Tag 'Set'{
+        Describe "MSFT_SqlDatabasePermission\Set-TargetResource" -Tag 'Set' {
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
                 Mock -CommandName New-Object -MockWith $mockNewObjectUser -ParameterFilter {
@@ -547,15 +549,15 @@ try
                 It 'Should throw the correct error' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Database    = 'unknownDatabaseName'
-                        Name        = $mockSqlServerLogin
+                        Database        = 'unknownDatabaseName'
+                        Name            = $mockSqlServerLogin
                         PermissionState = 'Grant'
-                        Permissions = @( 'Connect','Update' )
-                        Ensure      = 'Present'
+                        Permissions     = @( 'Connect', 'Update' )
+                        Ensure          = 'Present'
                     }
 
                     $throwInvalidOperation = ("Database 'unknownDatabaseName' does not exist " + `
-                                              "on SQL server 'localhost\MSSQLSERVER'.")
+                            "on SQL server 'localhost\MSSQLSERVER'.")
 
                     { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
 
@@ -567,15 +569,15 @@ try
                 It 'Should throw the correct error' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Database    = $mockSqlDatabaseName
-                        Name        = 'unknownLoginName'
+                        Database        = $mockSqlDatabaseName
+                        Name            = 'unknownLoginName'
                         PermissionState = 'Grant'
-                        Permissions = @( 'Connect','Update' )
-                        Ensure      = 'Present'
+                        Permissions     = @( 'Connect', 'Update' )
+                        Ensure          = 'Present'
                     }
 
                     $throwInvalidOperation = ("Login 'unknownLoginName' does not exist " + `
-                                              "on SQL server 'localhost\MSSQLSERVER'.")
+                            "on SQL server 'localhost\MSSQLSERVER'.")
 
                     { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
 
@@ -588,16 +590,16 @@ try
                     $mockInvalidOperationForCreateMethod = $true
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Database    = $mockSqlDatabaseName
-                        Name        = $mockSqlServerLoginUnknown
+                        Database        = $mockSqlDatabaseName
+                        Name            = $mockSqlServerLoginUnknown
                         PermissionState = 'Grant'
-                        Permissions = @( 'Connect','Update' )
-                        Ensure      = 'Present'
+                        Permissions     = @( 'Connect', 'Update' )
+                        Ensure          = 'Present'
                     }
 
                     $throwInvalidOperation = ('Failed adding the login Elysia\Chozo ' + `
-                                              'as a user of the database AdventureWorks, ' + `
-                                              'on the instance localhost\MSSQLSERVER.')
+                            'as a user of the database AdventureWorks, ' + `
+                            'on the instance localhost\MSSQLSERVER.')
 
                     { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
 
@@ -611,8 +613,8 @@ try
                 Context 'When the mock methods fail (testing the test)' {
                     BeforeAll {
                         $throwInvalidOperation = ('Failed to set permission for login named ' + `
-                                                'Zebes\SamusAran of the database named ' + `
-                                                'AdventureWorks on localhost\MSSQLSERVER.')
+                                'Zebes\SamusAran of the database named ' + `
+                                'AdventureWorks on localhost\MSSQLSERVER.')
 
                         $mockExpectedSqlServerLogin = $mockSqlServerLoginUnknown
                     }
@@ -620,11 +622,11 @@ try
                     It 'Should throw the correct error when mock Grant() method is called' {
                         $testParameters = $mockDefaultParameters.Clone()
                         $testParameters += @{
-                            Database    = $mockSqlDatabaseName
-                            Name        = $mockSqlServerLogin
+                            Database        = $mockSqlDatabaseName
+                            Name            = $mockSqlServerLogin
                             PermissionState = 'Grant'
-                            Permissions = @( 'Connect','Update' )
-                            Ensure      = 'Present'
+                            Permissions     = @( 'Connect', 'Update' )
+                            Ensure          = 'Present'
                         }
 
                         { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
@@ -637,11 +639,11 @@ try
                     It 'Should throw the correct error when mock Grant() method is called (for GrantWithGrant)' {
                         $testParameters = $mockDefaultParameters.Clone()
                         $testParameters += @{
-                            Database    = $mockSqlDatabaseName
-                            Name        = $mockSqlServerLogin
+                            Database        = $mockSqlDatabaseName
+                            Name            = $mockSqlServerLogin
                             PermissionState = 'GrantWithGrant'
-                            Permissions = @( 'Connect','Update' )
-                            Ensure      = 'Present'
+                            Permissions     = @( 'Connect', 'Update' )
+                            Ensure          = 'Present'
                         }
 
                         { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
@@ -655,11 +657,11 @@ try
                     It 'Should throw the correct error when mock Deny() method is called' {
                         $testParameters = $mockDefaultParameters.Clone()
                         $testParameters += @{
-                            Database    = $mockSqlDatabaseName
-                            Name        = $mockSqlServerLogin
+                            Database        = $mockSqlDatabaseName
+                            Name            = $mockSqlServerLogin
                             PermissionState = 'Deny'
-                            Permissions = @( 'Connect','Update' )
-                            Ensure      = 'Present'
+                            Permissions     = @( 'Connect', 'Update' )
+                            Ensure          = 'Present'
                         }
 
                         { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
@@ -672,11 +674,11 @@ try
                     It 'Should throw the correct error when mock Revoke() method is called' {
                         $testParameters = $mockDefaultParameters.Clone()
                         $testParameters += @{
-                            Database    = $mockSqlDatabaseName
-                            Name        = $mockSqlServerLogin
+                            Database        = $mockSqlDatabaseName
+                            Name            = $mockSqlServerLogin
                             PermissionState = 'Grant'
-                            Permissions = @( 'Connect','Update' )
-                            Ensure      = 'Absent'
+                            Permissions     = @( 'Connect', 'Update' )
+                            Ensure          = 'Absent'
                         }
 
                         { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
@@ -689,11 +691,11 @@ try
                     It 'Should throw the correct error when mock Revoke() method is called' {
                         $testParameters = $mockDefaultParameters.Clone()
                         $testParameters += @{
-                            Database    = $mockSqlDatabaseName
-                            Name        = $mockSqlServerLogin
+                            Database        = $mockSqlDatabaseName
+                            Name            = $mockSqlServerLogin
                             PermissionState = 'GrantWithGrant'
-                            Permissions = @( 'Connect','Update' )
-                            Ensure      = 'Absent'
+                            Permissions     = @( 'Connect', 'Update' )
+                            Ensure          = 'Absent'
                         }
 
                         { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
@@ -711,11 +713,11 @@ try
                             $mockExpectedSqlServerLogin = $mockSqlServerLoginUnknown
                             $testParameters = $mockDefaultParameters
                             $testParameters += @{
-                                Database    = $mockSqlDatabaseName
-                                Name        = $mockSqlServerLoginUnknown
+                                Database        = $mockSqlDatabaseName
+                                Name            = $mockSqlServerLoginUnknown
                                 PermissionState = 'Grant'
-                                Permissions = @( 'Connect','Update' )
-                                Ensure      = 'Present'
+                                Permissions     = @( 'Connect', 'Update' )
+                                Ensure          = 'Present'
                             }
 
                             { Set-TargetResource @testParameters } | Should -Not -Throw
@@ -730,11 +732,11 @@ try
                         $mockExpectedSqlServerLogin = $mockSqlServerLogin
                         $testParameters = $mockDefaultParameters
                         $testParameters += @{
-                            Database    = $mockSqlDatabaseName
-                            Name        = $mockSqlServerLogin
+                            Database        = $mockSqlDatabaseName
+                            Name            = $mockSqlServerLogin
                             PermissionState = 'Grant'
-                            Permissions = @( 'Connect','Update' )
-                            Ensure      = 'Present'
+                            Permissions     = @( 'Connect', 'Update' )
+                            Ensure          = 'Present'
                         }
 
                         { Set-TargetResource @testParameters } | Should -Not -Throw
@@ -750,11 +752,11 @@ try
                         $mockExpectedSqlServerLogin = $mockSqlServerLogin
                         $testParameters = $mockDefaultParameters
                         $testParameters += @{
-                            Database    = $mockSqlDatabaseName
-                            Name        = $mockSqlServerLogin
+                            Database        = $mockSqlDatabaseName
+                            Name            = $mockSqlServerLogin
                             PermissionState = 'GrantWithGrant'
-                            Permissions = @( 'Connect','Update' )
-                            Ensure      = 'Present'
+                            Permissions     = @( 'Connect', 'Update' )
+                            Ensure          = 'Present'
                         }
 
                         { Set-TargetResource @testParameters } | Should -Not -Throw
@@ -770,11 +772,11 @@ try
                         $mockExpectedSqlServerLogin = $mockSqlServerLogin
                         $testParameters = $mockDefaultParameters
                         $testParameters += @{
-                            Database    = $mockSqlDatabaseName
-                            Name        = $mockSqlServerLogin
+                            Database        = $mockSqlDatabaseName
+                            Name            = $mockSqlServerLogin
                             PermissionState = 'Deny'
-                            Permissions = @( 'Connect','Update' )
-                            Ensure      = 'Present'
+                            Permissions     = @( 'Connect', 'Update' )
+                            Ensure          = 'Present'
                         }
 
                         { Set-TargetResource @testParameters } | Should -Not -Throw
@@ -792,11 +794,11 @@ try
                         $mockExpectedSqlServerLogin = $mockSqlServerLogin
                         $testParameters = $mockDefaultParameters
                         $testParameters += @{
-                            Database    = $mockSqlDatabaseName
-                            Name        = $mockSqlServerLogin
+                            Database        = $mockSqlDatabaseName
+                            Name            = $mockSqlServerLogin
                             PermissionState = 'Grant'
-                            Permissions = @( 'Connect','Update' )
-                            Ensure      = 'Absent'
+                            Permissions     = @( 'Connect', 'Update' )
+                            Ensure          = 'Absent'
                         }
 
                         { Set-TargetResource @testParameters } | Should -Not -Throw
@@ -812,11 +814,11 @@ try
                         $mockExpectedSqlServerLogin = $mockSqlServerLogin
                         $testParameters = $mockDefaultParameters
                         $testParameters += @{
-                            Database    = $mockSqlDatabaseName
-                            Name        = $mockSqlServerLogin
+                            Database        = $mockSqlDatabaseName
+                            Name            = $mockSqlServerLogin
                             PermissionState = 'GrantWithGrant'
-                            Permissions = @( 'Connect','Update' )
-                            Ensure      = 'Absent'
+                            Permissions     = @( 'Connect', 'Update' )
+                            Ensure          = 'Absent'
                         }
 
                         { Set-TargetResource @testParameters } | Should -Not -Throw
@@ -832,11 +834,11 @@ try
                         $mockExpectedSqlServerLogin = $mockSqlServerLogin
                         $testParameters = $mockDefaultParameters
                         $testParameters += @{
-                            Database    = $mockSqlDatabaseName
-                            Name        = $mockSqlServerLogin
+                            Database        = $mockSqlDatabaseName
+                            Name            = $mockSqlServerLogin
                             PermissionState = 'Deny'
-                            Permissions = @( 'Connect','Update' )
-                            Ensure      = 'Absent'
+                            Permissions     = @( 'Connect', 'Update' )
+                            Ensure          = 'Absent'
                         }
 
                         { Set-TargetResource @testParameters } | Should -Not -Throw

--- a/Tests/Unit/MSFT_SqlDatabaseRecoveryModel.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabaseRecoveryModel.Tests.ps1
@@ -1,14 +1,14 @@
-$script:DSCModuleName      = 'SqlServerDsc'
-$script:DSCResourceName    = 'MSFT_SqlDatabaseRecoveryModel'
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlDatabaseRecoveryModel'
 
 #region HEADER
 
 # Unit Test Template Version: 1.2.0
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -20,10 +20,12 @@ $TestEnvironment = Initialize-TestEnvironment `
 
 #endregion HEADER
 
-function Invoke-TestSetup {
+function Invoke-TestSetup
+{
 }
 
-function Invoke-TestCleanup {
+function Invoke-TestCleanup
+{
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
 }
 
@@ -32,17 +34,17 @@ try
 {
     Invoke-TestSetup
     InModuleScope $script:DSCResourceName {
-        $mockSqlServerName                   = 'localhost'
-        $mockSqlServerInstanceName           = 'MSSQLSERVER'
-        $mockSqlDatabaseName                 = 'AdventureWorks'
-        $mockSqlDatabaseRecoveryModel        = 'Simple'
-        $mockInvalidOperationForAlterMethod  = $false
-        $mockExpectedRecoveryModel           = 'Simple'
+        $mockServerName = 'localhost'
+        $mockInstanceName = 'MSSQLSERVER'
+        $mockSqlDatabaseName = 'AdventureWorks'
+        $mockSqlDatabaseRecoveryModel = 'Simple'
+        $mockInvalidOperationForAlterMethod = $false
+        $mockExpectedRecoveryModel = 'Simple'
 
         # Default parameters that are used for the It-blocks
         $mockDefaultParameters = @{
-            SQLInstanceName = $mockSqlServerInstanceName
-            SQLServer       = $mockSqlServerName
+            InstanceName = $mockInstanceName
+            ServerName   = $mockServerName
         }
 
         #region Function mocks
@@ -50,34 +52,34 @@ try
             return @(
                 (
                     New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockSqlServerInstanceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockSqlServerName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockInstanceName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockServerName -PassThru |
                         Add-Member -MemberType ScriptProperty -Name Databases -Value {
-                            return @{
-                                $mockSqlDatabaseName = ( New-Object Object |
+                        return @{
+                            $mockSqlDatabaseName = ( New-Object Object |
                                     Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlDatabaseName -PassThru |
                                     Add-Member -MemberType NoteProperty -Name RecoveryModel -Value $mockSqlDatabaseRecoveryModel -PassThru |
                                     Add-Member -MemberType ScriptMethod -Name Alter -Value {
-                                        if ($mockInvalidOperationForAlterMethod)
-                                        {
-                                            throw 'Mock Alter Method was called with invalid operation.'
-                                        }
+                                    if ($mockInvalidOperationForAlterMethod)
+                                    {
+                                        throw 'Mock Alter Method was called with invalid operation.'
+                                    }
 
-                                        if ( $this.RecoveryModel -ne $mockExpectedRecoveryModel )
-                                        {
-                                            throw "Called Alter Drop() method without setting the right recovery model. Expected '{0}'. But was '{1}'." `
-                                                  -f $mockExpectedRecoveryModel, $this.RecoveryModel
-                                        }
-                                    } -PassThru
-                                    )
-                                }
-                            } -PassThru -Force
+                                    if ( $this.RecoveryModel -ne $mockExpectedRecoveryModel )
+                                    {
+                                        throw "Called Alter Drop() method without setting the right recovery model. Expected '{0}'. But was '{1}'." `
+                                            -f $mockExpectedRecoveryModel, $this.RecoveryModel
+                                    }
+                                } -PassThru
+                            )
+                        }
+                    } -PassThru -Force
                 )
             )
         }
         #endregion
 
-        Describe "MSFT_SqlDatabaseRecoveryModel\Get-TargetResource" -Tag 'Get'{
+        Describe "MSFT_SqlDatabaseRecoveryModel\Get-TargetResource" -Tag 'Get' {
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
             }
@@ -86,12 +88,12 @@ try
                 It 'Should throw the correct error' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name        = 'UnknownDatabase'
+                        Name          = 'UnknownDatabase'
                         RecoveryModel = 'Full'
                     }
 
                     $throwInvalidOperation = ("Database 'UnknownDatabase' does not exist " + `
-                                              "on SQL server 'localhost\MSSQLSERVER'.")
+                            "on SQL server 'localhost\MSSQLSERVER'.")
 
                     { Get-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
                 }
@@ -105,7 +107,7 @@ try
                 It 'Should return wrong RecoveryModel' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name = 'AdventureWorks'
+                        Name          = 'AdventureWorks'
                         RecoveryModel = 'Full'
                     }
 
@@ -114,8 +116,8 @@ try
                 }
 
                 It 'Should return the same values as passed as parameters' {
-                    $result.SQLServer | Should -Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should -Be $testParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.Name | Should -Be $testParameters.Name
                 }
 
@@ -128,7 +130,7 @@ try
                 It 'Should return the correct RecoveryModel' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name = 'AdventureWorks'
+                        Name          = 'AdventureWorks'
                         RecoveryModel = 'Simple'
                     }
 
@@ -137,8 +139,8 @@ try
                 }
 
                 It 'Should return the same values as passed as parameters' {
-                    $result.SQLServer | Should -Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should -Be $testParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.Name | Should -Be $testParameters.Name
                 }
 
@@ -150,7 +152,7 @@ try
             Assert-VerifiableMock
         }
 
-        Describe "MSFT_SqlDatabaseRecoveryModel\Test-TargetResource" -Tag 'Test'{
+        Describe "MSFT_SqlDatabaseRecoveryModel\Test-TargetResource" -Tag 'Test' {
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
             }
@@ -159,7 +161,7 @@ try
                 It 'Should return the state as false when desired recovery model is not correct' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name = 'AdventureWorks'
+                        Name          = 'AdventureWorks'
                         RecoveryModel = 'Full'
                     }
 
@@ -176,7 +178,7 @@ try
                 It 'Should return the state as true when desired recovery model is correct' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name = 'AdventureWorks'
+                        Name          = 'AdventureWorks'
                         RecoveryModel = 'Simple'
                     }
 
@@ -192,7 +194,7 @@ try
             Assert-VerifiableMock
         }
 
-        Describe "MSFT_SqlDatabaseRecoveryModel\Set-TargetResource" -Tag 'Set'{
+        Describe "MSFT_SqlDatabaseRecoveryModel\Set-TargetResource" -Tag 'Set' {
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
             }
@@ -201,12 +203,12 @@ try
                 It 'Should throw the correct error' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name        = 'UnknownDatabase'
+                        Name          = 'UnknownDatabase'
                         RecoveryModel = 'Full'
                     }
 
                     $throwInvalidOperation = ("Database 'UnknownDatabase' does not exist " + `
-                                              "on SQL server 'localhost\MSSQLSERVER'.")
+                            "on SQL server 'localhost\MSSQLSERVER'.")
 
                     { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
                 }
@@ -221,7 +223,7 @@ try
                     $mockExpectedRecoveryModel = 'Full'
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name = 'AdventureWorks'
+                        Name          = 'AdventureWorks'
                         RecoveryModel = 'Full'
                     }
 
@@ -235,16 +237,16 @@ try
 
             Context 'When the system is not in the desired state' {
                 It 'Should throw when calling the alter method when desired recovery model should be set' {
-                    $mockInvalidOperationForAlterMethod  = $true
+                    $mockInvalidOperationForAlterMethod = $true
                     $mockExpectedRecoveryModel = 'Full'
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name = 'AdventureWorks'
+                        Name          = 'AdventureWorks'
                         RecoveryModel = 'Full'
                     }
 
                     $throwInvalidOperation = ('Exception calling "Alter" with "0" argument(s): ' +
-                                              '"Mock Alter Method was called with invalid operation."')
+                        '"Mock Alter Method was called with invalid operation."')
 
                     { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
                 }

--- a/Tests/Unit/MSFT_SqlDatabaseRole.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabaseRole.Tests.ps1
@@ -1,14 +1,14 @@
-$script:DSCModuleName      = 'SqlServerDsc'
-$script:DSCResourceName    = 'MSFT_SqlDatabaseRole'
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlDatabaseRole'
 
 #region HEADER
 
 # Unit Test Template Version: 1.2.0
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -20,12 +20,14 @@ $TestEnvironment = Initialize-TestEnvironment `
 
 #endregion HEADER
 
-function Invoke-TestSetup {
+function Invoke-TestSetup
+{
     # Loading mocked classes
     Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
 }
 
-function Invoke-TestCleanup {
+function Invoke-TestCleanup
+{
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
 }
 
@@ -35,27 +37,27 @@ try
     Invoke-TestSetup
 
     InModuleScope $script:DSCResourceName {
-        $mockSqlServerName                          = 'localhost'
-        $mockSqlServerInstanceName                  = 'MSSQLSERVER'
-        $mockSqlDatabaseName                        = 'AdventureWorks'
-        $mockSqlServerLogin                         = 'John'
-        $mockSqlServerLoginOne                      = 'CONTOSO\KingJulian'
-        $mockSqlServerLoginTwo                      = 'CONTOSO\SQLAdmin'
-        $mockSqlServerLoginType                     = 'WindowsUser'
-        $mockSqlDatabaseRole                        = 'MyRole'
-        $mockSqlDatabaseRoleSecond                  = 'MySecondRole'
-        $mockExpectedSqlDatabaseRole                = 'MyRole'
-        $mockInvalidOperationForAddMemberMethod     = $false
-        $mockInvalidOperationForDropMemberMethod    = $false
-        $mockInvalidOperationForCreateMethod        = $false
-        $mockExpectedForAddMemberMethod             = 'MySecondRole'
-        $mockExpectedForDropMemberMethod            = 'MyRole'
-        $mockExpectedForCreateMethod                = 'John'
+        $mockServerName = 'localhost'
+        $mockInstanceName = 'MSSQLSERVER'
+        $mockSqlDatabaseName = 'AdventureWorks'
+        $mockSqlServerLogin = 'John'
+        $mockSqlServerLoginOne = 'CONTOSO\KingJulian'
+        $mockSqlServerLoginTwo = 'CONTOSO\SQLAdmin'
+        $mockSqlServerLoginType = 'WindowsUser'
+        $mockSqlDatabaseRole = 'MyRole'
+        $mockSqlDatabaseRoleSecond = 'MySecondRole'
+        $mockExpectedSqlDatabaseRole = 'MyRole'
+        $mockInvalidOperationForAddMemberMethod = $false
+        $mockInvalidOperationForDropMemberMethod = $false
+        $mockInvalidOperationForCreateMethod = $false
+        $mockExpectedForAddMemberMethod = 'MySecondRole'
+        $mockExpectedForDropMemberMethod = 'MyRole'
+        $mockExpectedForCreateMethod = 'John'
 
         # Default parameters that are used for the It-blocks
         $mockDefaultParameters = @{
-            SQLInstanceName = $mockSqlServerInstanceName
-            SQLServer       = $mockSqlServerName
+            InstanceName = $mockInstanceName
+            ServerName   = $mockServerName
         }
 
         #region Function mocks
@@ -63,131 +65,131 @@ try
             return @(
                 (
                     New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockSqlServerInstanceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockSqlServerName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockInstanceName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockServerName -PassThru |
                         Add-Member -MemberType ScriptProperty -Name Databases -Value {
-                            return @{
-                                $mockSqlDatabaseName = @((
+                        return @{
+                            $mockSqlDatabaseName = @((
                                     New-Object Object |
                                         Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlDatabaseName -PassThru |
                                         Add-Member -MemberType ScriptProperty -Name Users -Value {
-                                            return @{
-                                                $mockSqlServerLoginOne = @((
+                                        return @{
+                                            $mockSqlServerLoginOne = @((
                                                     New-Object Object |
                                                         Add-Member -MemberType ScriptMethod -Name IsMember -Value {
-                                                            param(
-                                                                [String]
-                                                                $mockSqlDatabaseRole
-                                                            )
-                                                            if ( $mockSqlDatabaseRole -eq $mockExpectedSqlDatabaseRole )
-                                                            {
-                                                                return $true
-                                                            }
-                                                            else
-                                                            {
-                                                                return $false
-                                                            }
-                                                        } -PassThru
+                                                        param(
+                                                            [String]
+                                                            $mockSqlDatabaseRole
+                                                        )
+                                                        if ( $mockSqlDatabaseRole -eq $mockExpectedSqlDatabaseRole )
+                                                        {
+                                                            return $true
+                                                        }
+                                                        else
+                                                        {
+                                                            return $false
+                                                        }
+                                                    } -PassThru
                                                 ))
-                                                $mockSqlServerLoginTwo = @((
+                                            $mockSqlServerLoginTwo = @((
                                                     New-Object Object |
                                                         Add-Member -MemberType ScriptMethod -Name IsMember -Value {
-                                                                return $true
-                                                        } -PassThru
+                                                        return $true
+                                                    } -PassThru
                                                 ))
-                                            }
-                                        } -PassThru |
+                                        }
+                                    } -PassThru |
                                         Add-Member -MemberType ScriptProperty -Name Roles -Value {
-                                            return @{
-                                                $mockSqlDatabaseRole = @((
+                                        return @{
+                                            $mockSqlDatabaseRole       = @((
                                                     New-Object Object |
                                                         Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlDatabaseRole -PassThru |
                                                         Add-Member -MemberType ScriptMethod -Name AddMember -Value {
-                                                            param(
-                                                                [String]
-                                                                $mockSqlServerLogin
-                                                            )
-                                                            if ($mockInvalidOperationForAddMemberMethod)
-                                                            {
-                                                                throw 'Mock AddMember Method was called with invalid operation.'
-                                                            }
-                                                            if ( $this.Name -ne $mockExpectedForAddMemberMethod )
-                                                            {
-                                                                throw "Called mocked AddMember() method without adding the right user. Expected '{0}'. But was '{1}'." `
-                                                                        -f $mockExpectedForAddMemberMethod, $this.Name
-                                                            }
-                                                        } -PassThru |
+                                                        param(
+                                                            [String]
+                                                            $mockSqlServerLogin
+                                                        )
+                                                        if ($mockInvalidOperationForAddMemberMethod)
+                                                        {
+                                                            throw 'Mock AddMember Method was called with invalid operation.'
+                                                        }
+                                                        if ( $this.Name -ne $mockExpectedForAddMemberMethod )
+                                                        {
+                                                            throw "Called mocked AddMember() method without adding the right user. Expected '{0}'. But was '{1}'." `
+                                                                -f $mockExpectedForAddMemberMethod, $this.Name
+                                                        }
+                                                    } -PassThru |
                                                         Add-Member -MemberType ScriptMethod -Name DropMember -Value {
-                                                            param(
-                                                                [String]
-                                                                $mockSqlServerLogin
-                                                            )
-                                                            if ($mockInvalidOperationForDropMemberMethod)
-                                                            {
-                                                                throw 'Mock DropMember Method was called with invalid operation.'
-                                                            }
-                                                            if ( $this.Name -ne $mockExpectedForDropMemberMethod )
-                                                            {
-                                                                throw "Called mocked Drop() method without adding the right user. Expected '{0}'. But was '{1}'." `
-                                                                        -f $mockExpectedForDropMemberMethod, $this.Name
-                                                            }
-                                                        } -PassThru
+                                                        param(
+                                                            [String]
+                                                            $mockSqlServerLogin
+                                                        )
+                                                        if ($mockInvalidOperationForDropMemberMethod)
+                                                        {
+                                                            throw 'Mock DropMember Method was called with invalid operation.'
+                                                        }
+                                                        if ( $this.Name -ne $mockExpectedForDropMemberMethod )
+                                                        {
+                                                            throw "Called mocked Drop() method without adding the right user. Expected '{0}'. But was '{1}'." `
+                                                                -f $mockExpectedForDropMemberMethod, $this.Name
+                                                        }
+                                                    } -PassThru
                                                 ))
-                                                $mockSqlDatabaseRoleSecond = @((
+                                            $mockSqlDatabaseRoleSecond = @((
                                                     New-Object Object |
                                                         Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlDatabaseRoleSecond -PassThru |
                                                         Add-Member -MemberType ScriptMethod -Name AddMember -Value {
-                                                            param(
-                                                                [String]
-                                                                $mockSqlServerLogin
-                                                            )
-                                                            if ($mockInvalidOperationForAddMemberMethod)
-                                                            {
-                                                                throw 'Mock AddMember Method was called with invalid operation.'
-                                                            }
-                                                            if ( $this.Name -ne $mockExpectedForAddMemberMethod )
-                                                            {
-                                                                throw "Called mocked AddMember() method without adding the right user. Expected '{0}'. But was '{1}'." `
-                                                                        -f $mockExpectedForAddMemberMethod, $this.Name
-                                                            }
-                                                        } -PassThru |
+                                                        param(
+                                                            [String]
+                                                            $mockSqlServerLogin
+                                                        )
+                                                        if ($mockInvalidOperationForAddMemberMethod)
+                                                        {
+                                                            throw 'Mock AddMember Method was called with invalid operation.'
+                                                        }
+                                                        if ( $this.Name -ne $mockExpectedForAddMemberMethod )
+                                                        {
+                                                            throw "Called mocked AddMember() method without adding the right user. Expected '{0}'. But was '{1}'." `
+                                                                -f $mockExpectedForAddMemberMethod, $this.Name
+                                                        }
+                                                    } -PassThru |
                                                         Add-Member -MemberType ScriptMethod -Name DropMember -Value {
-                                                            param(
-                                                                [String]
-                                                                $mockSqlServerLogin
-                                                            )
-                                                            if ($mockInvalidOperationForDropMemberMethod)
-                                                            {
-                                                                throw 'Mock DropMember Method was called with invalid operation.'
-                                                            }
-                                                            if ( $this.Name -ne $mockExpectedForDropMemberMethod )
-                                                            {
-                                                                throw "Called mocked Drop() method without adding the right user. Expected '{0}'. But was '{1}'." `
-                                                                        -f $mockExpectedForDropMemberMethod, $this.Name
-                                                            }
-                                                        } -PassThru
+                                                        param(
+                                                            [String]
+                                                            $mockSqlServerLogin
+                                                        )
+                                                        if ($mockInvalidOperationForDropMemberMethod)
+                                                        {
+                                                            throw 'Mock DropMember Method was called with invalid operation.'
+                                                        }
+                                                        if ( $this.Name -ne $mockExpectedForDropMemberMethod )
+                                                        {
+                                                            throw "Called mocked Drop() method without adding the right user. Expected '{0}'. But was '{1}'." `
+                                                                -f $mockExpectedForDropMemberMethod, $this.Name
+                                                        }
+                                                    } -PassThru
                                                 ))
-                                            }
-                                        }-PassThru -Force
-                                    ))
-                                }
-                            } -PassThru -Force |
+                                        }
+                                    }-PassThru -Force
+                                ))
+                        }
+                    } -PassThru -Force |
                         Add-Member -MemberType ScriptProperty -Name Logins -Value {
-                            return @{
-                                $mockSqlServerLoginOne = @((
+                        return @{
+                            $mockSqlServerLoginOne = @((
                                     New-Object Object |
                                         Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru
                                 ))
-                                $mockSqlServerLoginTwo = @((
+                            $mockSqlServerLoginTwo = @((
                                     New-Object Object |
                                         Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru
                                 ))
-                                $mockSqlServerLogin = @((
+                            $mockSqlServerLogin    = @((
                                     New-Object Object |
                                         Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru
                                 ))
-                            }
-                        } -PassThru -Force
+                        }
+                    } -PassThru -Force
 
                 )
             )
@@ -200,22 +202,22 @@ try
                         Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlServerLogin -PassThru |
                         Add-Member -MemberType NoteProperty -Name Login -Value $mockSqlServerLogin -PassThru |
                         Add-Member -MemberType ScriptMethod -Name Create -Value {
-                            if ($mockInvalidOperationForCreateMethod)
-                            {
-                                throw 'Mock Create Method was called with invalid operation.'
-                            }
-                            if ( $this.Name -ne $mockExpectedForCreateMethod )
-                            {
-                                throw "Called mocked Create() method without adding the right user. Expected '{0}'. But was '{1}'." `
-                                        -f $mockExpectedForCreateMethod, $this.Name
-                            }
-                        } -PassThru -Force
+                        if ($mockInvalidOperationForCreateMethod)
+                        {
+                            throw 'Mock Create Method was called with invalid operation.'
+                        }
+                        if ( $this.Name -ne $mockExpectedForCreateMethod )
+                        {
+                            throw "Called mocked Create() method without adding the right user. Expected '{0}'. But was '{1}'." `
+                                -f $mockExpectedForCreateMethod, $this.Name
+                        }
+                    } -PassThru -Force
                 )
             )
         }
         #endregion
 
-        Describe "MSFT_SqlDatabaseRole\Get-TargetResource" -Tag 'Get'{
+        Describe "MSFT_SqlDatabaseRole\Get-TargetResource" -Tag 'Get' {
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
             }
@@ -224,13 +226,13 @@ try
                 It 'Should throw the correct error' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name        = $mockSqlServerLoginOne
-                        Database    = 'unknownDatabaseName'
-                        Role        = $mockSqlDatabaseRole
+                        Name     = $mockSqlServerLoginOne
+                        Database = 'unknownDatabaseName'
+                        Role     = $mockSqlDatabaseRole
                     }
 
                     $throwInvalidOperation = ("Database 'unknownDatabaseName' does not exist " + `
-                                              "on SQL server 'localhost\MSSQLSERVER'.")
+                            "on SQL server 'localhost\MSSQLSERVER'.")
 
                     { Get-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
                 }
@@ -244,13 +246,13 @@ try
                 It 'Should throw the correct error' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name        = $mockSqlServerLoginOne
-                        Database    = $mockSqlDatabaseName
-                        Role        = 'unknownRoleName'
+                        Name     = $mockSqlServerLoginOne
+                        Database = $mockSqlDatabaseName
+                        Role     = 'unknownRoleName'
                     }
 
-                     $throwInvalidOperation = ("Role 'unknownRoleName' does not exist on database " + `
-                                               "'AdventureWorks' on SQL server 'localhost\MSSQLSERVER'.")
+                    $throwInvalidOperation = ("Role 'unknownRoleName' does not exist on database " + `
+                            "'AdventureWorks' on SQL server 'localhost\MSSQLSERVER'.")
 
                     { Get-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
                 }
@@ -264,9 +266,9 @@ try
                 It 'Should not throw' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name        = $mockSqlServerLoginOne
-                        Database    = $mockSqlDatabaseName
-                        Role        = @($mockSqlDatabaseRole,$mockSqlDatabaseRoleSecond)
+                        Name     = $mockSqlServerLoginOne
+                        Database = $mockSqlDatabaseName
+                        Role     = @($mockSqlDatabaseRole, $mockSqlDatabaseRoleSecond)
                     }
 
                     { Get-TargetResource @testParameters } | Should -Not -Throw
@@ -281,13 +283,13 @@ try
                 It 'Should throw the correct error' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name        = 'unknownLoginName'
-                        Database    = $mockSqlDatabaseName
-                        Role        = $mockSqlDatabaseRole
+                        Name     = 'unknownLoginName'
+                        Database = $mockSqlDatabaseName
+                        Role     = $mockSqlDatabaseRole
                     }
 
                     $throwInvalidOperation = ("Login 'unknownLoginName' does not exist " + `
-                                              "on SQL server 'localhost\MSSQLSERVER'.")
+                            "on SQL server 'localhost\MSSQLSERVER'.")
 
                     { Get-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
                 }
@@ -300,9 +302,9 @@ try
             Context 'When the system is not in the desired state, with one role' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    Name        = $mockSqlServerLoginOne
-                    Database    = $mockSqlDatabaseName
-                    Role        = $mockSqlDatabaseRoleSecond
+                    Name     = $mockSqlServerLoginOne
+                    Database = $mockSqlDatabaseName
+                    Role     = $mockSqlDatabaseRoleSecond
                 }
 
                 It 'Should return the state as absent' {
@@ -321,8 +323,8 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.SQLServer | Should -Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should -Be $testParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.Database | Should -Be $testParameters.Database
                     $result.Name | Should -Be $testParameters.Name
 
@@ -333,9 +335,9 @@ try
             Context 'When the system is not in the desired state, with two roles' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    Name        = $mockSqlServerLoginOne
-                    Database    = $mockSqlDatabaseName
-                    Role        = @($mockSqlDatabaseRole,$mockSqlDatabaseRoleSecond)
+                    Name     = $mockSqlServerLoginOne
+                    Database = $mockSqlDatabaseName
+                    Role     = @($mockSqlDatabaseRole, $mockSqlDatabaseRoleSecond)
                 }
 
                 It 'Should return the state as absent' {
@@ -354,8 +356,8 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.SQLServer | Should -Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should -Be $testParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.Database | Should -Be $testParameters.Database
                     $result.Name | Should -Be $testParameters.Name
 
@@ -366,9 +368,9 @@ try
             Context 'When the system is not in the desired state, and login is not a member of the database' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    Name        = $mockSqlServerLogin
-                    Database    = $mockSqlDatabaseName
-                    Role        = $mockSqlDatabaseRole
+                    Name     = $mockSqlServerLogin
+                    Database = $mockSqlDatabaseName
+                    Role     = $mockSqlDatabaseRole
                 }
 
                 It 'Should return the state as absent' {
@@ -380,8 +382,8 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.SQLServer | Should -Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should -Be $testParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.Database | Should -Be $testParameters.Database
                     $result.Name | Should -Be $testParameters.Name
 
@@ -392,9 +394,9 @@ try
             Context 'When the system is in the desired state for a Windows user' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    Name        = $mockSqlServerLoginOne
-                    Database    = $mockSqlDatabaseName
-                    Role        = $mockSqlDatabaseRole
+                    Name     = $mockSqlServerLoginOne
+                    Database = $mockSqlDatabaseName
+                    Role     = $mockSqlDatabaseRole
                 }
 
                 It 'Should return the state as absent' {
@@ -406,8 +408,8 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.SQLServer | Should -Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should -Be $testParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.Database | Should -Be $testParameters.Database
                     $result.Name | Should -Be $testParameters.Name
                     $result.Role | Should -Be $testParameters.Role
@@ -419,7 +421,7 @@ try
             Assert-VerifiableMock
         }
 
-        Describe "MSFT_SqlDatabaseRole\Test-TargetResource" -Tag 'Test'{
+        Describe "MSFT_SqlDatabaseRole\Test-TargetResource" -Tag 'Test' {
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
             }
@@ -428,10 +430,10 @@ try
                 It 'Should return the state as false when one desired role is not configured' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name        = $mockSqlServerLoginOne
-                        Database    = $mockSqlDatabaseName
-                        Role        = $mockSqlDatabaseRoleSecond
-                        Ensure      = 'Present'
+                        Name     = $mockSqlServerLoginOne
+                        Database = $mockSqlDatabaseName
+                        Role     = $mockSqlDatabaseRoleSecond
+                        Ensure   = 'Present'
                     }
 
                     $result = Test-TargetResource @testParameters
@@ -447,10 +449,10 @@ try
                 It 'Should return the state as false when two desired roles are not configured' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name        = $mockSqlServerLoginOne
-                        Database    = $mockSqlDatabaseName
-                        Role        = @($mockSqlDatabaseRole,$mockSqlDatabaseRoleSecond)
-                        Ensure      = 'Present'
+                        Name     = $mockSqlServerLoginOne
+                        Database = $mockSqlDatabaseName
+                        Role     = @($mockSqlDatabaseRole, $mockSqlDatabaseRoleSecond)
+                        Ensure   = 'Present'
                     }
 
                     $result = Test-TargetResource @testParameters
@@ -466,10 +468,10 @@ try
                 It 'Should return the state as false when undesired roles are not configured' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name        = $mockSqlServerLoginTwo
-                        Database    = $mockSqlDatabaseName
-                        Role        = @($mockSqlDatabaseRole,$mockSqlDatabaseRoleSecond)
-                        Ensure      = 'Absent'
+                        Name     = $mockSqlServerLoginTwo
+                        Database = $mockSqlDatabaseName
+                        Role     = @($mockSqlDatabaseRole, $mockSqlDatabaseRoleSecond)
+                        Ensure   = 'Absent'
                     }
 
                     $result = Test-TargetResource @testParameters
@@ -485,10 +487,10 @@ try
                 It 'Should return the state as true when one desired role is correctly configured' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name        = $mockSqlServerLoginOne
-                        Database    = $mockSqlDatabaseName
-                        Role        = $mockSqlDatabaseRole
-                        Ensure      = 'Present'
+                        Name     = $mockSqlServerLoginOne
+                        Database = $mockSqlDatabaseName
+                        Role     = $mockSqlDatabaseRole
+                        Ensure   = 'Present'
                     }
 
                     $result = Test-TargetResource @testParameters
@@ -504,10 +506,10 @@ try
                 It 'Should return the state as true when two desired role are correctly configured' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name        = $mockSqlServerLoginTwo
-                        Database    = $mockSqlDatabaseName
-                        Role        = @($mockSqlDatabaseRole,$mockSqlDatabaseRoleSecond)
-                        Ensure      = 'Present'
+                        Name     = $mockSqlServerLoginTwo
+                        Database = $mockSqlDatabaseName
+                        Role     = @($mockSqlDatabaseRole, $mockSqlDatabaseRoleSecond)
+                        Ensure   = 'Present'
                     }
 
                     $result = Test-TargetResource @testParameters
@@ -523,10 +525,10 @@ try
                 It 'Should return the state as true when two desired role are correctly configured' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name        = $mockSqlServerLoginOne
-                        Database    = $mockSqlDatabaseName
-                        Role        = $mockSqlDatabaseRoleSecond
-                        Ensure      = 'Absent'
+                        Name     = $mockSqlServerLoginOne
+                        Database = $mockSqlDatabaseName
+                        Role     = $mockSqlDatabaseRoleSecond
+                        Ensure   = 'Absent'
                     }
 
                     $result = Test-TargetResource @testParameters
@@ -541,7 +543,7 @@ try
             Assert-VerifiableMock
         }
 
-        Describe "MSFT_SqlDatabaseRole\Set-TargetResource" -Tag 'Set'{
+        Describe "MSFT_SqlDatabaseRole\Set-TargetResource" -Tag 'Set' {
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
                 Mock -CommandName New-Object -MockWith $mockNewObjectUser -ParameterFilter {
@@ -551,13 +553,13 @@ try
 
             Context 'When the system is not in the desired state, Ensure is set to Present and Login does not exist' {
                 It 'Should Not Throw when Ensure parameter is set to Present' {
-                    $mockExpectedForAddMemberMethod    = 'MyRole'
+                    $mockExpectedForAddMemberMethod = 'MyRole'
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name        = $mockSqlServerLogin
-                        Database    = $mockSqlDatabaseName
-                        Role        = $mockSqlDatabaseRole
-                        Ensure      = 'Present'
+                        Name     = $mockSqlServerLogin
+                        Database = $mockSqlDatabaseName
+                        Role     = $mockSqlDatabaseRole
+                        Ensure   = 'Present'
                     }
 
                     { Set-TargetResource @testParameters } | Should -Not -Throw
@@ -579,15 +581,15 @@ try
                     $mockInvalidOperationForCreateMethod = $true
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name        = $mockSqlServerLogin
-                        Database    = $mockSqlDatabaseName
-                        Role        = $mockSqlDatabaseRoleSecond
-                        Ensure      = 'Present'
+                        Name     = $mockSqlServerLogin
+                        Database = $mockSqlDatabaseName
+                        Role     = $mockSqlDatabaseRoleSecond
+                        Ensure   = 'Present'
                     }
 
                     $throwInvalidOperation = ('Failed adding the login John as a user of the database AdventureWorks, on ' + `
-                                              'the instance localhost\MSSQLSERVER. InnerException: Exception calling "Create" ' + `
-                                              'with "0" argument(s): "Mock Create Method was called with invalid operation."')
+                            'the instance localhost\MSSQLSERVER. InnerException: Exception calling "Create" ' + `
+                            'with "0" argument(s): "Mock Create Method was called with invalid operation."')
 
                     { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
                 }
@@ -609,10 +611,10 @@ try
                     $mockSqlServerLogin = $mockSqlServerLoginOne
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name        = $mockSqlServerLogin
-                        Database    = $mockSqlDatabaseName
-                        Role        = $mockSqlDatabaseRoleSecond
-                        Ensure      = 'Present'
+                        Name     = $mockSqlServerLogin
+                        Database = $mockSqlDatabaseName
+                        Role     = $mockSqlDatabaseRoleSecond
+                        Ensure   = 'Present'
                     }
 
                     { Set-TargetResource @testParameters } | Should -Not -Throw
@@ -634,16 +636,16 @@ try
                     $mockInvalidOperationForAddMemberMethod = $true
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name        = $mockSqlServerLoginOne
-                        Database    = $mockSqlDatabaseName
-                        Role        = $mockSqlDatabaseRoleSecond
-                        Ensure      = 'Present'
+                        Name     = $mockSqlServerLoginOne
+                        Database = $mockSqlDatabaseName
+                        Role     = $mockSqlDatabaseRoleSecond
+                        Ensure   = 'Present'
                     }
 
                     $throwInvalidOperation = ('Failed adding the login CONTOSO\KingJulian to the role MySecondRole on ' + `
-                                              'the database AdventureWorks, on the instance localhost\MSSQLSERVER. ' + `
-                                              'InnerException: Exception calling "AddMember" with "1" argument(s): ' + `
-                                              '"Mock AddMember Method was called with invalid operation."')
+                            'the database AdventureWorks, on the instance localhost\MSSQLSERVER. ' + `
+                            'InnerException: Exception calling "AddMember" with "1" argument(s): ' + `
+                            '"Mock AddMember Method was called with invalid operation."')
 
                     { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
                 }
@@ -663,10 +665,10 @@ try
                 It 'Should not throw the correct error when Ensure parameter is set to Absent' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name        = $mockSqlServerLoginTwo
-                        Database    = $mockSqlDatabaseName
-                        Role        = $mockSqlDatabaseRole
-                        Ensure      = 'Absent'
+                        Name     = $mockSqlServerLoginTwo
+                        Database = $mockSqlDatabaseName
+                        Role     = $mockSqlDatabaseRole
+                        Ensure   = 'Absent'
                     }
 
                     { Set-TargetResource @testParameters } | Should -Not -Throw
@@ -689,16 +691,16 @@ try
                 It 'Should not throw the correct error when Ensure parameter is set to Absent' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name        = $mockSqlServerLoginTwo
-                        Database    = $mockSqlDatabaseName
-                        Role        = $mockSqlDatabaseRole
-                        Ensure      = 'Absent'
+                        Name     = $mockSqlServerLoginTwo
+                        Database = $mockSqlDatabaseName
+                        Role     = $mockSqlDatabaseRole
+                        Ensure   = 'Absent'
                     }
 
                     $throwInvalidOperation = ('Failed removing the login CONTOSO\SQLAdmin from the role MyRole on ' + `
-                                              'the database AdventureWorks, on the instance localhost\MSSQLSERVER. ' + `
-                                              'InnerException: Exception calling "DropMember" with "1" argument(s): ' + `
-                                              '"Mock DropMember Method was called with invalid operation."')
+                            'the database AdventureWorks, on the instance localhost\MSSQLSERVER. ' + `
+                            'InnerException: Exception calling "DropMember" with "1" argument(s): ' + `
+                            '"Mock DropMember Method was called with invalid operation."')
 
                     { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
                 }

--- a/Tests/Unit/MSFT_SqlServerConfiguration.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerConfiguration.Tests.ps1
@@ -1,12 +1,12 @@
-$script:DSCModuleName      = 'SqlServerDsc'
-$script:DSCResourceName    = 'MSFT_SqlServerConfiguration'
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlServerConfiguration'
 
 # Unit Test Template Version: 1.1.0
 [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -16,46 +16,46 @@ $TestEnvironment = Initialize-TestEnvironment `
     -TestType Unit
 
 $defaultState = @{
-    SQLServer = 'CLU01'
-    SQLInstanceName = 'ClusteredInstance'
-    OptionName = 'user connections'
-    OptionValue = 0
+    ServerName     = 'CLU01'
+    InstanceName   = 'ClusteredInstance'
+    OptionName     = 'user connections'
+    OptionValue    = 0
     RestartService = $false
     RestartTimeout = 120
 }
 
 $desiredState = @{
-    SQLServer = 'CLU01'
-    SQLInstanceName = 'ClusteredInstance'
-    OptionName = 'user connections'
-    OptionValue = 500
+    ServerName     = 'CLU01'
+    InstanceName   = 'ClusteredInstance'
+    OptionName     = 'user connections'
+    OptionValue    = 500
     RestartService = $false
     RestartTimeout = 120
 }
 
 $desiredStateRestart = @{
-    SQLServer = 'CLU01'
-    SQLInstanceName = 'ClusteredInstance'
-    OptionName = 'user connections'
-    OptionValue = 5000
+    ServerName     = 'CLU01'
+    InstanceName   = 'ClusteredInstance'
+    OptionName     = 'user connections'
+    OptionValue    = 5000
     RestartService = $true
     RestartTimeout = 120
 }
 
 $dynamicOption = @{
-    SQLServer = 'CLU02'
-    SQLInstanceName = 'ClusteredInstance'
-    OptionName = 'show advanced options'
-    OptionValue = 0
+    ServerName     = 'CLU02'
+    InstanceName   = 'ClusteredInstance'
+    OptionName     = 'show advanced options'
+    OptionValue    = 0
     RestartService = $false
     RestartTimeout = 120
 }
 
 $invalidOption = @{
-    SQLServer = 'CLU01'
-    SQLInstanceName = 'MSSQLSERVER'
-    OptionName = 'Does Not Exist'
-    OptionValue = 1
+    ServerName     = 'CLU01'
+    InstanceName   = 'MSSQLSERVER'
+    OptionName     = 'Does Not Exist'
+    OptionValue    = 1
     RestartService = $false
     RestartTimeout = 120
 }
@@ -95,8 +95,8 @@ try
             $result = Get-TargetResource @desiredState
 
             It 'Should return the same values as passed' {
-                $result.SQLServer | Should -Be $desiredState.SQLServer
-                $result.SQLInstanceName | Should -Be $desiredState.SQLInstanceName
+                $result.ServerName | Should -Be $desiredState.ServerName
+                $result.InstanceName | Should -Be $desiredState.InstanceName
                 $result.OptionName | Should -Be $desiredState.OptionName
                 $result.OptionValue | Should -Not -Be $desiredState.OptionValue
                 $result.RestartService | Should -Be $desiredState.RestartService
@@ -132,8 +132,8 @@ try
             $result = Get-TargetResource @desiredState
 
             It 'Should return the same values as passed' {
-                $result.SQLServer | Should -Be $desiredState.SQLServer
-                $result.SQLInstanceName | Should -Be $desiredState.SQLInstanceName
+                $result.ServerName | Should -Be $desiredState.ServerName
+                $result.InstanceName | Should -Be $desiredState.InstanceName
                 $result.OptionName | Should -Be $desiredState.OptionName
                 $result.OptionValue | Should -Be $desiredState.OptionValue
                 $result.RestartService | Should -Be $desiredState.RestartService
@@ -216,7 +216,7 @@ try
                         @{
                             DisplayName = 'user connections'
                             ConfigValue = 0
-                            IsDynamic = $false
+                            IsDynamic   = $false
                         }
                     )
                 }
@@ -235,7 +235,7 @@ try
                         @{
                             DisplayName = 'show advanced options'
                             ConfigValue = 1
-                            IsDynamic = $true
+                            IsDynamic   = $true
                         }
                     )
                 }

--- a/Tests/Unit/MSFT_SqlServerEndpoint.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerEndpoint.Tests.ps1
@@ -35,7 +35,7 @@ try
     Invoke-TestSetup
 
     InModuleScope $script:DSCResourceName {
-        $mockNodeName = 'localhost'
+        $mockServerName = 'localhost'
         $mockInstanceName = 'INSTANCE1'
         $mockPrincipal = 'COMPANY\SqlServiceAcct'
         $mockOtherPrincipal = 'COMPANY\OtherAcct'
@@ -136,8 +136,8 @@ try
         }
 
         $defaultParameters = @{
-            SQLInstanceName = $mockInstanceName
-            SQLServer = $mockNodeName
+            InstanceName = $mockInstanceName
+            ServerName = $mockServerName
             EndpointName = $mockEndpointName
         }
 
@@ -159,8 +159,8 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.SQLServer | Should -Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should -Be $testParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
                 }
 
                 It 'Should not return any values in the properties for the endpoint' {
@@ -187,8 +187,8 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.SQLServer | Should -Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should -Be $testParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.EndpointName | Should -Be $testParameters.EndpointName
                     $result.Port | Should -Be $mockEndpointListenerPort
                     $result.IpAddress | Should -Be $mockEndpointListenerIpAddress

--- a/Tests/Unit/MSFT_SqlServerEndpointPermission.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerEndpointPermission.Tests.ps1
@@ -1,14 +1,14 @@
-$script:DSCModuleName      = 'SqlServerDsc'
-$script:DSCResourceName    = 'MSFT_SqlServerEndpointPermission'
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlServerEndpointPermission'
 
 #region HEADER
 
 # Unit Test Template Version: 1.2.0
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -20,12 +20,14 @@ $TestEnvironment = Initialize-TestEnvironment `
 
 #endregion HEADER
 
-function Invoke-TestSetup {
+function Invoke-TestSetup
+{
     # Loading mocked classes
     Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
 }
 
-function Invoke-TestCleanup {
+function Invoke-TestCleanup
+{
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
 }
 
@@ -49,46 +51,46 @@ try
         $mockConnectSql = {
             return New-Object Object |
                 Add-Member -MemberType ScriptProperty -Name 'Endpoints' {
-                    return @(
-                        @{
-                            # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
-                            $mockDynamicEndpointName = New-Object Object |
-                                                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockEndpointName -PassThru |
-                                                        Add-Member -MemberType ScriptMethod -Name 'EnumObjectPermissions' {
-                                                            param($permissionSet)
-                                                            return @(
-                                                                (New-Object Object |
-                                                                    Add-Member -MemberType NoteProperty Grantee $mockDynamicPrincipal -PassThru |
-                                                                    Add-Member -MemberType NoteProperty PermissionState 'Grant' -PassThru
-                                                                )
-                                                            )
-                                                        } -PassThru |
-                                                        Add-Member -MemberType ScriptMethod -Name 'Grant' {
-                                                            param(
-                                                                $permissionSet,
-                                                                $mockPrincipal
-                                                            )
+                return @(
+                    @{
+                        # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                        $mockDynamicEndpointName = New-Object Object |
+                            Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockEndpointName -PassThru |
+                            Add-Member -MemberType ScriptMethod -Name 'EnumObjectPermissions' {
+                            param($permissionSet)
+                            return @(
+                                (New-Object Object |
+                                        Add-Member -MemberType NoteProperty Grantee $mockDynamicPrincipal -PassThru |
+                                        Add-Member -MemberType NoteProperty PermissionState 'Grant' -PassThru
+                                )
+                            )
+                        } -PassThru |
+                            Add-Member -MemberType ScriptMethod -Name 'Grant' {
+                            param(
+                                $permissionSet,
+                                $mockPrincipal
+                            )
 
-                                                            $script:mockMethodGrantRan = $true
-                                                        } -PassThru |
-                                                        Add-Member -MemberType ScriptMethod -Name 'Revoke' {
-                                                            param(
-                                                                $permissionSet,
-                                                                $mockPrincipal
-                                                            )
+                            $script:mockMethodGrantRan = $true
+                        } -PassThru |
+                            Add-Member -MemberType ScriptMethod -Name 'Revoke' {
+                            param(
+                                $permissionSet,
+                                $mockPrincipal
+                            )
 
-                                                            $script:mockMethodRevokeRan = $true
-                                                        } -PassThru -Force
-                        }
-                    )
-                } -PassThru -Force
+                            $script:mockMethodRevokeRan = $true
+                        } -PassThru -Force
+                    }
+                )
+            } -PassThru -Force
         }
 
         $defaultParameters = @{
             InstanceName = $mockInstanceName
-            NodeName = $mockNodeName
-            Name = $mockEndpointName
-            Principal = $mockPrincipal
+            ServerName   = $mockNodeName
+            Name         = $mockEndpointName
+            Principal    = $mockPrincipal
         }
 
         Describe 'MSFT_SqlServerEndpointPermission\Get-TargetResource' -Tag 'Get' {
@@ -108,7 +110,7 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.NodeName | Should -Be $testParameters.NodeName
+                    $result.ServerName | Should -Be $testParameters.ServerName
                     $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.Name | Should -Be $testParameters.Name
                     $result.Principal | Should -Be $testParameters.Principal
@@ -147,7 +149,7 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.NodeName | Should -Be $testParameters.NodeName
+                    $result.ServerName | Should -Be $testParameters.ServerName
                     $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.Name | Should -Be $testParameters.Name
                     $result.Principal | Should -Be $testParameters.Principal

--- a/Tests/Unit/MSFT_SqlServerEndpointState.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerEndpointState.Tests.ps1
@@ -1,14 +1,14 @@
-$script:DSCModuleName      = 'SqlServerDsc'
-$script:DSCResourceName    = 'MSFT_SqlServerEndpointState'
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlServerEndpointState'
 
 #region HEADER
 
 # Unit Test Template Version: 1.2.0
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -20,12 +20,14 @@ $TestEnvironment = Initialize-TestEnvironment `
 
 #endregion HEADER
 
-function Invoke-TestSetup {
+function Invoke-TestSetup
+{
     # Loading stub cmdlets
     Import-Module -Name ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SQLPSStub.psm1 ) -Force -Global
 }
 
-function Invoke-TestCleanup {
+function Invoke-TestCleanup
+{
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
 }
 
@@ -49,21 +51,21 @@ try
         $mockConnectSql = {
             return New-Object Object |
                 Add-Member -MemberType ScriptProperty -Name 'Endpoints' {
-                    return @(
-                        @{
-                            # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
-                            $mockDynamicEndpointName = New-Object Object |
-                                                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDynamicEndpointName -PassThru |
-                                                        Add-Member -MemberType NoteProperty -Name 'EndpointState' -Value $mockDynamicEndpointState -PassThru -Force
-                        }
-                    )
-                } -PassThru -Force
+                return @(
+                    @{
+                        # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                        $mockDynamicEndpointName = New-Object Object |
+                            Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDynamicEndpointName -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'EndpointState' -Value $mockDynamicEndpointState -PassThru -Force
+                    }
+                )
+            } -PassThru -Force
         }
 
         $defaultParameters = @{
             InstanceName = $mockInstanceName
-            NodeName = $mockNodeName
-            Name = $mockEndpointName
+            ServerName   = $mockNodeName
+            Name         = $mockEndpointName
         }
 
         #endregion Pester Test Initialization
@@ -88,7 +90,7 @@ try
 
                     It 'Should return the same values as passed as parameters' {
                         $result = Get-TargetResource @testParameters
-                        $result.NodeName | Should -Be $testParameters.NodeName
+                        $result.ServerName | Should -Be $testParameters.ServerName
                         $result.InstanceName | Should -Be $testParameters.InstanceName
                         $result.Name | Should -Be $testParameters.Name
                     }
@@ -109,7 +111,7 @@ try
 
                     It 'Should return the same values as passed as parameters' {
                         $result = Get-TargetResource @testParameters
-                        $result.NodeName | Should -Be $testParameters.NodeName
+                        $result.ServerName | Should -Be $testParameters.ServerName
                         $result.InstanceName | Should -Be $testParameters.InstanceName
                         $result.Name | Should -Be $testParameters.Name
                     }
@@ -144,7 +146,7 @@ try
 
                     It 'Should return the same values as passed as parameters' {
                         $result = Get-TargetResource @testParameters
-                        $result.NodeName | Should -Be $testParameters.NodeName
+                        $result.ServerName | Should -Be $testParameters.ServerName
                         $result.InstanceName | Should -Be $testParameters.InstanceName
                         $result.Name | Should -Be $testParameters.Name
                     }
@@ -165,7 +167,7 @@ try
 
                     It 'Should return the same values as passed as parameters' {
                         $result = Get-TargetResource @testParameters
-                        $result.NodeName | Should -Be $testParameters.NodeName
+                        $result.ServerName | Should -Be $testParameters.ServerName
                         $result.InstanceName | Should -Be $testParameters.InstanceName
                         $result.Name | Should -Be $testParameters.Name
                     }

--- a/Tests/Unit/MSFT_SqlServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerLogin.Tests.ps1
@@ -54,8 +54,8 @@ try
         $mockSqlLoginCredentialOtherPassword = New-Object System.Management.Automation.PSCredential( $mockSqlLoginUser, $mockSqlLoginOtherPassword )
 
         $instanceParameters = @{
-            SQLInstanceName = 'MSSQLSERVER'
-            SQLServer = 'Server1'
+            InstanceName = 'MSSQLSERVER'
+            ServerName = 'Server1'
         }
 
         $getTargetResource_UnknownSqlLogin = $instanceParameters.Clone()

--- a/Tests/Unit/MSFT_SqlServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerLogin.Tests.ps1
@@ -2,17 +2,17 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 param()
 
-$script:DSCModuleName      = 'SqlServerDsc'
-$script:DSCResourceName    = 'MSFT_SqlServerLogin'
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlServerLogin'
 
 #region HEADER
 
 # Unit Test Template Version: 1.2.0
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -24,12 +24,14 @@ $TestEnvironment = Initialize-TestEnvironment `
 
 #endregion HEADER
 
-function Invoke-TestSetup {
+function Invoke-TestSetup
+{
     Import-Module -Name ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SQLPSStub.psm1 ) -Force
     Add-Type -Path ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SMO.cs )
 }
 
-function Invoke-TestCleanup {
+function Invoke-TestCleanup
+{
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
 }
 
@@ -55,111 +57,111 @@ try
 
         $instanceParameters = @{
             InstanceName = 'MSSQLSERVER'
-            ServerName = 'Server1'
+            ServerName   = 'Server1'
         }
 
         $getTargetResource_UnknownSqlLogin = $instanceParameters.Clone()
-        $getTargetResource_UnknownSqlLogin.Add( 'Name','UnknownSqlLogin' )
+        $getTargetResource_UnknownSqlLogin.Add( 'Name', 'UnknownSqlLogin' )
 
         $getTargetResource_UnknownWindows = $instanceParameters.Clone()
-        $getTargetResource_UnknownWindows.Add( 'Name','Windows\UserOrGroup' )
+        $getTargetResource_UnknownWindows.Add( 'Name', 'Windows\UserOrGroup' )
 
         $getTargetResource_KnownSqlLogin = $instanceParameters.Clone()
-        $getTargetResource_KnownSqlLogin.Add( 'Name','SqlLogin1' )
+        $getTargetResource_KnownSqlLogin.Add( 'Name', 'SqlLogin1' )
 
         $getTargetResource_KnownWindowsUser = $instanceParameters.Clone()
-        $getTargetResource_KnownWindowsUser.Add( 'Name','Windows\User1' )
+        $getTargetResource_KnownWindowsUser.Add( 'Name', 'Windows\User1' )
 
         $getTargetResource_KnownWindowsGroup = $instanceParameters.Clone()
-        $getTargetResource_KnownWindowsGroup.Add( 'Name','Windows\Group1' )
+        $getTargetResource_KnownWindowsGroup.Add( 'Name', 'Windows\Group1' )
 
         $testTargetResource_WindowsUserAbsent = $instanceParameters.Clone()
-        $testTargetResource_WindowsUserAbsent.Add( 'Name','Windows\UserAbsent' )
-        $testTargetResource_WindowsUserAbsent.Add( 'LoginType','WindowsUser' )
+        $testTargetResource_WindowsUserAbsent.Add( 'Name', 'Windows\UserAbsent' )
+        $testTargetResource_WindowsUserAbsent.Add( 'LoginType', 'WindowsUser' )
 
         $testTargetResource_WindowsGroupAbsent = $instanceParameters.Clone()
-        $testTargetResource_WindowsGroupAbsent.Add( 'Name','Windows\GroupAbsent' )
-        $testTargetResource_WindowsGroupAbsent.Add( 'LoginType','WindowsGroup' )
+        $testTargetResource_WindowsGroupAbsent.Add( 'Name', 'Windows\GroupAbsent' )
+        $testTargetResource_WindowsGroupAbsent.Add( 'LoginType', 'WindowsGroup' )
 
         $testTargetResource_SqlLoginAbsent = $instanceParameters.Clone()
-        $testTargetResource_SqlLoginAbsent.Add( 'Name','SqlLoginAbsent' )
-        $testTargetResource_SqlLoginAbsent.Add( 'LoginType','SqlLogin' )
+        $testTargetResource_SqlLoginAbsent.Add( 'Name', 'SqlLoginAbsent' )
+        $testTargetResource_SqlLoginAbsent.Add( 'LoginType', 'SqlLogin' )
 
         $testTargetResource_WindowsUserPresent = $instanceParameters.Clone()
-        $testTargetResource_WindowsUserPresent.Add( 'Name','Windows\User1' )
-        $testTargetResource_WindowsUserPresent.Add( 'LoginType','WindowsUser' )
+        $testTargetResource_WindowsUserPresent.Add( 'Name', 'Windows\User1' )
+        $testTargetResource_WindowsUserPresent.Add( 'LoginType', 'WindowsUser' )
 
         $testTargetResource_WindowsGroupPresent = $instanceParameters.Clone()
-        $testTargetResource_WindowsGroupPresent.Add( 'Name','Windows\Group1' )
-        $testTargetResource_WindowsGroupPresent.Add( 'LoginType','WindowsGroup' )
+        $testTargetResource_WindowsGroupPresent.Add( 'Name', 'Windows\Group1' )
+        $testTargetResource_WindowsGroupPresent.Add( 'LoginType', 'WindowsGroup' )
 
         $testTargetResource_SqlLoginPresentWithDefaultValues = $instanceParameters.Clone()
-        $testTargetResource_SqlLoginPresentWithDefaultValues.Add( 'Name','SqlLogin1' )
-        $testTargetResource_SqlLoginPresentWithDefaultValues.Add( 'LoginType','SqlLogin' )
+        $testTargetResource_SqlLoginPresentWithDefaultValues.Add( 'Name', 'SqlLogin1' )
+        $testTargetResource_SqlLoginPresentWithDefaultValues.Add( 'LoginType', 'SqlLogin' )
 
         $setTargetResource_CertificateAbsent = $instanceParameters.Clone()
-        $setTargetResource_CertificateAbsent.Add( 'Name','Certificate' )
-        $setTargetResource_CertificateAbsent.Add( 'LoginType','Certificate' )
+        $setTargetResource_CertificateAbsent.Add( 'Name', 'Certificate' )
+        $setTargetResource_CertificateAbsent.Add( 'LoginType', 'Certificate' )
 
         $setTargetResource_WindowsUserAbsent = $instanceParameters.Clone()
-        $setTargetResource_WindowsUserAbsent.Add( 'Name','Windows\UserAbsent' )
-        $setTargetResource_WindowsUserAbsent.Add( 'LoginType','WindowsUser' )
+        $setTargetResource_WindowsUserAbsent.Add( 'Name', 'Windows\UserAbsent' )
+        $setTargetResource_WindowsUserAbsent.Add( 'LoginType', 'WindowsUser' )
 
         $setTargetResource_WindowsGroupAbsent = $instanceParameters.Clone()
-        $setTargetResource_WindowsGroupAbsent.Add( 'Name','Windows\GroupAbsent' )
-        $setTargetResource_WindowsGroupAbsent.Add( 'LoginType','WindowsGroup' )
+        $setTargetResource_WindowsGroupAbsent.Add( 'Name', 'Windows\GroupAbsent' )
+        $setTargetResource_WindowsGroupAbsent.Add( 'LoginType', 'WindowsGroup' )
 
         $setTargetResource_SqlLoginAbsent = $instanceParameters.Clone()
-        $setTargetResource_SqlLoginAbsent.Add( 'Name','SqlLoginAbsent' )
-        $setTargetResource_SqlLoginAbsent.Add( 'LoginType','SqlLogin' )
+        $setTargetResource_SqlLoginAbsent.Add( 'Name', 'SqlLoginAbsent' )
+        $setTargetResource_SqlLoginAbsent.Add( 'LoginType', 'SqlLogin' )
 
         $setTargetResource_SqlLoginAbsentExisting = $instanceParameters.Clone()
-        $setTargetResource_SqlLoginAbsentExisting.Add( 'Name','Existing' )
-        $setTargetResource_SqlLoginAbsentExisting.Add( 'LoginType','SqlLogin' )
+        $setTargetResource_SqlLoginAbsentExisting.Add( 'Name', 'Existing' )
+        $setTargetResource_SqlLoginAbsentExisting.Add( 'LoginType', 'SqlLogin' )
 
         $setTargetResource_SqlLoginAbsentUnknown = $instanceParameters.Clone()
-        $setTargetResource_SqlLoginAbsentUnknown.Add( 'Name','Unknown' )
-        $setTargetResource_SqlLoginAbsentUnknown.Add( 'LoginType','SqlLogin' )
+        $setTargetResource_SqlLoginAbsentUnknown.Add( 'Name', 'Unknown' )
+        $setTargetResource_SqlLoginAbsentUnknown.Add( 'LoginType', 'SqlLogin' )
 
         $setTargetResource_WindowsUserPresent = $instanceParameters.Clone()
-        $setTargetResource_WindowsUserPresent.Add( 'Name','Windows\User1' )
-        $setTargetResource_WindowsUserPresent.Add( 'LoginType','WindowsUser' )
+        $setTargetResource_WindowsUserPresent.Add( 'Name', 'Windows\User1' )
+        $setTargetResource_WindowsUserPresent.Add( 'LoginType', 'WindowsUser' )
 
         $setTargetResource_CertificateAbsent = $instanceParameters.Clone()
-        $setTargetResource_CertificateAbsent.Add( 'Name','Certificate' )
-        $setTargetResource_CertificateAbsent.Add( 'LoginType','Certificate' )
+        $setTargetResource_CertificateAbsent.Add( 'Name', 'Certificate' )
+        $setTargetResource_CertificateAbsent.Add( 'LoginType', 'Certificate' )
 
         $setTargetResource_WindowsUserAbsent = $instanceParameters.Clone()
-        $setTargetResource_WindowsUserAbsent.Add( 'Name','Windows\UserAbsent' )
-        $setTargetResource_WindowsUserAbsent.Add( 'LoginType','WindowsUser' )
+        $setTargetResource_WindowsUserAbsent.Add( 'Name', 'Windows\UserAbsent' )
+        $setTargetResource_WindowsUserAbsent.Add( 'LoginType', 'WindowsUser' )
 
         $setTargetResource_WindowsGroupAbsent = $instanceParameters.Clone()
-        $setTargetResource_WindowsGroupAbsent.Add( 'Name','Windows\GroupAbsent' )
-        $setTargetResource_WindowsGroupAbsent.Add( 'LoginType','WindowsGroup' )
+        $setTargetResource_WindowsGroupAbsent.Add( 'Name', 'Windows\GroupAbsent' )
+        $setTargetResource_WindowsGroupAbsent.Add( 'LoginType', 'WindowsGroup' )
 
         $setTargetResource_SqlLoginAbsent = $instanceParameters.Clone()
-        $setTargetResource_SqlLoginAbsent.Add( 'Name','SqlLoginAbsent' )
-        $setTargetResource_SqlLoginAbsent.Add( 'LoginType','SqlLogin' )
+        $setTargetResource_SqlLoginAbsent.Add( 'Name', 'SqlLoginAbsent' )
+        $setTargetResource_SqlLoginAbsent.Add( 'LoginType', 'SqlLogin' )
 
         $setTargetResource_SqlLoginAbsentExisting = $instanceParameters.Clone()
-        $setTargetResource_SqlLoginAbsentExisting.Add( 'Name','Existing' )
-        $setTargetResource_SqlLoginAbsentExisting.Add( 'LoginType','SqlLogin' )
+        $setTargetResource_SqlLoginAbsentExisting.Add( 'Name', 'Existing' )
+        $setTargetResource_SqlLoginAbsentExisting.Add( 'LoginType', 'SqlLogin' )
 
         $setTargetResource_SqlLoginAbsentUnknown = $instanceParameters.Clone()
-        $setTargetResource_SqlLoginAbsentUnknown.Add( 'Name','Unknown' )
-        $setTargetResource_SqlLoginAbsentUnknown.Add( 'LoginType','SqlLogin' )
+        $setTargetResource_SqlLoginAbsentUnknown.Add( 'Name', 'Unknown' )
+        $setTargetResource_SqlLoginAbsentUnknown.Add( 'LoginType', 'SqlLogin' )
 
         $setTargetResource_WindowsUserPresent = $instanceParameters.Clone()
-        $setTargetResource_WindowsUserPresent.Add( 'Name','Windows\User1' )
-        $setTargetResource_WindowsUserPresent.Add( 'LoginType','WindowsUser' )
+        $setTargetResource_WindowsUserPresent.Add( 'Name', 'Windows\User1' )
+        $setTargetResource_WindowsUserPresent.Add( 'LoginType', 'WindowsUser' )
 
         $setTargetResource_WindowsGroupPresent = $instanceParameters.Clone()
-        $setTargetResource_WindowsGroupPresent.Add( 'Name','Windows\Group1' )
-        $setTargetResource_WindowsGroupPresent.Add( 'LoginType','WindowsGroup' )
+        $setTargetResource_WindowsGroupPresent.Add( 'Name', 'Windows\Group1' )
+        $setTargetResource_WindowsGroupPresent.Add( 'LoginType', 'WindowsGroup' )
 
         $setTargetResource_SqlLoginPresent = $instanceParameters.Clone()
-        $setTargetResource_SqlLoginPresent.Add( 'Name','SqlLogin1' )
-        $setTargetResource_SqlLoginPresent.Add( 'LoginType','SqlLogin' )
+        $setTargetResource_SqlLoginPresent.Add( 'Name', 'SqlLogin1' )
+        $setTargetResource_SqlLoginPresent.Add( 'LoginType', 'SqlLogin' )
 
         <#
             These are set when the mocked methods Enable() and Disabled() are called.
@@ -263,7 +265,7 @@ try
 
                 It 'Should be return the correct values when a login is disabled' {
                     $mockGetTargetResourceParameters = $instanceParameters.Clone()
-                    $mockGetTargetResourceParameters.Add( 'Name','Windows\UserDisabled' )
+                    $mockGetTargetResourceParameters.Add( 'Name', 'Windows\UserDisabled' )
                     $result = Get-TargetResource @mockGetTargetResourceParameters
 
                     $result.Ensure | Should -Be 'Present'
@@ -284,7 +286,7 @@ try
             Context 'When the desired state is Absent' {
                 It 'Should return $true when the specified Windows user is Absent' {
                     $testTargetResource_WindowsUserAbsent_EnsureAbsent = $testTargetResource_WindowsUserAbsent.Clone()
-                    $testTargetResource_WindowsUserAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
+                    $testTargetResource_WindowsUserAbsent_EnsureAbsent.Add( 'Ensure', 'Absent' )
 
                     ( Test-TargetResource @testTargetResource_WindowsUserAbsent_EnsureAbsent ) | Should -Be $true
 
@@ -293,7 +295,7 @@ try
 
                 It 'Should return $true when the specified Windows group is Absent' {
                     $testTargetResource_WindowsGroupAbsent_EnsureAbsent = $testTargetResource_WindowsGroupAbsent.Clone()
-                    $testTargetResource_WindowsGroupAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
+                    $testTargetResource_WindowsGroupAbsent_EnsureAbsent.Add( 'Ensure', 'Absent' )
 
                     ( Test-TargetResource @testTargetResource_WindowsGroupAbsent_EnsureAbsent ) | Should -Be $true
 
@@ -302,7 +304,7 @@ try
 
                 It 'Should return $true when the specified SQL Login is Absent' {
                     $testTargetResource_SqlLoginAbsent_EnsureAbsent = $testTargetResource_SqlLoginAbsent.Clone()
-                    $testTargetResource_SqlLoginAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
+                    $testTargetResource_SqlLoginAbsent_EnsureAbsent.Add( 'Ensure', 'Absent' )
 
                     ( Test-TargetResource @testTargetResource_SqlLoginAbsent_EnsureAbsent ) | Should -Be $true
 
@@ -311,7 +313,7 @@ try
 
                 It 'Should return $false when the specified Windows user is Present' {
                     $testTargetResource_WindowsUserPresent_EnsureAbsent = $testTargetResource_WindowsUserPresent.Clone()
-                    $testTargetResource_WindowsUserPresent_EnsureAbsent.Add( 'Ensure','Absent' )
+                    $testTargetResource_WindowsUserPresent_EnsureAbsent.Add( 'Ensure', 'Absent' )
 
                     ( Test-TargetResource @testTargetResource_WindowsUserPresent_EnsureAbsent ) | Should -Be $false
 
@@ -320,7 +322,7 @@ try
 
                 It 'Should return $false when the specified Windows group is Present' {
                     $testTargetResource_WindowsGroupPresent_EnsureAbsent = $testTargetResource_WindowsGroupPresent.Clone()
-                    $testTargetResource_WindowsGroupPresent_EnsureAbsent.Add( 'Ensure','Absent' )
+                    $testTargetResource_WindowsGroupPresent_EnsureAbsent.Add( 'Ensure', 'Absent' )
 
                     ( Test-TargetResource @testTargetResource_WindowsGroupPresent_EnsureAbsent ) | Should -Be $false
 
@@ -329,7 +331,7 @@ try
 
                 It 'Should return $false when the specified SQL Login is Present' {
                     $testTargetResource_SqlLoginPresentWithDefaultValues_EnsureAbsent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
-                    $testTargetResource_SqlLoginPresentWithDefaultValues_EnsureAbsent.Add( 'Ensure','Absent' )
+                    $testTargetResource_SqlLoginPresentWithDefaultValues_EnsureAbsent.Add( 'Ensure', 'Absent' )
 
                     ( Test-TargetResource @testTargetResource_SqlLoginPresentWithDefaultValues_EnsureAbsent ) | Should -Be $false
 
@@ -338,8 +340,8 @@ try
 
                 It 'Should be return $false when a login should be disabled but are enabled' {
                     $mockTestTargetResourceParameters = $instanceParameters.Clone()
-                    $mockTestTargetResourceParameters.Add( 'Ensure','Present' )
-                    $mockTestTargetResourceParameters.Add( 'Name','Windows\User1' )
+                    $mockTestTargetResourceParameters.Add( 'Ensure', 'Present' )
+                    $mockTestTargetResourceParameters.Add( 'Name', 'Windows\User1' )
                     $mockTestTargetResourceParameters.Add( 'Disabled', $true )
 
                     $result = Test-TargetResource @mockTestTargetResourceParameters
@@ -350,8 +352,8 @@ try
 
                 It 'Should be return $false when a login should be enabled but are disabled' {
                     $mockTestTargetResourceParameters = $instanceParameters.Clone()
-                    $mockTestTargetResourceParameters.Add( 'Ensure','Present' )
-                    $mockTestTargetResourceParameters.Add( 'Name','Windows\UserDisabled' )
+                    $mockTestTargetResourceParameters.Add( 'Ensure', 'Present' )
+                    $mockTestTargetResourceParameters.Add( 'Name', 'Windows\UserDisabled' )
                     $mockTestTargetResourceParameters.Add( 'Disabled', $false )
 
                     $result = Test-TargetResource @mockTestTargetResourceParameters
@@ -364,7 +366,7 @@ try
             Context 'When the desired state is Present' {
                 It 'Should return $false when the specified Windows user is Absent' {
                     $testTargetResource_WindowsUserAbsent_EnsurePresent = $testTargetResource_WindowsUserAbsent.Clone()
-                    $testTargetResource_WindowsUserAbsent_EnsurePresent.Add( 'Ensure','Present' )
+                    $testTargetResource_WindowsUserAbsent_EnsurePresent.Add( 'Ensure', 'Present' )
 
                     ( Test-TargetResource @testTargetResource_WindowsUserAbsent_EnsurePresent ) | Should -Be $false
 
@@ -373,7 +375,7 @@ try
 
                 It 'Should return $false when the specified Windows group is Absent' {
                     $testTargetResource_WindowsGroupAbsent_EnsurePresent = $testTargetResource_WindowsGroupAbsent.Clone()
-                    $testTargetResource_WindowsGroupAbsent_EnsurePresent.Add( 'Ensure','Present' )
+                    $testTargetResource_WindowsGroupAbsent_EnsurePresent.Add( 'Ensure', 'Present' )
 
                     ( Test-TargetResource @testTargetResource_WindowsGroupAbsent_EnsurePresent ) | Should -Be $false
 
@@ -382,7 +384,7 @@ try
 
                 It 'Should return $false when the specified SQL Login is Absent' {
                     $testTargetResource_SqlLoginAbsent_EnsurePresent = $testTargetResource_SqlLoginAbsent.Clone()
-                    $testTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
+                    $testTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure', 'Present' )
 
                     ( Test-TargetResource @testTargetResource_SqlLoginAbsent_EnsurePresent ) | Should -Be $false
 
@@ -391,7 +393,7 @@ try
 
                 It 'Should return $true when the specified Windows user is Present' {
                     $testTargetResource_WindowsUserPresent_EnsurePresent = $testTargetResource_WindowsUserPresent.Clone()
-                    $testTargetResource_WindowsUserPresent_EnsurePresent.Add( 'Ensure','Present' )
+                    $testTargetResource_WindowsUserPresent_EnsurePresent.Add( 'Ensure', 'Present' )
 
                     ( Test-TargetResource @testTargetResource_WindowsUserPresent_EnsurePresent ) | Should -Be $true
 
@@ -400,7 +402,7 @@ try
 
                 It 'Should return $true when the specified Windows group is Present' {
                     $testTargetResource_WindowsGroupPresent_EnsurePresent = $testTargetResource_WindowsGroupPresent.Clone()
-                    $testTargetResource_WindowsGroupPresent_EnsurePresent.Add( 'Ensure','Present' )
+                    $testTargetResource_WindowsGroupPresent_EnsurePresent.Add( 'Ensure', 'Present' )
 
                     ( Test-TargetResource @testTargetResource_WindowsGroupPresent_EnsurePresent ) | Should -Be $true
 
@@ -409,7 +411,7 @@ try
 
                 It 'Should return $true when the specified SQL Login is Present using default parameter values' {
                     $testTargetResource_SqlLoginPresentWithDefaultValues_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
-                    $testTargetResource_SqlLoginPresentWithDefaultValues_EnsurePresent.Add( 'Ensure','Present' )
+                    $testTargetResource_SqlLoginPresentWithDefaultValues_EnsurePresent.Add( 'Ensure', 'Present' )
 
                     ( Test-TargetResource @testTargetResource_SqlLoginPresentWithDefaultValues_EnsurePresent ) | Should -Be $true
 
@@ -418,8 +420,8 @@ try
 
                 It 'Should return $true when the specified SQL Login is Present and PasswordExpirationEnabled is $true' {
                     $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledTrue_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
-                    $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledTrue_EnsurePresent.Add( 'Ensure','Present' )
-                    $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledTrue_EnsurePresent.Add( 'LoginPasswordExpirationEnabled',$true )
+                    $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledTrue_EnsurePresent.Add( 'Ensure', 'Present' )
+                    $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledTrue_EnsurePresent.Add( 'LoginPasswordExpirationEnabled', $true )
 
                     ( Test-TargetResource @testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledTrue_EnsurePresent ) | Should -Be $true
 
@@ -428,8 +430,8 @@ try
 
                 It 'Should return $false when the specified SQL Login is Present and PasswordExpirationEnabled is $false' {
                     $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledFalse_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
-                    $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledFalse_EnsurePresent.Add( 'Ensure','Present' )
-                    $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledFalse_EnsurePresent.Add( 'LoginPasswordExpirationEnabled',$false )
+                    $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledFalse_EnsurePresent.Add( 'Ensure', 'Present' )
+                    $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledFalse_EnsurePresent.Add( 'LoginPasswordExpirationEnabled', $false )
 
                     ( Test-TargetResource @testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledFalse_EnsurePresent ) | Should -Be $false
 
@@ -438,8 +440,8 @@ try
 
                 It 'Should return $true when the specified SQL Login is Present and PasswordPolicyEnforced is $true' {
                     $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedTrue_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
-                    $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedTrue_EnsurePresent.Add( 'Ensure','Present' )
-                    $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedTrue_EnsurePresent.Add( 'LoginPasswordPolicyEnforced',$true )
+                    $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedTrue_EnsurePresent.Add( 'Ensure', 'Present' )
+                    $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedTrue_EnsurePresent.Add( 'LoginPasswordPolicyEnforced', $true )
 
                     ( Test-TargetResource @testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedTrue_EnsurePresent ) | Should -Be $true
 
@@ -448,8 +450,8 @@ try
 
                 It 'Should return $false when the specified SQL Login is Present and PasswordPolicyEnforced is $false' {
                     $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
-                    $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent.Add( 'Ensure','Present' )
-                    $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent.Add( 'LoginPasswordPolicyEnforced',$false )
+                    $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent.Add( 'Ensure', 'Present' )
+                    $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent.Add( 'LoginPasswordPolicyEnforced', $false )
 
                     ( Test-TargetResource @testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent ) | Should -Be $false
 
@@ -458,8 +460,8 @@ try
 
                 It 'Should return $true when the specified SQL Login is Present using default parameter values and the password is properly configured.' {
                     $testTargetResource_SqlLoginPresentWithDefaultValuesGoodPw_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
-                    $testTargetResource_SqlLoginPresentWithDefaultValuesGoodPw_EnsurePresent.Add( 'Ensure','Present' )
-                    $testTargetResource_SqlLoginPresentWithDefaultValuesGoodPw_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
+                    $testTargetResource_SqlLoginPresentWithDefaultValuesGoodPw_EnsurePresent.Add( 'Ensure', 'Present' )
+                    $testTargetResource_SqlLoginPresentWithDefaultValuesGoodPw_EnsurePresent.Add( 'LoginCredential', $mockSqlLoginCredential )
 
                     ( Test-TargetResource @testTargetResource_SqlLoginPresentWithDefaultValuesGoodPw_EnsurePresent ) | Should -Be $true
 
@@ -470,8 +472,8 @@ try
                     Mock -CommandName Connect-SQL -MockWith { throw } -Verifiable -ParameterFilter { $SetupCredential }
 
                     $testTargetResource_SqlLoginPresentWithDefaultValuesBadPw_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
-                    $testTargetResource_SqlLoginPresentWithDefaultValuesBadPw_EnsurePresent.Add( 'Ensure','Present' )
-                    $testTargetResource_SqlLoginPresentWithDefaultValuesBadPw_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredentialBadPassword )
+                    $testTargetResource_SqlLoginPresentWithDefaultValuesBadPw_EnsurePresent.Add( 'Ensure', 'Present' )
+                    $testTargetResource_SqlLoginPresentWithDefaultValuesBadPw_EnsurePresent.Add( 'LoginCredential', $mockSqlLoginCredentialBadPassword )
 
                     ( Test-TargetResource @testTargetResource_SqlLoginPresentWithDefaultValuesBadPw_EnsurePresent ) | Should -Be $false
 
@@ -480,8 +482,8 @@ try
 
                 It 'Should be return $true when a login is enabled' {
                     $mockTestTargetResourceParameters = $instanceParameters.Clone()
-                    $mockTestTargetResourceParameters.Add( 'Ensure','Present' )
-                    $mockTestTargetResourceParameters.Add( 'Name','Windows\User1' )
+                    $mockTestTargetResourceParameters.Add( 'Ensure', 'Present' )
+                    $mockTestTargetResourceParameters.Add( 'Name', 'Windows\User1' )
                     $mockTestTargetResourceParameters.Add( 'Disabled', $false )
 
                     $result = Test-TargetResource @mockTestTargetResourceParameters
@@ -492,8 +494,8 @@ try
 
                 It 'Should be return $true when a login is disabled' {
                     $mockTestTargetResourceParameters = $instanceParameters.Clone()
-                    $mockTestTargetResourceParameters.Add( 'Ensure','Present' )
-                    $mockTestTargetResourceParameters.Add( 'Name','Windows\UserDisabled' )
+                    $mockTestTargetResourceParameters.Add( 'Ensure', 'Present' )
+                    $mockTestTargetResourceParameters.Add( 'Name', 'Windows\UserDisabled' )
                     $mockTestTargetResourceParameters.Add( 'Disabled', $true )
 
                     $result = Test-TargetResource @mockTestTargetResourceParameters
@@ -521,7 +523,7 @@ try
                     Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
                     $setTargetResource_WindowsUserPresent_EnsureAbsent = $setTargetResource_WindowsUserPresent.Clone()
-                    $setTargetResource_WindowsUserPresent_EnsureAbsent.Add( 'Ensure','Absent' )
+                    $setTargetResource_WindowsUserPresent_EnsureAbsent.Add( 'Ensure', 'Absent' )
 
                     Set-TargetResource @setTargetResource_WindowsUserPresent_EnsureAbsent
 
@@ -536,8 +538,8 @@ try
                     Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
                     $mockSetTargetResourceParameters = $instanceParameters.Clone()
-                    $mockSetTargetResourceParameters.Add( 'Ensure','Present' )
-                    $mockSetTargetResourceParameters.Add( 'Name','Windows\UserDisabled' )
+                    $mockSetTargetResourceParameters.Add( 'Ensure', 'Present' )
+                    $mockSetTargetResourceParameters.Add( 'Name', 'Windows\UserDisabled' )
                     $mockSetTargetResourceParameters.Add( 'Disabled', $false )
 
                     Set-TargetResource @mockSetTargetResourceParameters
@@ -555,8 +557,8 @@ try
                     Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
                     $mockSetTargetResourceParameters = $instanceParameters.Clone()
-                    $mockSetTargetResourceParameters.Add( 'Ensure','Present' )
-                    $mockSetTargetResourceParameters.Add( 'Name','Windows\User1' )
+                    $mockSetTargetResourceParameters.Add( 'Ensure', 'Present' )
+                    $mockSetTargetResourceParameters.Add( 'Name', 'Windows\User1' )
                     $mockSetTargetResourceParameters.Add( 'Disabled', $true )
 
                     Set-TargetResource @mockSetTargetResourceParameters
@@ -574,7 +576,7 @@ try
                     Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
                     $setTargetResource_WindowsGroupPresent_EnsureAbsent = $setTargetResource_WindowsGroupPresent.Clone()
-                    $setTargetResource_WindowsGroupPresent_EnsureAbsent.Add( 'Ensure','Absent' )
+                    $setTargetResource_WindowsGroupPresent_EnsureAbsent.Add( 'Ensure', 'Absent' )
 
                     Set-TargetResource @setTargetResource_WindowsGroupPresent_EnsureAbsent
 
@@ -589,7 +591,7 @@ try
                     Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
                     $setTargetResource_SqlLoginPresent_EnsureAbsent = $setTargetResource_SqlLoginPresent.Clone()
-                    $setTargetResource_SqlLoginPresent_EnsureAbsent.Add( 'Ensure','Absent' )
+                    $setTargetResource_SqlLoginPresent_EnsureAbsent.Add( 'Ensure', 'Absent' )
 
                     Set-TargetResource @setTargetResource_SqlLoginPresent_EnsureAbsent
 
@@ -604,7 +606,7 @@ try
                     Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
                     $setTargetResource_WindowsUserAbsent_EnsureAbsent = $setTargetResource_WindowsUserAbsent.Clone()
-                    $setTargetResource_WindowsUserAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
+                    $setTargetResource_WindowsUserAbsent_EnsureAbsent.Add( 'Ensure', 'Absent' )
 
                     Set-TargetResource @setTargetResource_WindowsUserAbsent_EnsureAbsent
 
@@ -619,7 +621,7 @@ try
                     Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
                     $setTargetResource_WindowsGroupAbsent_EnsureAbsent = $setTargetResource_WindowsGroupAbsent.Clone()
-                    $setTargetResource_WindowsGroupAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
+                    $setTargetResource_WindowsGroupAbsent_EnsureAbsent.Add( 'Ensure', 'Absent' )
 
                     Set-TargetResource @setTargetResource_WindowsGroupAbsent_EnsureAbsent
 
@@ -634,7 +636,7 @@ try
                     Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
                     $setTargetResource_SqlLoginAbsent_EnsureAbsent = $setTargetResource_SqlLoginAbsent.Clone()
-                    $setTargetResource_SqlLoginAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
+                    $setTargetResource_SqlLoginAbsent_EnsureAbsent.Add( 'Ensure', 'Absent' )
 
                     Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsureAbsent
 
@@ -656,7 +658,7 @@ try
                     Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
                     $setTargetResource_WindowsUserAbsent_EnsurePresent = $setTargetResource_WindowsUserAbsent.Clone()
-                    $setTargetResource_WindowsUserAbsent_EnsurePresent.Add( 'Ensure','Present' )
+                    $setTargetResource_WindowsUserAbsent_EnsurePresent.Add( 'Ensure', 'Present' )
 
                     Set-TargetResource @setTargetResource_WindowsUserAbsent_EnsurePresent
 
@@ -686,8 +688,8 @@ try
                     }-Verifiable
 
                     $mockSetTargetResourceParameters = $instanceParameters.Clone()
-                    $mockSetTargetResourceParameters.Add( 'Ensure','Present' )
-                    $mockSetTargetResourceParameters.Add( 'Name','Windows\UserAbsent' )
+                    $mockSetTargetResourceParameters.Add( 'Ensure', 'Present' )
+                    $mockSetTargetResourceParameters.Add( 'Name', 'Windows\UserAbsent' )
                     $mockSetTargetResourceParameters.Add( 'Disabled', $true )
 
                     Set-TargetResource @mockSetTargetResourceParameters
@@ -704,7 +706,7 @@ try
                     Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
                     $setTargetResource_WindowsGroupAbsent_EnsurePresent = $setTargetResource_WindowsGroupAbsent.Clone()
-                    $setTargetResource_WindowsGroupAbsent_EnsurePresent.Add( 'Ensure','Present' )
+                    $setTargetResource_WindowsGroupAbsent_EnsurePresent.Add( 'Ensure', 'Present' )
 
                     Set-TargetResource @setTargetResource_WindowsGroupAbsent_EnsurePresent
 
@@ -719,8 +721,8 @@ try
                     Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
                     $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
-                    $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
-                    $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
+                    $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure', 'Present' )
+                    $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential', $mockSqlLoginCredential )
 
                     Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent
 
@@ -735,9 +737,9 @@ try
                     Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
                     $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
-                    $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
-                    $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
-                    $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginMustChangePassword',$false )
+                    $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure', 'Present' )
+                    $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential', $mockSqlLoginCredential )
+                    $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginMustChangePassword', $false )
 
                     Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent
 
@@ -752,7 +754,7 @@ try
                     Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
                     $setTargetResource_CertificateAbsent_EnsurePresent = $setTargetResource_CertificateAbsent.Clone()
-                    $setTargetResource_CertificateAbsent_EnsurePresent.Add( 'Ensure','Present' )
+                    $setTargetResource_CertificateAbsent_EnsurePresent.Add( 'Ensure', 'Present' )
 
                     { Set-TargetResource @setTargetResource_CertificateAbsent_EnsurePresent } | Should -Throw 'LoginTypeNotImplemented'
 
@@ -767,7 +769,7 @@ try
                     Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
                     $setTargetResource_SqlLoginAbsent_EnsurePresent_NoCred = $setTargetResource_SqlLoginAbsent.Clone()
-                    $setTargetResource_SqlLoginAbsent_EnsurePresent_NoCred.Add( 'Ensure','Present' )
+                    $setTargetResource_SqlLoginAbsent_EnsurePresent_NoCred.Add( 'Ensure', 'Present' )
 
                     { Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent_NoCred } | Should -Throw 'LoginCredentialNotFound'
 
@@ -782,7 +784,7 @@ try
                     Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
                     $setTargetResource_WindowsUserPresent_EnsurePresent = $setTargetResource_WindowsUserPresent.Clone()
-                    $setTargetResource_WindowsUserPresent_EnsurePresent.Add( 'Ensure','Present' )
+                    $setTargetResource_WindowsUserPresent_EnsurePresent.Add( 'Ensure', 'Present' )
 
                     Set-TargetResource @setTargetResource_WindowsUserPresent_EnsurePresent
 
@@ -797,7 +799,7 @@ try
                     Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
                     $setTargetResource_WindowsGroupPresent_EnsurePresent = $setTargetResource_WindowsGroupPresent.Clone()
-                    $setTargetResource_WindowsGroupPresent_EnsurePresent.Add( 'Ensure','Present' )
+                    $setTargetResource_WindowsGroupPresent_EnsurePresent.Add( 'Ensure', 'Present' )
 
                     Set-TargetResource @setTargetResource_WindowsGroupPresent_EnsurePresent
 
@@ -812,8 +814,8 @@ try
                     Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
                     $setTargetResource_SqlLoginPresent_EnsurePresent = $setTargetResource_SqlLoginPresent.Clone()
-                    $setTargetResource_SqlLoginPresent_EnsurePresent.Add( 'Ensure','Present' )
-                    $setTargetResource_SqlLoginPresent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
+                    $setTargetResource_SqlLoginPresent_EnsurePresent.Add( 'Ensure', 'Present' )
+                    $setTargetResource_SqlLoginPresent_EnsurePresent.Add( 'LoginCredential', $mockSqlLoginCredential )
 
                     Set-TargetResource @setTargetResource_SqlLoginPresent_EnsurePresent
 
@@ -828,9 +830,9 @@ try
                     Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
                     $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled = $setTargetResource_SqlLoginPresent.Clone()
-                    $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled.Add( 'Ensure','Present' )
-                    $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled.Add( 'LoginCredential',$mockSqlLoginCredential )
-                    $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled.Add( 'LoginPasswordExpirationEnabled',$false )
+                    $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled.Add( 'Ensure', 'Present' )
+                    $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled.Add( 'LoginCredential', $mockSqlLoginCredential )
+                    $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled.Add( 'LoginPasswordExpirationEnabled', $false )
 
                     Set-TargetResource @setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled
 
@@ -845,9 +847,9 @@ try
                     Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
                     $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced = $setTargetResource_SqlLoginPresent.Clone()
-                    $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced.Add( 'Ensure','Present' )
-                    $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced.Add( 'LoginCredential',$mockSqlLoginCredential )
-                    $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced.Add( 'LoginPasswordPolicyEnforced',$false )
+                    $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced.Add( 'Ensure', 'Present' )
+                    $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced.Add( 'LoginCredential', $mockSqlLoginCredential )
+                    $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced.Add( 'LoginPasswordPolicyEnforced', $false )
 
                     Set-TargetResource @setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced
 
@@ -862,14 +864,14 @@ try
                     $mockConnectSQL_LoginModeNormal = {
                         return New-Object Object |
                             Add-Member ScriptProperty Logins {
-                                return @{
-                                    'Windows\User1' = ( New-Object Object |
+                            return @{
+                                'Windows\User1' = ( New-Object Object |
                                         Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Windows\User1' -PassThru |
                                         Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'WindowsUser' -PassThru |
                                         Add-Member -MemberType ScriptMethod -Name Alter -Value {} -PassThru |
                                         Add-Member -MemberType ScriptMethod -Name Drop -Value {} -PassThru -Force
-                                    )
-                                    'SqlLogin1' = ( New-Object Object |
+                                )
+                                'SqlLogin1' = ( New-Object Object |
                                         Add-Member -MemberType NoteProperty -Name 'Name' -Value 'SqlLogin1' -PassThru |
                                         Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'SqlLogin' -PassThru |
                                         Add-Member -MemberType NoteProperty -Name 'MustChangePassword' -Value $false -PassThru |
@@ -877,23 +879,23 @@ try
                                         Add-Member -MemberType NoteProperty -Name 'PasswordPolicyEnforced' -Value $true -PassThru |
                                         Add-Member -MemberType ScriptMethod -Name Alter -Value {} -PassThru |
                                         Add-Member -MemberType ScriptMethod -Name Drop -Value {} -PassThru -Force
-                                    )
-                                    'Windows\Group1' = ( New-Object Object |
+                                )
+                                'Windows\Group1' = ( New-Object Object |
                                         Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Windows\Group1' -PassThru |
                                         Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'WindowsGroup' -PassThru |
                                         Add-Member -MemberType ScriptMethod -Name Alter -Value {} -PassThru |
                                         Add-Member -MemberType ScriptMethod -Name Drop -Value {} -PassThru -Force
-                                    )
-                                }
-                            } -PassThru |
+                                )
+                            }
+                        } -PassThru |
                             Add-Member -MemberType NoteProperty -Name LoginMode -Value 'Normal' -PassThru -Force
                     }
 
                     Mock -CommandName Connect-SQL -MockWith $mockConnectSQL_LoginModeNormal -Verifiable
 
                     $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
-                    $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
-                    $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
+                    $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure', 'Present' )
+                    $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential', $mockSqlLoginCredential )
 
                     { Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent } | Should -Throw 'IncorrectLoginMode'
 

--- a/Tests/Unit/MSFT_SqlServerMaxDop.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerMaxDop.Tests.ps1
@@ -1,14 +1,14 @@
-$script:DSCModuleName      = 'SqlServerDsc'
-$script:DSCResourceName    = 'MSFT_SqlServerMaxDop'
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlServerMaxDop'
 
 #region HEADER
 
 # Unit Test Template Version: 1.2.0
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -23,10 +23,12 @@ $TestEnvironment = Initialize-TestEnvironment `
 
 #endregion HEADER
 
-function Invoke-TestSetup {
+function Invoke-TestSetup
+{
 }
 
-function Invoke-TestCleanup {
+function Invoke-TestCleanup
+{
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
 }
 
@@ -36,19 +38,19 @@ try
     Invoke-TestSetup
 
     InModuleScope $script:DSCResourceName {
-        $mockSQLServerName                  = 'localhost'
-        $mockSQLServerInstanceName          = 'MSSQLSERVER'
-        $mockMaxDegreeOfParallelism         = 4
-        $mockExpectedMaxDopForAlterMethod   = 1
+        $mockServerName = 'localhost'
+        $mockInstanceName = 'MSSQLSERVER'
+        $mockMaxDegreeOfParallelism = 4
+        $mockExpectedMaxDopForAlterMethod = 1
         $mockInvalidOperationForAlterMethod = $false
-        $mockNumberOfLogicalProcessors      = 4
-        $mockNumberOfCores                  = 4
-        $mockProcessOnlyOnActiveNode        = $true
+        $mockNumberOfLogicalProcessors = 4
+        $mockNumberOfCores = 4
+        $mockProcessOnlyOnActiveNode = $true
 
         # Default parameters that are used for the It-blocks
         $mockDefaultParameters = @{
-            SQLInstanceName = $mockSQLServerInstanceName
-            SQLServer       = $mockSQLServerName
+            InstanceName = $mockInstanceName
+            ServerName   = $mockServerName
         }
 
         #region Function mocks
@@ -57,31 +59,31 @@ try
             return @(
                 (
                     New-Object Object -TypeName Microsoft.SqlServer.Management.Smo.Server |
-                        Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockSQLServerInstanceName -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockSQLServerName -PassThru -Force |
+                        Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockInstanceName -PassThru -Force |
+                        Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockServerName -PassThru -Force |
                         Add-Member -MemberType ScriptProperty -Name Configuration -Value {
-                            return @( ( New-Object Object |
-                                Add-Member -MemberType ScriptProperty -Name MaxDegreeOfParallelism -Value {
+                        return @( ( New-Object Object |
+                                    Add-Member -MemberType ScriptProperty -Name MaxDegreeOfParallelism -Value {
                                     return @( ( New-Object Object |
-                                        Add-Member -MemberType NoteProperty -Name DisplayName -Value 'max degree of parallelism' -PassThru |
-                                        Add-Member -MemberType NoteProperty -Name Description -Value 'maximum degree of parallelism' -PassThru |
-                                        Add-Member -MemberType NoteProperty -Name RunValue -Value $mockMaxDegreeOfParallelism -PassThru |
-                                        Add-Member -MemberType NoteProperty -Name ConfigValue -Value $mockMaxDegreeOfParallelism -PassThru -Force
-                                    ) )
+                                                Add-Member -MemberType NoteProperty -Name DisplayName -Value 'max degree of parallelism' -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name Description -Value 'maximum degree of parallelism' -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name RunValue -Value $mockMaxDegreeOfParallelism -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name ConfigValue -Value $mockMaxDegreeOfParallelism -PassThru -Force
+                                        ) )
                                 } -PassThru -Force
                             ) )
-                        } -PassThru |
+                    } -PassThru |
                         Add-Member -MemberType ScriptMethod -Name Alter -Value {
-                            if ( $this.Configuration.MaxDegreeOfParallelism.ConfigValue -ne $mockExpectedMaxDopForAlterMethod )
-                            {
-                                throw "Called mocked Alter() method without setting the right MaxDegreeOfParallelism. Expected '{0}'. But was '{1}'." `
-                                      -f $mockExpectedMaxDopForAlterMethod, $this.Configuration.MaxDegreeOfParallelism.ConfigValue
-                            }
-                            if ($mockInvalidOperationForAlterMethod)
-                            {
-                                throw 'Mock Alter Method was called with invalid operation.'
-                            }
-                        } -PassThru -Force
+                        if ( $this.Configuration.MaxDegreeOfParallelism.ConfigValue -ne $mockExpectedMaxDopForAlterMethod )
+                        {
+                            throw "Called mocked Alter() method without setting the right MaxDegreeOfParallelism. Expected '{0}'. But was '{1}'." `
+                                -f $mockExpectedMaxDopForAlterMethod, $this.Configuration.MaxDegreeOfParallelism.ConfigValue
+                        }
+                        if ($mockInvalidOperationForAlterMethod)
+                        {
+                            throw 'Mock Alter Method was called with invalid operation.'
+                        }
+                    } -PassThru -Force
                 )
             )
         }
@@ -98,7 +100,7 @@ try
 
         #endregion
 
-        Describe "MSFT_SqlServerMaxDop\Get-TargetResource" -Tag 'Get'{
+        Describe "MSFT_SqlServerMaxDop\Get-TargetResource" -Tag 'Get' {
             Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
             Mock -CommandName Test-ActiveNode -MockWith { return $mockProcessOnlyOnActiveNode } -Verifiable
 
@@ -112,8 +114,8 @@ try
                 }
 
                 It 'Should return the same values as passed as parameters' {
-                    $result.SQLServer | Should -Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should -Be $testParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
                 }
 
                 It 'Should call the mock function Connect-SQL' {
@@ -128,7 +130,7 @@ try
             Assert-VerifiableMock
         }
 
-        Describe "MSFT_SqlServerMaxDop\Test-TargetResource" -Tag 'Test'{
+        Describe "MSFT_SqlServerMaxDop\Test-TargetResource" -Tag 'Test' {
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
@@ -148,9 +150,9 @@ try
             Context 'When the system is not in the desired state and DynamicAlloc is set to false' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    MaxDop          = 1
-                    DynamicAlloc    = $false
-                    Ensure = 'Present'
+                    MaxDop       = 1
+                    DynamicAlloc = $false
+                    Ensure       = 'Present'
                 }
 
                 It 'Should return the state as false when desired MaxDop is the wrong value' {
@@ -172,8 +174,8 @@ try
             Context 'When the system is in the desired state and DynamicAlloc is set to false' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    MaxDop          = 6
-                    DynamicAlloc    = $false
+                    MaxDop       = 6
+                    DynamicAlloc = $false
                 }
 
                 It 'Should return the state as true when desired MaxDop is the correct value' {
@@ -311,7 +313,7 @@ try
                 BeforeAll {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Ensure = 'Absent'
+                        Ensure                  = 'Absent'
                         ProcessOnlyOnActiveNode = $true
                     }
 
@@ -349,8 +351,8 @@ try
             Context 'When the MaxDop parameter is not null and DynamicAlloc set to true' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    MaxDop          = 4
-                    DynamicAlloc    = $true
+                    MaxDop       = 4
+                    DynamicAlloc = $true
                 }
 
                 It 'Should throw the correct error' {
@@ -363,9 +365,9 @@ try
             }
 
             # This is regression test for issue #576
-            Context 'When the system is in the desired state and SQLServer is not set' {
+            Context 'When the system is in the desired state and ServerName is not set' {
                 $testParameters = $mockDefaultParameters
-                $testParameters.Remove('SQLServer')
+                $testParameters.Remove('ServerName')
                 $testParameters += @{
                     Ensure = 'Absent'
                 }
@@ -378,7 +380,7 @@ try
             Assert-VerifiableMock
         }
 
-        Describe "MSFT_SqlServerMaxDop\Set-TargetResource" -Tag 'Set'{
+        Describe "MSFT_SqlServerMaxDop\Set-TargetResource" -Tag 'Set' {
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
@@ -394,9 +396,9 @@ try
             Context 'When the MaxDop parameter is not null and DynamicAlloc set to true' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    MaxDop          = 4
-                    DynamicAlloc    = $true
-                    Ensure          = 'Present'
+                    MaxDop       = 4
+                    DynamicAlloc = $true
+                    Ensure       = 'Present'
                 }
 
                 It 'Should throw the correct error' {
@@ -432,9 +434,9 @@ try
             Context 'When the desired MaxDop parameter is not set' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    MaxDop          = 1
-                    DynamicAlloc    = $false
-                    Ensure          = 'Present'
+                    MaxDop       = 1
+                    DynamicAlloc = $false
+                    Ensure       = 'Present'
                 }
 
                 It 'Should Not Throw when MaxDop parameter is not null and DynamicAlloc set to false' {
@@ -454,8 +456,8 @@ try
             Context 'When the system is not in the desired state and DynamicAlloc is set to true' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    DynamicAlloc    = $true
-                    Ensure          = 'Present'
+                    DynamicAlloc = $true
+                    Ensure       = 'Present'
                 }
 
                 It 'Should Not Throw when MaxDop parameter is not null and DynamicAlloc set to false' {
@@ -478,15 +480,15 @@ try
             Context 'When the desired MaxDop parameter is not set' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    MaxDop          = 1
-                    DynamicAlloc    = $false
-                    Ensure          = 'Present'
+                    MaxDop       = 1
+                    DynamicAlloc = $false
+                    Ensure       = 'Present'
                 }
 
                 It 'Shoud throw the correct error when Alter() method was called with invalid operation' {
                     $throwInvalidOperation = ('Unexpected result when trying to configure the max degree of parallelism ' + `
-                                              'server configuration option. InnerException: Exception calling "Alter" ' + `
-                                              'with "0" argument(s): "Mock Alter Method was called with invalid operation."')
+                            'server configuration option. InnerException: Exception calling "Alter" ' + `
+                            'with "0" argument(s): "Mock Alter Method was called with invalid operation."')
 
                     { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
                 }

--- a/Tests/Unit/MSFT_SqlServerMemory.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerMemory.Tests.ps1
@@ -1,14 +1,14 @@
-$script:DSCModuleName      = 'SqlServerDsc'
-$script:DSCResourceName    = 'MSFT_SqlServerMemory'
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlServerMemory'
 
 #region HEADER
 
 # Unit Test Template Version: 1.2.0
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -23,10 +23,12 @@ $TestEnvironment = Initialize-TestEnvironment `
 
 #endregion HEADER
 
-function Invoke-TestSetup {
+function Invoke-TestSetup
+{
 }
 
-function Invoke-TestCleanup {
+function Invoke-TestCleanup
+{
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
 }
 
@@ -36,8 +38,8 @@ try
     Invoke-TestSetup
 
     InModuleScope $script:DSCResourceName {
-        $mockSQLServerName = 'localhost'
-        $mockSQLServerInstanceName = 'MSSQLSERVER'
+        $mockServerName = 'localhost'
+        $mockInstanceName = 'MSSQLSERVER'
         $mockMinServerMemory = 2048
         $mockMaxServerMemory = 10300
         $mockPhysicalMemoryCapacity = 8589934592
@@ -47,8 +49,8 @@ try
 
         # Default parameters that are used for the It-blocks
         $mockDefaultParameters = @{
-            SQLInstanceName = $mockSQLServerInstanceName
-            SQLServer       = $mockSQLServerName
+            InstanceName = $mockInstanceName
+            ServerName   = $mockServerName
         }
 
         #region Function mocks
@@ -58,45 +60,45 @@ try
                 (
                     # New-Object Object |
                     New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server |
-                        Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockSQLServerInstanceName -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockSQLServerName -PassThru -Force |
+                        Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockInstanceName -PassThru -Force |
+                        Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockServerName -PassThru -Force |
                         Add-Member -MemberType ScriptProperty -Name Configuration -Value {
-                            return @( ( New-Object Object |
-                                Add-Member -MemberType ScriptProperty -Name MinServerMemory -Value {
+                        return @( ( New-Object Object |
+                                    Add-Member -MemberType ScriptProperty -Name MinServerMemory -Value {
                                     return @( ( New-Object Object |
-                                        Add-Member -MemberType NoteProperty -Name DisplayName -Value 'min server memory (MB)' -PassThru |
-                                        Add-Member -MemberType NoteProperty -Name Description -Value 'Minimum size of server memory (MB)' -PassThru |
-                                        Add-Member -MemberType NoteProperty -Name RunValue -Value $mockMinServerMemory -PassThru |
-                                        Add-Member -MemberType NoteProperty -Name ConfigValue -Value $mockMinServerMemory -PassThru -Force
-                                    ) )
+                                                Add-Member -MemberType NoteProperty -Name DisplayName -Value 'min server memory (MB)' -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name Description -Value 'Minimum size of server memory (MB)' -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name RunValue -Value $mockMinServerMemory -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name ConfigValue -Value $mockMinServerMemory -PassThru -Force
+                                        ) )
                                 } -PassThru |
-                                Add-Member -MemberType ScriptProperty -Name MaxServerMemory -Value {
+                                    Add-Member -MemberType ScriptProperty -Name MaxServerMemory -Value {
                                     return @( ( New-Object Object |
-                                        Add-Member -MemberType NoteProperty -Name DisplayName -Value 'max server memory (MB)' -PassThru |
-                                        Add-Member -MemberType NoteProperty -Name Description -Value 'Maximum size of server memory (MB)' -PassThru |
-                                        Add-Member -MemberType NoteProperty -Name RunValue -Value $mockMaxServerMemory -PassThru |
-                                        Add-Member -MemberType NoteProperty -Name ConfigValue -Value $mockMaxServerMemory -PassThru -Force
-                                    ) )
+                                                Add-Member -MemberType NoteProperty -Name DisplayName -Value 'max server memory (MB)' -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name Description -Value 'Maximum size of server memory (MB)' -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name RunValue -Value $mockMaxServerMemory -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name ConfigValue -Value $mockMaxServerMemory -PassThru -Force
+                                        ) )
                                 } -PassThru -Force
                             ) )
-                        } -PassThru -Force |
+                    } -PassThru -Force |
                         Add-Member -MemberType ScriptMethod -Name Alter -Value {
-                            if ( $this.Configuration.MinServerMemory.ConfigValue -ne $mockExpectedMinMemoryForAlterMethod )
-                            {
-                                throw "Called mocked Alter() method without setting the right minimum server memory. Expected '{0}'. But was '{1}'." -f $mockExpectedMinMemoryForAlterMethod, $this.Configuration.MinServerMemory.ConfigValue
-                            }
-                            if ( $this.Configuration.MaxServerMemory.ConfigValue -ne $mockExpectedMaxMemoryForAlterMethod )
-                            {
-                                throw "Called mocked Alter() method without setting the right maximum server memory. Expected '{0}'. But was '{1}'." -f $mockExpectedMaxMemoryForAlterMethod, $this.Configuration.MaxServerMemory.ConfigValue
-                            }
-                        } -PassThru -Force
+                        if ( $this.Configuration.MinServerMemory.ConfigValue -ne $mockExpectedMinMemoryForAlterMethod )
+                        {
+                            throw "Called mocked Alter() method without setting the right minimum server memory. Expected '{0}'. But was '{1}'." -f $mockExpectedMinMemoryForAlterMethod, $this.Configuration.MinServerMemory.ConfigValue
+                        }
+                        if ( $this.Configuration.MaxServerMemory.ConfigValue -ne $mockExpectedMaxMemoryForAlterMethod )
+                        {
+                            throw "Called mocked Alter() method without setting the right maximum server memory. Expected '{0}'. But was '{1}'." -f $mockExpectedMaxMemoryForAlterMethod, $this.Configuration.MaxServerMemory.ConfigValue
+                        }
+                    } -PassThru -Force
                 )
             )
         }
 
         #endregion
 
-        Describe "MSFT_SqlServerMemory\Get-TargetResource" -Tag 'Get'{
+        Describe "MSFT_SqlServerMemory\Get-TargetResource" -Tag 'Get' {
             Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
             Mock -CommandName Test-ActiveNode -MockWith { return $mockTestActiveNode } -Verifiable
 
@@ -114,8 +116,8 @@ try
                 }
 
                 It 'Should return the same values as passed as parameters' {
-                    $result.SQLServer | Should -Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should -Be $testParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
                 }
 
                 It 'Should call the mock function Connect-SQL' {
@@ -130,7 +132,7 @@ try
             Assert-VerifiableMock
         }
 
-        Describe "MSFT_SqlServerMemory\Test-TargetResource" -Tag 'Test'{
+        Describe "MSFT_SqlServerMemory\Test-TargetResource" -Tag 'Test' {
             Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
             Mock -CommandName Get-CimInstance -MockWith {
@@ -141,14 +143,14 @@ try
                 $mockGetCimInstanceMem = @()
 
                 $mockGetCimInstanceMem += New-Object -TypeName psobject -Property @{
-                    Name = 'Physical Memory'
-                    Tag = 'Physical Memory 0'
+                    Name     = 'Physical Memory'
+                    Tag      = 'Physical Memory 0'
                     Capacity = 8589934592
                 }
 
                 $mockGetCimInstanceMem += New-Object -TypeName psobject -Property @{
-                    Name = 'Physical Memory'
-                    Tag = 'Physical Memory 1'
+                    Name     = 'Physical Memory'
+                    Tag      = 'Physical Memory 1'
                     Capacity = 8589934592
                 }
 
@@ -176,10 +178,10 @@ try
             Context 'When the system is not in the desired state and DynamicAlloc is set to false' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    Ensure          = 'Present'
-                    MinMemory       = 1024
-                    MaxMemory       = 8192
-                    DynamicAlloc    = $false
+                    Ensure       = 'Present'
+                    MinMemory    = 1024
+                    MaxMemory    = 8192
+                    DynamicAlloc = $false
                 }
 
                 It 'Should return the state as false when desired MinMemory and MaxMemory are not present' {
@@ -199,9 +201,9 @@ try
             Context 'When the system is not in the desired state and DynamicAlloc is set to false' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    Ensure          = 'Present'
-                    MaxMemory       = 8192
-                    DynamicAlloc    = $false
+                    Ensure       = 'Present'
+                    MaxMemory    = 8192
+                    DynamicAlloc = $false
                 }
 
                 It 'Should return the state as false when desired MaxMemory is not present' {
@@ -221,10 +223,10 @@ try
             Context 'When the system is in the desired state and DynamicAlloc is set to false' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    Ensure          = 'Present'
-                    MinMemory       = 0
-                    MaxMemory       = 10300
-                    DynamicAlloc    = $false
+                    Ensure       = 'Present'
+                    MinMemory    = 0
+                    MaxMemory    = 10300
+                    DynamicAlloc = $false
                 }
 
                 It 'Should return the state as true when desired MinMemory and MaxMemory are present' {
@@ -244,9 +246,9 @@ try
             Context 'When the MaxMemory parameter is not null and DynamicAlloc is set to true' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    MaxMemory       = 8192
-                    DynamicAlloc    = $true
-                    Ensure          = 'Present'
+                    MaxMemory    = 8192
+                    DynamicAlloc = $true
+                    Ensure       = 'Present'
                 }
 
                 It 'Should throw the correct error' {
@@ -265,8 +267,8 @@ try
             Context 'When the MaxMemory parameter is null and DynamicAlloc is set to false' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    DynamicAlloc    = $false
-                    Ensure          = 'Present'
+                    DynamicAlloc = $false
+                    Ensure       = 'Present'
                 }
 
                 It 'Should throw the correct error' {
@@ -285,8 +287,8 @@ try
             Context 'When the system is not in the desired state and DynamicAlloc is set to true' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    Ensure          = 'Present'
-                    DynamicAlloc    = $true
+                    Ensure       = 'Present'
+                    DynamicAlloc = $true
                 }
 
                 It 'Should return the state as false when desired MinMemory and MaxMemory are not present' {
@@ -369,8 +371,8 @@ try
             Context 'When the system is in the desired state and DynamicAlloc is set to true' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    Ensure          = 'Present'
-                    DynamicAlloc    = $true
+                    Ensure       = 'Present'
+                    DynamicAlloc = $true
                 }
 
                 It 'Should return the state as true when desired MinMemory and MaxMemory are present' {
@@ -409,7 +411,7 @@ try
             Context 'When the system is not in the desired state and Ensure is set to Absent' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    Ensure          = 'Absent'
+                    Ensure = 'Absent'
                 }
 
                 It 'Should return the state as false when desired MinMemory and MaxMemory are not set to the default values' {
@@ -434,7 +436,7 @@ try
             Context 'When the system is in the desired state and Ensure is set to Absent' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    Ensure          = 'Absent'
+                    Ensure = 'Absent'
                 }
 
                 It 'Should return the state as true when desired MinMemory and MaxMemory are present' {
@@ -452,9 +454,9 @@ try
             }
 
             # This is regression test for issue #576
-            Context 'When the system is in the desired state and SQLServer is not set' {
+            Context 'When the system is in the desired state and ServerName is not set' {
                 $testParameters = $mockDefaultParameters
-                $testParameters.Remove('SQLServer')
+                $testParameters.Remove('ServerName')
                 $testParameters += @{
                     Ensure = 'Absent'
                 }
@@ -481,14 +483,14 @@ try
                 $mockGetCimInstanceMem = @()
 
                 $mockGetCimInstanceMem += New-Object -TypeName psobject -Property @{
-                    Name = 'Physical Memory'
-                    Tag = 'Physical Memory 0'
+                    Name     = 'Physical Memory'
+                    Tag      = 'Physical Memory 0'
                     Capacity = 17179869184
                 }
 
                 $mockGetCimInstanceMem += New-Object -TypeName psobject -Property @{
-                    Name = 'Physical Memory'
-                    Tag = 'Physical Memory 1'
+                    Name     = 'Physical Memory'
+                    Tag      = 'Physical Memory 1'
                     Capacity = 17179869184
                 }
 
@@ -514,9 +516,9 @@ try
             Context 'When the MaxMemory parameter is not null and DynamicAlloc is set to true' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    MaxMemory       = 8192
-                    DynamicAlloc    = $true
-                    Ensure          = 'Present'
+                    MaxMemory    = 8192
+                    DynamicAlloc = $true
+                    Ensure       = 'Present'
                 }
 
                 It 'Should throw the correct error' {
@@ -535,8 +537,8 @@ try
             Context 'When the MaxMemory parameter is null and DynamicAlloc is set to false' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    DynamicAlloc    = $false
-                    Ensure          = 'Present'
+                    DynamicAlloc = $false
+                    Ensure       = 'Present'
                 }
 
                 It 'Should throw the correct error' {
@@ -582,10 +584,10 @@ try
                 $mockExpectedMaxMemoryForAlterMethod = 8192
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    MaxMemory       = 8192
-                    MinMemory       = 1024
-                    DynamicAlloc    = $false
-                    Ensure          = 'Present'
+                    MaxMemory    = 8192
+                    MinMemory    = 1024
+                    DynamicAlloc = $false
+                    Ensure       = 'Present'
                 }
 
                 It 'Should set the MinMemory and MaxMemory to the correct values when Ensure parameter is set to Present and DynamicAlloc is set to false' {
@@ -604,9 +606,9 @@ try
             Context 'When the system (OS IA64-bit) is not in the desired state and Ensure is set to Present, and DynamicAlloc is set to true' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    DynamicAlloc    = $true
-                    Ensure          = 'Present'
-                    MinMemory       = 2048
+                    DynamicAlloc = $true
+                    Ensure       = 'Present'
+                    MinMemory    = 2048
                 }
 
                 It 'Should set the MaxMemory to the correct values when Ensure parameter is set to Present and DynamicAlloc is set to true' {
@@ -647,8 +649,8 @@ try
             Context 'When the system (OS 32-bit) is not in the desired state and Ensure is set to Present, and DynamicAlloc is set to true' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    DynamicAlloc    = $true
-                    Ensure          = 'Present'
+                    DynamicAlloc = $true
+                    Ensure       = 'Present'
                 }
 
                 It 'Should set the MaxMemory to the correct values when Ensure parameter is set to Present and DynamicAlloc is set to true' {
@@ -680,9 +682,9 @@ try
 
             Mock -CommandName Connect-SQL -MockWith {
                 $mockSqlServerObject = [PSCustomObject]@{
-                    InstanceName                = $mockSQLServerInstanceName
-                    ComputerNamePhysicalNetBIOS = $mockSQLServerName
-                    Configuration = @{
+                    InstanceName                = $mockInstanceName
+                    ComputerNamePhysicalNetBIOS = $mockServerName
+                    Configuration               = @{
                         MinServerMemory = @{
                             DisplayName = 'min server memory (MB)'
                             Description = 'Minimum size of server memory (MB)'
@@ -709,16 +711,16 @@ try
             Context 'When the desired MinMemory and MaxMemory fails to be set' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    MaxMemory       = 8192
-                    MinMemory       = 1024
-                    DynamicAlloc    = $false
-                    Ensure          = 'Present'
+                    MaxMemory    = 8192
+                    MinMemory    = 1024
+                    DynamicAlloc = $false
+                    Ensure       = 'Present'
                 }
 
                 It 'Should throw the correct error' {
-                    { Set-TargetResource @testParameters } | Should -Throw ("Failed to alter the server configuration memory for $($env:COMPUTERNAME)" + "\" +`
-                                                                        "$mockSQLServerInstanceName. InnerException: Exception calling ""Alter"" with ""0"" argument(s): " + `
-                                                                        """Mock Alter Method was called with invalid operation.""")
+                    { Set-TargetResource @testParameters } | Should -Throw ("Failed to alter the server configuration memory for $($env:COMPUTERNAME)" + "\" + `
+                            "$mockInstanceName. InnerException: Exception calling ""Alter"" with ""0"" argument(s): " + `
+                            """Mock Alter Method was called with invalid operation.""")
                 }
 
                 It 'Should call the mock function Connect-SQL' {
@@ -737,8 +739,8 @@ try
             Context 'When the Get-SqlDscDynamicMaxMemory fails to calculate the MaxMemory' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    DynamicAlloc    = $true
-                    Ensure          = 'Present'
+                    DynamicAlloc = $true
+                    Ensure       = 'Present'
                 }
 
                 It 'Should throw the correct error' {

--- a/Tests/Unit/MSFT_SqlServerPermission.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerPermission.Tests.ps1
@@ -79,7 +79,7 @@ try
 
                     It 'Should return the same values as passed as parameters' {
                         $result = Get-TargetResource @testParameters
-                        $result.ServerName | Should -Be$mockServerName
+                        $result.ServerName | Should -Be $mockServerName
                         $result.InstanceName | Should -Be $mockInstanceName
                         $result.Principal | Should -Be $mockPrincipal
                     }
@@ -109,7 +109,7 @@ try
 
                     It 'Should return the same values as passed as parameters' {
                         $result = Get-TargetResource @testParameters
-                        $result.ServerName | Should -Be$mockServerName
+                        $result.ServerName | Should -Be $mockServerName
                         $result.InstanceName | Should -Be $mockInstanceName
                         $result.Principal | Should -Be $mockPrincipal
                     }
@@ -146,7 +146,7 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.ServerName | Should -Be$mockServerName
+                    $result.ServerName | Should -Be $mockServerName
                     $result.InstanceName | Should -Be $mockInstanceName
                     $result.Principal | Should -Be $mockPrincipal
                 }

--- a/Tests/Unit/MSFT_SqlServerPermission.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerPermission.Tests.ps1
@@ -1,14 +1,14 @@
-$script:DSCModuleName      = 'SqlServerDsc'
-$script:DSCResourceName    = 'MSFT_SqlServerPermission'
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlServerPermission'
 
 #region HEADER
 
 # Unit Test Template Version: 1.2.0
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -20,12 +20,14 @@ $TestEnvironment = Initialize-TestEnvironment `
 
 #endregion HEADER
 
-function Invoke-TestSetup {
+function Invoke-TestSetup
+{
     # Loading mocked classes
     Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
 }
 
-function Invoke-TestCleanup {
+function Invoke-TestCleanup
+{
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
 }
 
@@ -35,19 +37,19 @@ try
     Invoke-TestSetup
 
     InModuleScope $script:DSCResourceName {
-        $mockNodeName = 'localhost'
+        $mockServerName = 'localhost'
         $mockInstanceName = 'DEFAULT'
         $mockPrincipal = 'COMPANY\SqlServiceAcct'
         $mockOtherPrincipal = 'COMPANY\OtherAccount'
-        $mockPermission = @('ConnectSql','AlterAnyAvailabilityGroup','ViewServerState')
+        $mockPermission = @('ConnectSql', 'AlterAnyAvailabilityGroup', 'ViewServerState')
 
         #endregion Pester Test Initialization
 
         $defaultParameters = @{
             InstanceName = $mockInstanceName
-            NodeName = $mockNodeName
-            Principal = $mockPrincipal
-            Permission = $mockPermission
+            ServerName   = $mockServerName
+            Principal    = $mockPrincipal
+            Permission   = $mockPermission
         }
 
         Describe 'MSFT_SqlServerPermission\Get-TargetResource' {
@@ -56,7 +58,7 @@ try
 
                 Mock -CommandName Connect-SQL -MockWith {
                     $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
-                    $mockObjectSmoServer.Name = "$mockNodeName\$mockInstanceName"
+                    $mockObjectSmoServer.Name = "$mockServerName\$mockInstanceName"
                     $mockObjectSmoServer.DisplayName = $mockInstanceName
                     $mockObjectSmoServer.InstanceName = $mockInstanceName
                     $mockObjectSmoServer.IsHadrEnabled = $False
@@ -77,7 +79,7 @@ try
 
                     It 'Should return the same values as passed as parameters' {
                         $result = Get-TargetResource @testParameters
-                        $result.NodeName | Should -Be $mockNodeName
+                        $result.ServerName | Should -Be$mockServerName
                         $result.InstanceName | Should -Be $mockInstanceName
                         $result.Principal | Should -Be $mockPrincipal
                     }
@@ -97,7 +99,7 @@ try
                     [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $true
 
                     BeforeEach {
-                        $testParameters.Permission = @( 'AlterAnyAvailabilityGroup','ViewServerState','AlterAnyEndpoint')
+                        $testParameters.Permission = @( 'AlterAnyAvailabilityGroup', 'ViewServerState', 'AlterAnyEndpoint')
                     }
 
                     It 'Should return the desired state as absent' {
@@ -107,14 +109,14 @@ try
 
                     It 'Should return the same values as passed as parameters' {
                         $result = Get-TargetResource @testParameters
-                        $result.NodeName | Should -Be $mockNodeName
+                        $result.ServerName | Should -Be$mockServerName
                         $result.InstanceName | Should -Be $mockInstanceName
                         $result.Principal | Should -Be $mockPrincipal
                     }
 
                     It 'Should not return any permissions' {
                         $result = Get-TargetResource @testParameters
-                        $result.Permission | Should -Be @('AlterAnyAvailabilityGroup','ConnectSql', 'ViewServerState')
+                        $result.Permission | Should -Be @('AlterAnyAvailabilityGroup', 'ConnectSql', 'ViewServerState')
                     }
 
                     It 'Should call the mock function Connect-SQL' {
@@ -144,17 +146,21 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.NodeName | Should -Be $mockNodeName
+                    $result.ServerName | Should -Be$mockServerName
                     $result.InstanceName | Should -Be $mockInstanceName
                     $result.Principal | Should -Be $mockPrincipal
                 }
 
                 It 'Should return the permissions passed as parameter' {
                     $result = Get-TargetResource @testParameters
-                    foreach ($currentPermission in $mockPermission) {
-                        if( $result.Permission -ccontains $currentPermission ) {
+                    foreach ($currentPermission in $mockPermission)
+                    {
+                        if ( $result.Permission -ccontains $currentPermission )
+                        {
                             $permissionState = $true
-                        } else {
+                        }
+                        else
+                        {
                             $permissionState = $false
                             break
                         }
@@ -178,7 +184,7 @@ try
 
                 Mock -CommandName Connect-SQL -MockWith {
                     $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
-                    $mockObjectSmoServer.Name = "$mockNodeName\$mockInstanceName"
+                    $mockObjectSmoServer.Name = "$mockServerName\$mockInstanceName"
                     $mockObjectSmoServer.DisplayName = $mockInstanceName
                     $mockObjectSmoServer.InstanceName = $mockInstanceName
                     $mockObjectSmoServer.IsHadrEnabled = $False
@@ -246,7 +252,7 @@ try
 
                 Mock -CommandName Connect-SQL -MockWith {
                     $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
-                    $mockObjectSmoServer.Name = "$mockNodeName\$mockInstanceName"
+                    $mockObjectSmoServer.Name = "$mockServerName\$mockInstanceName"
                     $mockObjectSmoServer.DisplayName = $mockInstanceName
                     $mockObjectSmoServer.InstanceName = $mockInstanceName
                     $mockObjectSmoServer.IsHadrEnabled = $False
@@ -303,7 +309,7 @@ try
                     It 'Should return the correct error message' {
                         Mock -CommandName Connect-SQL -MockWith {
                             $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
-                            $mockObjectSmoServer.Name = "$mockNodeName\$mockInstanceName"
+                            $mockObjectSmoServer.Name = "$mockServerName\$mockInstanceName"
                             $mockObjectSmoServer.DisplayName = $mockInstanceName
                             $mockObjectSmoServer.InstanceName = $mockInstanceName
                             $mockObjectSmoServer.IsHadrEnabled = $False

--- a/Tests/Unit/MSFT_SqlServerRole.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerRole.Tests.ps1
@@ -1,14 +1,14 @@
-$script:DSCModuleName      = 'SqlServerDsc'
-$script:DSCResourceName    = 'MSFT_SqlServerRole'
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlServerRole'
 
 #region HEADER
 
 # Unit Test Template Version: 1.2.0
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -20,10 +20,12 @@ $TestEnvironment = Initialize-TestEnvironment `
 
 #endregion HEADER
 
-function Invoke-TestSetup {
+function Invoke-TestSetup
+{
 }
 
-function Invoke-TestCleanup {
+function Invoke-TestCleanup
+{
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
 }
 
@@ -33,21 +35,21 @@ try
     Invoke-TestSetup
 
     InModuleScope $script:DSCResourceName {
-        $mockSqlServerName                      = 'localhost'
-        $mockSqlServerInstanceName              = 'MSSQLSERVER'
-        $mockSqlServerRole                      = 'AdminSqlforBI'
-        $mockSqlServerLoginOne                  = 'CONTOSO\John'
-        $mockSqlServerLoginTwo                  = 'CONTOSO\Kelly'
-        $mockSqlServerLoginTree                 = 'CONTOSO\Lucy'
-        $mockSqlServerLoginFour                 = 'CONTOSO\Steve'
-        $mockEnumMemberNames                    = @($mockSqlServerLoginOne,$mockSqlServerLoginTwo)
-        $mockSqlServerLoginType                 = 'WindowsUser'
-        $mockExpectedServerRoleToDrop           = 'ServerRoleToDrop'
+        $mockServerName = 'localhost'
+        $mockInstanceName = 'MSSQLSERVER'
+        $mockSqlServerRole = 'AdminSqlforBI'
+        $mockSqlServerLoginOne = 'CONTOSO\John'
+        $mockSqlServerLoginTwo = 'CONTOSO\Kelly'
+        $mockSqlServerLoginTree = 'CONTOSO\Lucy'
+        $mockSqlServerLoginFour = 'CONTOSO\Steve'
+        $mockEnumMemberNames = @($mockSqlServerLoginOne, $mockSqlServerLoginTwo)
+        $mockSqlServerLoginType = 'WindowsUser'
+        $mockExpectedServerRoleToDrop = 'ServerRoleToDrop'
 
         # Default parameters that are used for the It-blocks
         $mockDefaultParameters = @{
-            SQLInstanceName = $mockSqlServerInstanceName
-            SQLServer       = $mockSqlServerName
+            InstanceName = $mockInstanceName
+            ServerName   = $mockServerName
         }
 
         #region Function mocks
@@ -56,81 +58,81 @@ try
             return @(
                 (
                     New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockSqlServerInstanceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockSqlServerName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockInstanceName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockServerName -PassThru |
                         Add-Member -MemberType ScriptProperty -Name Roles -Value {
-                            return @{
-                                $mockSqlServerRole = ( New-Object Object |
+                        return @{
+                            $mockSqlServerRole = ( New-Object Object |
                                     Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlServerRole -PassThru |
                                     Add-Member -MemberType ScriptMethod -Name EnumMemberNames -Value {
-                                        if ($mockInvalidOperationForEnumMethod)
-                                        {
-                                            throw 'Mock EnumMemberNames Method was called with invalid operation.'
-                                        }
-                                        else
-                                        {
-                                            $mockEnumMemberNames
-                                        }
-                                    } -PassThru |
+                                    if ($mockInvalidOperationForEnumMethod)
+                                    {
+                                        throw 'Mock EnumMemberNames Method was called with invalid operation.'
+                                    }
+                                    else
+                                    {
+                                        $mockEnumMemberNames
+                                    }
+                                } -PassThru |
                                     Add-Member -MemberType ScriptMethod -Name Drop -Value {
-                                        if ($mockInvalidOperationForDropMethod)
-                                        {
-                                            throw 'Mock Drop Method was called with invalid operation.'
-                                        }
+                                    if ($mockInvalidOperationForDropMethod)
+                                    {
+                                        throw 'Mock Drop Method was called with invalid operation.'
+                                    }
 
-                                        if ( $this.Name -ne $mockExpectedServerRoleToDrop )
-                                        {
-                                            throw "Called mocked drop() method without dropping the right server role. Expected '{0}'. But was '{1}'." `
-                                                    -f $mockExpectedServerRoleToDrop, $this.Name
-                                        }
-                                    } -PassThru |
+                                    if ( $this.Name -ne $mockExpectedServerRoleToDrop )
+                                    {
+                                        throw "Called mocked drop() method without dropping the right server role. Expected '{0}'. But was '{1}'." `
+                                            -f $mockExpectedServerRoleToDrop, $this.Name
+                                    }
+                                } -PassThru |
                                     Add-Member -MemberType ScriptMethod -Name AddMember -Value {
-                                        if ($mockInvalidOperationForAddMemberMethod)
-                                        {
-                                            throw 'Mock AddMember Method was called with invalid operation.'
-                                        }
+                                    if ($mockInvalidOperationForAddMemberMethod)
+                                    {
+                                        throw 'Mock AddMember Method was called with invalid operation.'
+                                    }
 
-                                        if ( $mockSqlServerLoginToAdd -ne $mockExpectedMemberToAdd )
-                                        {
-                                            throw "Called mocked AddMember() method without adding the right login. Expected '{0}'. But was '{1}'." `
-                                                    -f $mockExpectedMemberToAdd, $mockSqlServerLoginToAdd
-                                        }
-                                    } -PassThru |
+                                    if ( $mockSqlServerLoginToAdd -ne $mockExpectedMemberToAdd )
+                                    {
+                                        throw "Called mocked AddMember() method without adding the right login. Expected '{0}'. But was '{1}'." `
+                                            -f $mockExpectedMemberToAdd, $mockSqlServerLoginToAdd
+                                    }
+                                } -PassThru |
                                     Add-Member -MemberType ScriptMethod -Name DropMember -Value {
-                                        if ($mockInvalidOperationForDropMemberMethod)
-                                        {
-                                            throw 'Mock DropMember Method was called with invalid operation.'
-                                        }
+                                    if ($mockInvalidOperationForDropMemberMethod)
+                                    {
+                                        throw 'Mock DropMember Method was called with invalid operation.'
+                                    }
 
-                                        if ( $mockSqlServerLoginToDrop -ne $mockExpectedMemberToDrop )
-                                        {
-                                            throw "Called mocked DropMember() method without removing the right login. Expected '{0}'. But was '{1}'." `
-                                                    -f $mockExpectedMemberToDrop, $mockSqlServerLoginToDrop
-                                        }
-                                    } -PassThru
-                                    )
-                                }
-                            } -PassThru |
-                            Add-Member -MemberType ScriptProperty -Name Logins -Value {
-                            return @{
-                                $mockSqlServerLoginOne = @((
+                                    if ( $mockSqlServerLoginToDrop -ne $mockExpectedMemberToDrop )
+                                    {
+                                        throw "Called mocked DropMember() method without removing the right login. Expected '{0}'. But was '{1}'." `
+                                            -f $mockExpectedMemberToDrop, $mockSqlServerLoginToDrop
+                                    }
+                                } -PassThru
+                            )
+                        }
+                    } -PassThru |
+                        Add-Member -MemberType ScriptProperty -Name Logins -Value {
+                        return @{
+                            $mockSqlServerLoginOne  = @((
                                     New-Object Object |
                                         Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru
                                 ))
-                                $mockSqlServerLoginTwo = @((
+                            $mockSqlServerLoginTwo  = @((
                                     New-Object Object |
                                         Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru
                                 ))
-                                $mockSqlServerLoginTree = @((
+                            $mockSqlServerLoginTree = @((
                                     New-Object Object |
                                         Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru
                                 ))
-                                $mockSqlServerLoginFour = @((
+                            $mockSqlServerLoginFour = @((
                                     New-Object Object |
                                         Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru
                                 ))
-                            }
-                        } -PassThru -Force
+                        }
+                    } -PassThru -Force
                 )
             )
         }
@@ -141,23 +143,23 @@ try
                     New-Object Object |
                         Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlServerRoleAdd -PassThru |
                         Add-Member -MemberType ScriptMethod -Name Create -Value {
-                            if ($mockInvalidOperationForCreateMethod)
-                            {
-                                throw 'Mock Create Method was called with invalid operation.'
-                            }
+                        if ($mockInvalidOperationForCreateMethod)
+                        {
+                            throw 'Mock Create Method was called with invalid operation.'
+                        }
 
-                            if ( $this.Name -ne $mockExpectedServerRoleToCreate )
-                            {
-                                throw "Called mocked Create() method without adding the right server role. Expected '{0}'. But was '{1}'." `
-                                        -f $mockExpectedServerRoleToCreate, $this.Name
-                            }
-                        } -PassThru -Force
+                        if ( $this.Name -ne $mockExpectedServerRoleToCreate )
+                        {
+                            throw "Called mocked Create() method without adding the right server role. Expected '{0}'. But was '{1}'." `
+                                -f $mockExpectedServerRoleToCreate, $this.Name
+                        }
+                    } -PassThru -Force
                 )
             )
         }
         #endregion
 
-        Describe "MSFT_SqlServerRole\Get-TargetResource" -Tag 'Get'{
+        Describe "MSFT_SqlServerRole\Get-TargetResource" -Tag 'Get' {
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
             }
@@ -184,8 +186,8 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.SQLServer | Should -Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should -Be $testParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.ServerRoleName | Should -Be $testParameters.ServerRoleName
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
@@ -222,8 +224,8 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.SQLServer | Should -Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should -Be $testParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.ServerRoleName | Should -Be $testParameters.ServerRoleName
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
@@ -239,9 +241,9 @@ try
                     }
 
                     $throwInvalidOperation = ('Failed to enumerate members of the server role ' + `
-                                              'named AdminSqlforBI on localhost\MSSQLSERVER. InnerException: ' + `
-                                              'Exception calling "EnumMemberNames" with "0" argument(s): ' + `
-                                              '"Mock EnumMemberNames Method was called with invalid operation."')
+                            'named AdminSqlforBI on localhost\MSSQLSERVER. InnerException: ' + `
+                            'Exception calling "EnumMemberNames" with "0" argument(s): ' + `
+                            '"Mock EnumMemberNames Method was called with invalid operation."')
 
                     { Get-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
                 }
@@ -282,8 +284,8 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.SQLServer | Should -Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should -Be $testParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.ServerRoleName | Should -Be $testParameters.ServerRoleName
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
@@ -293,8 +295,8 @@ try
             Context 'When the system is in the desired state, parameter MembersToInclude is assigned a value and ensure is set to Present' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    ServerRoleName    = $mockSqlServerRole
-                    MembersToInclude  = $mockSqlServerLoginTwo
+                    ServerRoleName   = $mockSqlServerRole
+                    MembersToInclude = $mockSqlServerLoginTwo
                 }
 
                 It 'Should return the state as present when the correct members exist' {
@@ -321,8 +323,8 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.SQLServer | Should -Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should -Be $testParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.ServerRoleName | Should -Be $testParameters.ServerRoleName
                     $result.MembersToInclude | Should -Be $testParameters.MembersToInclude
 
@@ -333,8 +335,8 @@ try
             Context 'When the system is in the desired state, parameter MembersToExclude is assigned a value and ensure is set to Present' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    ServerRoleName    = $mockSqlServerRole
-                    MembersToExclude  = $mockSqlServerLoginTree
+                    ServerRoleName   = $mockSqlServerRole
+                    MembersToExclude = $mockSqlServerLoginTree
                 }
 
                 It 'Should return the state as present when the members does not exist' {
@@ -346,8 +348,8 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.SQLServer | Should -Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should -Be $testParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.ServerRoleName | Should -Be $testParameters.ServerRoleName
                     $result.MembersToExclude | Should -Be $testParameters.MembersToExclude
 
@@ -359,14 +361,14 @@ try
                 It 'Should throw the correct error' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        ServerRoleName = $mockSqlServerRole
-                        Members = $mockEnumMemberNames
+                        ServerRoleName   = $mockSqlServerRole
+                        Members          = $mockEnumMemberNames
                         MembersToInclude = $mockSqlServerLoginTree
                     }
 
                     $throwInvalidOperation = ('The parameter MembersToInclude and/or ' + `
-                                              'MembersToExclude must not be set, or be set ' + `
-                                              'to $null, when parameter Members are used.')
+                            'MembersToExclude must not be set, or be set ' + `
+                            'to $null, when parameter Members are used.')
 
                     { Get-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
                 }
@@ -381,14 +383,14 @@ try
                 It 'Should throw the correct error' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        ServerRoleName = $mockSqlServerRole
-                        Members = $mockEnumMemberNames
+                        ServerRoleName   = $mockSqlServerRole
+                        Members          = $mockEnumMemberNames
                         MembersToExclude = $mockSqlServerLoginTree
                     }
 
                     $throwInvalidOperation = ('The parameter MembersToInclude and/or ' + `
-                                              'MembersToExclude must not be set, or be set ' + `
-                                              'to $null, when parameter Members are used.')
+                            'MembersToExclude must not be set, or be set ' + `
+                            'to $null, when parameter Members are used.')
 
                     { Get-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
                 }
@@ -420,8 +422,8 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.SQLServer | Should -Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should -Be $testParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.ServerRoleName | Should -Be $testParameters.ServerRoleName
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
@@ -432,7 +434,7 @@ try
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
                     ServerRoleName = $mockSqlServerRole
-                    Members        = @($mockSqlServerLoginOne,$mockSqlServerLoginTree)
+                    Members        = @($mockSqlServerLoginOne, $mockSqlServerLoginTree)
                 }
 
                 It 'Should return the state as absent when the members in the role are wrong' {
@@ -459,8 +461,8 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.SQLServer | Should -Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should -Be $testParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.ServerRoleName | Should -Be $testParameters.ServerRoleName
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
@@ -470,8 +472,8 @@ try
             Context 'When the system is not in the desired state, parameter MembersToInclude is assigned a value and ensure is set to Present' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    ServerRoleName    = $mockSqlServerRole
-                    MembersToInclude  = $mockSqlServerLoginTree
+                    ServerRoleName   = $mockSqlServerRole
+                    MembersToInclude = $mockSqlServerLoginTree
                 }
 
                 It 'Should return the state as absent when the members in the role are missing' {
@@ -498,8 +500,8 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.SQLServer | Should -Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should -Be $testParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.ServerRoleName | Should -Be $testParameters.ServerRoleName
                     $result.MembersToInclude | Should -Be $testParameters.MembersToInclude
 
@@ -510,8 +512,8 @@ try
             Context 'When the system is not in the desired state, parameter MembersToExclude is assigned a value and ensure is set to Present' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
-                    ServerRoleName    = $mockSqlServerRole
-                    MembersToExclude  = $mockSqlServerLoginTwo
+                    ServerRoleName   = $mockSqlServerRole
+                    MembersToExclude = $mockSqlServerLoginTwo
                 }
 
                 It 'Should return the state as absent when the members in the role are present' {
@@ -523,8 +525,8 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.SQLServer | Should -Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should -Be $testParameters.SQLInstanceName
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
                     $result.ServerRoleName | Should -Be $testParameters.ServerRoleName
                     $result.MembersToExclude | Should -Be $testParameters.MembersToExclude
 
@@ -535,7 +537,7 @@ try
             Assert-VerifiableMock
         }
 
-        Describe "MSFT_SqlServerRole\Test-TargetResource" -Tag 'Test'{
+        Describe "MSFT_SqlServerRole\Test-TargetResource" -Tag 'Test' {
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
             }
@@ -544,7 +546,7 @@ try
                 It 'Should return false when desired server role exist' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Ensure = 'Absent'
+                        Ensure         = 'Absent'
                         ServerRoleName = $mockSqlServerRole
                     }
 
@@ -559,7 +561,7 @@ try
                 It 'Should return true when desired server role does not exist' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Ensure = 'Absent'
+                        Ensure         = 'Absent'
                         ServerRoleName = 'newServerRole'
                     }
 
@@ -574,7 +576,7 @@ try
                 It 'Should return true when desired server role exist' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Ensure = 'Present'
+                        Ensure         = 'Present'
                         ServerRoleName = $mockSqlServerRole
                     }
 
@@ -589,9 +591,9 @@ try
                 It 'Should return false when desired members are not in desired server role' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Ensure = 'Present'
+                        Ensure         = 'Present'
                         ServerRoleName = $mockSqlServerRole
-                        Members = @($mockSqlServerLoginTree,$mockSqlServerLoginFour)
+                        Members        = @($mockSqlServerLoginTree, $mockSqlServerLoginFour)
                     }
 
                     $result = Test-TargetResource @testParameters
@@ -605,15 +607,15 @@ try
                 It 'Should throw the correct error' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Ensure = 'Present'
-                        ServerRoleName = $mockSqlServerRole
-                        Members = $mockEnumMemberNames
+                        Ensure           = 'Present'
+                        ServerRoleName   = $mockSqlServerRole
+                        Members          = $mockEnumMemberNames
                         MembersToInclude = $mockSqlServerLoginTree
                     }
 
                     $throwInvalidOperation = ('The parameter MembersToInclude and/or ' + `
-                                              'MembersToExclude must not be set, or be set ' + `
-                                              'to $null, when parameter Members are used.')
+                            'MembersToExclude must not be set, or be set ' + `
+                            'to $null, when parameter Members are used.')
 
                     { Test-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
 
@@ -625,8 +627,8 @@ try
                 It 'Should return true when desired server role exist' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Ensure = 'Present'
-                        ServerRoleName = $mockSqlServerRole
+                        Ensure           = 'Present'
+                        ServerRoleName   = $mockSqlServerRole
                         MembersToInclude = $mockSqlServerLoginTwo
                     }
 
@@ -641,8 +643,8 @@ try
                 It 'Should return false when desired server role does not exist' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Ensure = 'Present'
-                        ServerRoleName = $mockSqlServerRole
+                        Ensure           = 'Present'
+                        ServerRoleName   = $mockSqlServerRole
                         MembersToInclude = $mockSqlServerLoginTree
                     }
 
@@ -657,15 +659,15 @@ try
                 It 'Should throw the correct error' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Ensure = 'Present'
-                        ServerRoleName = $mockSqlServerRole
-                        Members = $mockEnumMemberNames
+                        Ensure           = 'Present'
+                        ServerRoleName   = $mockSqlServerRole
+                        Members          = $mockEnumMemberNames
                         MembersToExclude = $mockSqlServerLoginTwo
                     }
 
                     $throwInvalidOperation = ('The parameter MembersToInclude and/or ' + `
-                                              'MembersToExclude must not be set, or be set ' + `
-                                              'to $null, when parameter Members are used.')
+                            'MembersToExclude must not be set, or be set ' + `
+                            'to $null, when parameter Members are used.')
 
                     { Test-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
 
@@ -677,8 +679,8 @@ try
                 It 'Should return true when desired server role does not exist' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Ensure = 'Present'
-                        ServerRoleName = $mockSqlServerRole
+                        Ensure           = 'Present'
+                        ServerRoleName   = $mockSqlServerRole
                         MembersToExclude = $mockSqlServerLoginTree
                     }
 
@@ -693,8 +695,8 @@ try
                 It 'Should return false when desired server role exist' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Ensure = 'Present'
-                        ServerRoleName = $mockSqlServerRole
+                        Ensure           = 'Present'
+                        ServerRoleName   = $mockSqlServerRole
                         MembersToExclude = $mockSqlServerLoginTwo
                     }
 
@@ -708,7 +710,7 @@ try
             Assert-VerifiableMock
         }
 
-        Describe "MSFT_SqlServerRole\Set-TargetResource" -Tag 'Set'{
+        Describe "MSFT_SqlServerRole\Set-TargetResource" -Tag 'Set' {
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
                 Mock -CommandName New-Object -MockWith $mockNewObjectServerRole -ParameterFilter {
@@ -722,7 +724,7 @@ try
                     $mockExpectedServerRoleToDrop = 'ServerRoleToDrop'
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Ensure = 'Absent'
+                        Ensure         = 'Absent'
                         ServerRoleName = $mockSqlServerRole
                     }
 
@@ -737,14 +739,14 @@ try
                     $mockInvalidOperationForDropMethod = $true
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Ensure = 'Absent'
+                        Ensure         = 'Absent'
                         ServerRoleName = $mockSqlServerRole
                     }
 
                     $throwInvalidOperation = ('Failed to drop the server role named AdminSqlforBI on ' + `
-                                              'localhost\MSSQLSERVER. InnerException: Exception calling ' + `
-                                              '"Drop" with "0" argument(s): "Mock Drop Method ' + `
-                                              'was called with invalid operation."')
+                            'localhost\MSSQLSERVER. InnerException: Exception calling ' + `
+                            '"Drop" with "0" argument(s): "Mock Drop Method ' + `
+                            'was called with invalid operation."')
 
                     { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
 
@@ -758,7 +760,7 @@ try
                     $mockExpectedServerRoleToCreate = 'ServerRoleToAdd'
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Ensure = 'Present'
+                        Ensure         = 'Present'
                         ServerRoleName = $mockSqlServerRoleAdd
                     }
 
@@ -781,14 +783,14 @@ try
                     $mockInvalidOperationForCreateMethod = $true
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Ensure = 'Present'
+                        Ensure         = 'Present'
                         ServerRoleName = $mockSqlServerRoleAdd
                     }
 
                     $throwInvalidOperation = ('Failed to create the server role named ServerRoleToAdd on ' + `
-                                              'localhost\MSSQLSERVER. InnerException: Exception calling ' + `
-                                              '"Create" with "0" argument(s): "Mock Create Method ' + `
-                                              'was called with invalid operation."')
+                            'localhost\MSSQLSERVER. InnerException: Exception calling ' + `
+                            '"Create" with "0" argument(s): "Mock Create Method ' + `
+                            'was called with invalid operation."')
 
                     { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
 
@@ -806,15 +808,15 @@ try
                 It 'Should throw the correct error' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Ensure = 'Present'
-                        ServerRoleName = $mockSqlServerRole
-                        Members = $mockEnumMemberNames
+                        Ensure           = 'Present'
+                        ServerRoleName   = $mockSqlServerRole
+                        Members          = $mockEnumMemberNames
                         MembersToInclude = $mockSqlServerLoginTree
                     }
 
                     $throwInvalidOperation = ('The parameter MembersToInclude and/or ' + `
-                                              'MembersToExclude must not be set, or be set ' + `
-                                              'to $null, when parameter Members are used.')
+                            'MembersToExclude must not be set, or be set ' + `
+                            'to $null, when parameter Members are used.')
 
                     { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
 
@@ -826,15 +828,15 @@ try
                 It 'Should throw the correct error' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Ensure = 'Present'
-                        ServerRoleName = $mockSqlServerRole
-                        Members = $mockEnumMemberNames
+                        Ensure           = 'Present'
+                        ServerRoleName   = $mockSqlServerRole
+                        Members          = $mockEnumMemberNames
                         MembersToExclude = $mockSqlServerLoginTwo
                     }
 
                     $throwInvalidOperation = ('The parameter MembersToInclude and/or ' + `
-                                              'MembersToExclude must not be set, or be set ' + `
-                                              'to $null, when parameter Members are used.')
+                            'MembersToExclude must not be set, or be set ' + `
+                            'to $null, when parameter Members are used.')
 
                     { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
 
@@ -848,8 +850,8 @@ try
                     $mockSqlServerLoginToAdd = $mockSqlServerLoginTree
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Ensure = 'Present'
-                        ServerRoleName = $mockSqlServerRole
+                        Ensure           = 'Present'
+                        ServerRoleName   = $mockSqlServerRole
                         MembersToInclude = $mockSqlServerLoginTree
                     }
 
@@ -866,14 +868,14 @@ try
                     $mockSqlServerLoginToAdd = $mockSqlServerLoginTree
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Ensure = 'Present'
-                        ServerRoleName = $mockSqlServerRole
+                        Ensure           = 'Present'
+                        ServerRoleName   = $mockSqlServerRole
                         MembersToInclude = $mockSqlServerLoginTree
                     }
 
                     $throwInvalidOperation = ('Failed to add member CONTOSO\Lucy to the server role named AdminSqlforBI ' + `
-                                              'on localhost\MSSQLSERVER. InnerException: Exception calling "AddMember" ' + `
-                                              'with "1" argument(s): "Mock AddMember Method was called with invalid operation."')
+                            'on localhost\MSSQLSERVER. InnerException: Exception calling "AddMember" ' + `
+                            'with "1" argument(s): "Mock AddMember Method was called with invalid operation."')
 
                     { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
 
@@ -887,8 +889,8 @@ try
                     $mockSqlServerLoginToAdd = $mockSqlServerLoginTree
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Ensure = 'Present'
-                        ServerRoleName = $mockSqlServerRole
+                        Ensure           = 'Present'
+                        ServerRoleName   = $mockSqlServerRole
                         MembersToInclude = 'KingJulian'
                     }
 
@@ -906,8 +908,8 @@ try
                     $mockSqlServerLoginToAdd = $mockSqlServerLoginTwo
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Ensure = 'Present'
-                        ServerRoleName = $mockSqlServerRole
+                        Ensure           = 'Present'
+                        ServerRoleName   = $mockSqlServerRole
                         MembersToExclude = $mockSqlServerLoginTwo
                     }
 
@@ -924,14 +926,14 @@ try
                     $mockSqlServerLoginToDrop = $mockSqlServerLoginTwo
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Ensure = 'Present'
-                        ServerRoleName = $mockSqlServerRole
+                        Ensure           = 'Present'
+                        ServerRoleName   = $mockSqlServerRole
                         MembersToExclude = $mockSqlServerLoginTwo
                     }
 
                     $throwInvalidOperation = ('Failed to drop member CONTOSO\Kelly to the server role named AdminSqlforBI ' + `
-                                              'on localhost\MSSQLSERVER. InnerException: Exception calling "DropMember" ' + `
-                                              'with "1" argument(s): "Mock DropMember Method was called with invalid operation."')
+                            'on localhost\MSSQLSERVER. InnerException: Exception calling "DropMember" ' + `
+                            'with "1" argument(s): "Mock DropMember Method was called with invalid operation."')
 
                     { Set-TargetResource @testParameters } | Should -Throw $throwInvalidOperation
 
@@ -941,13 +943,13 @@ try
 
             Context 'When parameter MembersToExclude is assigned a value, parameter Members is not assigned a value, and ensure is set to Present' {
                 It 'Should throw the correct error when login does not exist' {
-                    $mockEnumMemberNames = @('KingJulian',$mockSqlServerLoginOne,$mockSqlServerLoginTwo)
+                    $mockEnumMemberNames = @('KingJulian', $mockSqlServerLoginOne, $mockSqlServerLoginTwo)
                     $mockExpectedMemberToAdd = $mockSqlServerLoginTree
                     $mockSqlServerLoginToAdd = $mockSqlServerLoginTree
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Ensure = 'Present'
-                        ServerRoleName = $mockSqlServerRole
+                        Ensure           = 'Present'
+                        ServerRoleName   = $mockSqlServerRole
                         MembersToExclude = 'KingJulian'
                     }
 
@@ -965,9 +967,9 @@ try
                     $mockSqlServerLoginToAdd = $mockSqlServerLoginTree
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Ensure = 'Present'
+                        Ensure         = 'Present'
                         ServerRoleName = $mockSqlServerRole
-                        Members = @('KingJulian',$mockSqlServerLoginOne,$mockSqlServerLoginTree)
+                        Members        = @('KingJulian', $mockSqlServerLoginOne, $mockSqlServerLoginTree)
                     }
 
                     $throwInvalidOperation = ("Login 'KingJulian' does not exist on SQL server 'localhost\MSSQLSERVER'.")
@@ -986,9 +988,9 @@ try
                     $mockSqlServerLoginToDrop = $mockSqlServerLoginTwo
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Ensure = 'Present'
+                        Ensure         = 'Present'
                         ServerRoleName = $mockSqlServerRole
-                        Members = @($mockSqlServerLoginOne,$mockSqlServerLoginTree)
+                        Members        = @($mockSqlServerLoginOne, $mockSqlServerLoginTree)
                     }
 
                     { Set-TargetResource @testParameters } | Should -Not -Throw

--- a/Tests/Unit/MSFT_SqlServiceAccount.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServiceAccount.Tests.ps1
@@ -1,14 +1,14 @@
-$script:DSCModuleName      = 'SqlServerDsc'
-$script:DSCResourceName    = 'MSFT_SqlServiceAccount'
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlServiceAccount'
 
 #region HEADER
 
 # Unit Test Template Version: 1.2.1
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))
 }
 
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
@@ -26,7 +26,8 @@ function Invoke-TestSetup
     Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
 }
 
-function Invoke-TestCleanup {
+function Invoke-TestCleanup
+{
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
 }
 
@@ -50,9 +51,9 @@ try
 
         # Stores the result of SetServiceAccount calls
         $testServiceAccountUpdated = @{
-            Processed = $false
+            Processed      = $false
             NewUserAccount = [System.String]::Empty
-            NewPassword = [System.String]::Emtpy
+            NewPassword    = [System.String]::Emtpy
         }
 
         # Script block for changing the service account in mocks
@@ -88,26 +89,26 @@ try
 
         # Splat for creating the SetServiceAccount method
         $mockAddMemberParameters_SetServiceAccount = @{
-            Name = 'SetServiceAccount'
+            Name       = 'SetServiceAccount'
             MemberType = 'ScriptMethod'
-            Value = $mockSetServiceAccount
+            Value      = $mockSetServiceAccount
         }
 
         $mockAddMemberParameters_SetServiceAccount_Exception = @{
-            Name = 'SetServiceAccount'
+            Name       = 'SetServiceAccount'
             MemberType = 'ScriptMethod'
-            Value = $mockSetServiceAccount_Exception
+            Value      = $mockSetServiceAccount_Exception
         }
 
         # Used to mock ManagedComputer object for a default instance
         $mockNewObject_ManagedComputer_DefaultInstance = {
             $managedComputerObject = New-Object -TypeName PSObject -Property @{
-                Name = $mockSqlServer
+                Name     = $mockSqlServer
                 Services = @(
                     New-Object -TypeName PSObject -Property @{
-                        Name = $mockDefaultInstanceName
+                        Name           = $mockDefaultInstanceName
                         ServiceAccount = $mockDefaultServiceAccountName
-                        Type = 'SqlServer'
+                        Type           = 'SqlServer'
                     }
                 )
             }
@@ -122,12 +123,12 @@ try
         # Creates a new ManagedComputer object for a default instance with a local service account
         $mockNewObject_ManagedComputer_DefaultInstance_LocalServiceAccount = {
             $managedComputerObject = New-Object -TypeName PSObject -Property @{
-                Name = $mockSqlServer
+                Name     = $mockSqlServer
                 Services = @(
                     New-Object -TypeName PSObject -Property @{
-                        Name = $mockDefaultInstanceName
-                        ServiceAccount = ($mockLocalServiceAccountName -replace $mockSqlServer,'.')
-                        Type = 'SqlServer'
+                        Name           = $mockDefaultInstanceName
+                        ServiceAccount = ($mockLocalServiceAccountName -replace $mockSqlServer, '.')
+                        Type           = 'SqlServer'
                     }
                 )
             }
@@ -145,12 +146,12 @@ try
         #>
         $mockNewObject_ManagedComputer_DefaultInstance_SetServiceAccountException = {
             $managedComputerObject = New-Object -TypeName PSObject -Property @{
-                Name = $mockSqlServer
+                Name     = $mockSqlServer
                 Services = @(
                     New-Object -TypeName PSObject -Property @{
-                        Name = $mockDefaultInstanceName
+                        Name           = $mockDefaultInstanceName
                         ServiceAccount = $mockDefaultServiceAccountName
-                        Type = 'SqlServer'
+                        Type           = 'SqlServer'
                     }
                 )
             }
@@ -165,12 +166,12 @@ try
         # Used to mock a ManagedComputer object for a named instance
         $mockNewObject_ManagedComputer_NamedInstance = {
             $managedComputerObject = New-Object -TypeName PSObject -Property @{
-                Name = $mockSqlServer
+                Name     = $mockSqlServer
                 Services = @(
                     New-Object -TypeName PSObject -Property @{
-                        Name = ('MSSQL${0}' -f $mockNamedInstance)
+                        Name           = ('MSSQL${0}' -f $mockNamedInstance)
                         ServiceAccount = $mockDesiredServiceAccountName
-                        Type = 'SqlServer'
+                        Type           = 'SqlServer'
                     }
                 )
             }
@@ -185,12 +186,12 @@ try
         # Used to mock a ManagedComputer object that fails to change the service account
         $mockNewObject_ManagedComputer_NamedInstance_SetServiceAccountException = {
             $managedComputerObject = New-Object -TypeName PSObject -Property @{
-                Name = $mockSqlServer
+                Name     = $mockSqlServer
                 Services = @(
                     New-Object -TypeName PSObject -Property @{
-                        Name = ('MSSQL${0}' -f $mockNamedInstance)
+                        Name           = ('MSSQL${0}' -f $mockNamedInstance)
                         ServiceAccount = $mockDesiredServiceAccountName
-                        Type = 'SqlServer'
+                        Type           = 'SqlServer'
                     }
                 )
             }
@@ -209,60 +210,60 @@ try
 
         # Splat to simplify creation of Mock for New-Object with a default instance
         $mockNewObjectParameters_DefaultInstance = @{
-            CommandName = 'New-Object'
-            MockWith = $mockNewObject_ManagedComputer_DefaultInstance
+            CommandName     = 'New-Object'
+            MockWith        = $mockNewObject_ManagedComputer_DefaultInstance
             ParameterFilter = $mockNewObject_ParameterFilter
-            Verifiable = $true
+            Verifiable      = $true
         }
 
         # Splat to simplify creation of Mock for New-Object with a named instance
         $mockNewObjectParameters_NamedInstance = @{
-            CommandName = 'New-Object'
-            MockWith = $mockNewObject_ManagedComputer_NamedInstance
+            CommandName     = 'New-Object'
+            MockWith        = $mockNewObject_ManagedComputer_NamedInstance
             ParameterFilter = $mockNewObject_ParameterFilter
-            Verifiable = $true
+            Verifiable      = $true
         }
 
         Describe 'MSFT_SqlServerServiceAccount\ConvertTo-ManagedServiceType' -Tag 'Helper' {
             Context 'Translating service types' {
                 $testCases = @(
                     @{
-                        ServiceType = 'DatabaseEngine'
+                        ServiceType  = 'DatabaseEngine'
                         ExpectedType = 'SqlServer'
                     }
 
                     @{
-                        ServiceType = 'SQLServerAgent'
+                        ServiceType  = 'SQLServerAgent'
                         ExpectedType = 'SqlAgent'
                     }
 
                     @{
-                        ServiceType = 'Search'
+                        ServiceType  = 'Search'
                         ExpectedType = 'Search'
                     }
 
                     @{
-                        ServiceType = 'IntegrationServices'
+                        ServiceType  = 'IntegrationServices'
                         ExpectedType = 'SqlServerIntegrationService'
                     }
 
                     @{
-                        ServiceType = 'AnalysisServices'
+                        ServiceType  = 'AnalysisServices'
                         ExpectedType = 'AnalysisServer'
                     }
 
                     @{
-                        ServiceType = 'ReportingServices'
+                        ServiceType  = 'ReportingServices'
                         ExpectedType = 'ReportServer'
                     }
 
                     @{
-                        ServiceType = 'SQLServerBrowser'
+                        ServiceType  = 'SQLServerBrowser'
                         ExpectedType = 'SqlBrowser'
                     }
 
                     @{
-                        ServiceType = 'NotificationServices'
+                        ServiceType  = 'NotificationServices'
                         ExpectedType = 'NotificationServer'
                     }
                 )
@@ -290,9 +291,9 @@ try
             Mock -CommandName Import-SQLPSModule -Verifiable
 
             $defaultGetServiceObjectParameters = @{
-                SQLServer = $mockSqlServer
-                SQLInstanceName = ''
-                ServiceType = $mockServiceType
+                ServerName   = $mockSqlServer
+                InstanceName = ''
+                ServiceType  = $mockServiceType
             }
 
             Context 'When getting the service information for a default instance' {
@@ -300,7 +301,7 @@ try
 
                 It 'Should have the correct Type for the service' {
                     $getServiceObjectParameters = $defaultGetServiceObjectParameters.Clone()
-                    $getServiceObjectParameters.SQLInstanceName = $mockDefaultInstanceName
+                    $getServiceObjectParameters.InstanceName = $mockDefaultInstanceName
 
                     $serviceObject = Get-ServiceObject @getServiceObjectParameters
                     $serviceObject.Type | Should -Be 'SqlServer'
@@ -316,7 +317,7 @@ try
 
                 It 'Should have the correct Type for the service' {
                     $getServiceObjectParameters = $defaultGetServiceObjectParameters.Clone()
-                    $getServiceObjectParameters.SQLInstanceName = $mockNamedInstance
+                    $getServiceObjectParameters.InstanceName = $mockNamedInstance
 
                     $serviceObject = Get-ServiceObject @getServiceObjectParameters
                     $serviceObject.Type | Should -Be 'SqlServer'
@@ -335,9 +336,9 @@ try
                 Mock @mockNewObjectParameters_DefaultInstance
 
                 $defaultGetTargetResourceParameters = @{
-                    SQLServer = $mockSqlServer
-                    SQLInstanceName = $mockDefaultInstanceName
-                    ServiceType = $mockServiceType
+                    ServerName     = $mockSqlServer
+                    InstanceName   = $mockDefaultInstanceName
+                    ServiceType    = $mockServiceType
                     ServiceAccount = $mockDefaultServiceAccountCredential
                 }
 
@@ -346,8 +347,8 @@ try
                     $testServiceInformation = Get-TargetResource @defaultGetTargetResourceParameters
 
                     # Validate the hashtable returned
-                    $testServiceInformation.SQLServer | Should -Be $mockSqlServer
-                    $testServiceInformation.SQLInstanceName | Should -Be $mockDefaultInstanceName
+                    $testServiceInformation.ServerName | Should -Be $mockSqlServer
+                    $testServiceInformation.InstanceName | Should -Be $mockDefaultInstanceName
                     $testServiceInformation.ServiceType | Should -Be 'SqlServer'
                     $testServiceInformation.ServiceAccount | Should -Be $mockDefaultServiceAccountName
 
@@ -374,9 +375,9 @@ try
 
                 # Splat the function parameters
                 $defaultGetTargetResourceParameters = @{
-                    SQLServer = $mockSqlServer
-                    SQLInstanceName = $mockNamedInstance
-                    ServiceType = $mockServiceType
+                    ServerName     = $mockSqlServer
+                    InstanceName   = $mockNamedInstance
+                    ServiceType    = $mockServiceType
                     ServiceAccount = $mockServiceAccountCredential
                 }
 
@@ -385,8 +386,8 @@ try
                     $testServiceInformation = Get-TargetResource @defaultGetTargetResourceParameters
 
                     # Validate the hashtable returned
-                    $testServiceInformation.SQLServer | Should -Be $mockSqlServer
-                    $testServiceInformation.SQLInstanceName | Should -Be $mockNamedInstance
+                    $testServiceInformation.ServerName | Should -Be $mockSqlServer
+                    $testServiceInformation.InstanceName | Should -Be $mockNamedInstance
                     $testServiceInformation.ServiceType | Should -Be 'SqlServer'
                     $testServiceInformation.ServiceAccount | Should -Be $mockDesiredServiceAccountName
 
@@ -415,9 +416,9 @@ try
                 Mock @mockNewObjectParameters
 
                 $defaultGetTargetResourceParameters = @{
-                    SQLServer = $mockSqlServer
-                    SQLInstanceName = $mockDefaultInstanceName
-                    ServiceType = $mockServiceType
+                    ServerName     = $mockSqlServer
+                    InstanceName   = $mockDefaultInstanceName
+                    ServiceType    = $mockServiceType
                     ServiceAccount = $mockLocalServiceAccountCredential
                 }
 
@@ -441,9 +442,9 @@ try
 
                 It 'Should return false' {
                     $testTargetResourceParameters = @{
-                        SQLServer = $mockSqlServer
-                        SQLInstanceName = $mockDefaultInstanceName
-                        ServiceType = $mockServiceType
+                        ServerName     = $mockSqlServer
+                        InstanceName   = $mockDefaultInstanceName
+                        ServiceType    = $mockServiceType
                         ServiceAccount = $mockServiceAccountCredential
                     }
 
@@ -460,9 +461,9 @@ try
 
                 It 'Should return true' {
                     $testTargetResourceParameters = @{
-                        SQLServer = $mockSqlServer
-                        SQLInstanceName = $mockDefaultInstanceName
-                        ServiceType = $mockServiceType
+                        ServerName     = $mockSqlServer
+                        InstanceName   = $mockDefaultInstanceName
+                        ServiceType    = $mockServiceType
                         ServiceAccount = $mockDefaultServiceAccountCredential
                     }
 
@@ -479,11 +480,11 @@ try
 
                 It 'Should return False when Force is specified' {
                     $testTargetResourceParameters = @{
-                        SQLServer = $mockSqlServer
-                        SQLInstanceName = $mockDefaultInstanceName
-                        ServiceType = $mockServiceType
+                        ServerName     = $mockSqlServer
+                        InstanceName   = $mockDefaultInstanceName
+                        ServiceType    = $mockServiceType
                         ServiceAccount = $mockServiceAccountCredential
-                        Force = $true
+                        Force          = $true
                     }
 
                     Test-TargetResource @testTargetResourceParameters | Should -Be $false
@@ -498,9 +499,9 @@ try
 
                 It 'Should return false' {
                     $testTargetResourceParameters = @{
-                        SQLServer = $mockSqlServer
-                        SQLInstanceName = $mockNamedInstance
-                        ServiceType = $mockServiceType
+                        ServerName     = $mockSqlServer
+                        InstanceName   = $mockNamedInstance
+                        ServiceType    = $mockServiceType
                         ServiceAccount = $mockDefaultServiceAccountCredential
                     }
 
@@ -517,9 +518,9 @@ try
 
                 It 'Should return true' {
                     $testTargetResourceParameters = @{
-                        SQLServer = $mockSqlServer
-                        SQLInstanceName = $mockNamedInstance
-                        ServiceType = $mockServiceType
+                        ServerName     = $mockSqlServer
+                        InstanceName   = $mockNamedInstance
+                        ServiceType    = $mockServiceType
                         ServiceAccount = $mockServiceAccountCredential
                     }
 
@@ -536,11 +537,11 @@ try
 
                 It 'Should return false' {
                     $testTargetResourceParameters = @{
-                        SQLServer = $mockSqlServer
-                        SQLInstanceName = $mockNamedInstance
-                        ServiceType = $mockServiceType
+                        ServerName     = $mockSqlServer
+                        InstanceName   = $mockNamedInstance
+                        ServiceType    = $mockServiceType
                         ServiceAccount = $mockServiceAccountCredential
-                        Force = $true
+                        Force          = $true
                     }
 
                     # Validate the return  value
@@ -558,9 +559,9 @@ try
             Context 'When changing the service account for the default instance' {
                 BeforeAll {
                     $defaultSetTargetResourceParameters = @{
-                        SQLServer = $mockSqlServer
-                        SQLInstanceName = $mockDefaultInstanceName
-                        ServiceType = $mockServiceType
+                        ServerName     = $mockSqlServer
+                        InstanceName   = $mockDefaultInstanceName
+                        ServiceType    = $mockServiceType
                         ServiceAccount = $mockDefaultServiceAccountCredential
                     }
 
@@ -596,7 +597,7 @@ try
                     $setTargetResourceParameters.ServiceType = 'SQLServerAgent'
 
                     # Get the localized error message
-                    $mockCorrectErrorMessage = $script:localizedData.ServiceNotFound -f $setTargetResourceParameters.ServiceType, $setTargetResourceParameters.SQLServer, $setTargetResourceParameters.SQLInstanceName
+                    $mockCorrectErrorMessage = $script:localizedData.ServiceNotFound -f $setTargetResourceParameters.ServiceType, $setTargetResourceParameters.ServerName, $setTargetResourceParameters.InstanceName
 
                     # Attempt to update the service account
                     { Set-TargetResource @setTargetResourceParameters } | Should -Throw $mockCorrectErrorMessage
@@ -628,7 +629,7 @@ try
                     $setTargetResourceParameters = $defaultSetTargetResourceParameters.Clone()
 
                     # Get the localized error message
-                    $mockCorrectErrorMessage = $script:localizedData.SetServiceAccountFailed -f $setTargetResourceParameters.SQLServer, $setTargetResourceParameters.SQLInstanceName, ''
+                    $mockCorrectErrorMessage = $script:localizedData.SetServiceAccountFailed -f $setTargetResourceParameters.ServerName, $setTargetResourceParameters.InstanceName, ''
 
                     # Attempt to update the service account
                     { Set-TargetResource @setTargetResourceParameters } | Should -Throw $mockCorrectErrorMessage
@@ -642,9 +643,9 @@ try
             Context 'When changing the service account for the default instance' {
                 BeforeAll {
                     $defaultSetTargetResourceParameters = @{
-                        SQLServer = $mockSqlServer
-                        SQLInstanceName = $mockNamedInstance
-                        ServiceType = $mockServiceType
+                        ServerName     = $mockSqlServer
+                        InstanceName   = $mockNamedInstance
+                        ServiceType    = $mockServiceType
                         ServiceAccount = $mockDefaultServiceAccountCredential
                     }
 
@@ -680,7 +681,7 @@ try
                     $setTargetResourceParameters.ServiceType = 'SQLServerAgent'
 
                     # Get the expected localized error message
-                    $mockCorrectErrorMessage = $script:localizedData.ServiceNotFound -f $setTargetResourceParameters.ServiceType, $setTargetResourceParameters.SQLServer, $setTargetResourceParameters.SQLInstanceName
+                    $mockCorrectErrorMessage = $script:localizedData.ServiceNotFound -f $setTargetResourceParameters.ServiceType, $setTargetResourceParameters.ServerName, $setTargetResourceParameters.InstanceName
 
                     # Attempt to update the service account
                     { Set-TargetResource @setTargetResourceParameters } | Should -Throw $mockCorrectErrorMessage
@@ -712,7 +713,7 @@ try
                     $setTargetResourceParameters = $defaultSetTargetResourceParameters.Clone()
 
                     # Get the expected localized error message
-                    $mockCorrectErrorMessage = $script:localizedData.SetServiceAccountFailed -f $setTargetResourceParameters.SQLServer, $setTargetResourceParameters.SQLInstanceName, ''
+                    $mockCorrectErrorMessage = $script:localizedData.SetServiceAccountFailed -f $setTargetResourceParameters.ServerName, $setTargetResourceParameters.InstanceName, ''
 
                     # Attempt to update the service information
                     { Set-TargetResource @setTargetResourceParameters } | Should -Throw $mockCorrectErrorMessage

--- a/Tests/Unit/Stubs/Write-ModuleStubFile.ps1
+++ b/Tests/Unit/Stubs/Write-ModuleStubFile.ps1
@@ -1,29 +1,29 @@
 <#
     .SYNOPSIS
-        Generates a file contaning function stubs of all cmdlets from the module given as a parameter. 
+        Generates a file contaning function stubs of all cmdlets from the module given as a parameter.
 
     .PARAMETER ModuleName
         The name of the module to load and generate stubs from. This module must exist on the computer where this function is ran.
 
     .PARAMETER Path
-         Path to where to write the stubs file. The filename will be generated from the module name.  
+         Path to where to write the stubs file. The filename will be generated from the module name.
 
     .EXAMPLE
-        Write-ModuleStubFile -ModuleName 'SQLServer' -Path 'C:\Source'
+        Write-ModuleStubFile -ModuleName 'SqlServer' -Path 'C:\Source'
 #>
 function Write-ModuleStubFile {
     param
     (
-        [Parameter( Mandatory )] 
+        [Parameter( Mandatory )]
         [System.String] $ModuleName,
 
-        [Parameter( Mandatory )] 
+        [Parameter( Mandatory )]
         [System.String] $Path
     )
 
     Import-Module $ModuleName -DisableNameChecking -Force
- 
-    ( ( get-command -Module $ModuleName -CommandType 'Cmdlet' ) | ForEach-Object -Begin { 
+
+    ( ( get-command -Module $ModuleName -CommandType 'Cmdlet' ) | ForEach-Object -Begin {
         "# Suppressing this rule because these functions are from an external module"
         "# and are only being used as stubs",
         "[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '')]"
@@ -34,7 +34,7 @@ function Write-ModuleStubFile {
         $command = $_
         $endOfDefinition = $false
         $metadata = New-Object -TypeName System.Management.Automation.CommandMetaData -ArgumentList $command
-        $definition = [System.Management.Automation.ProxyCommand]::Create($metadata) 
+        $definition = [System.Management.Automation.ProxyCommand]::Create($metadata)
         foreach ($line in $definition -split "`n")
         {
             $line = $line -replace '\[Microsoft.SqlServer.*.\]', '[object]'
@@ -45,7 +45,7 @@ function Write-ModuleStubFile {
                 $line = $line.Remove( $line.Length - 2 )
                 $endOfDefinition = $true
             }
-            
+
             if( $line.Trim() -ne '' ) {
                 $signature += "    $line"
             } else {
@@ -58,7 +58,7 @@ function Write-ModuleStubFile {
                 break
             }
         }
-        
+
         "function $($command.Name) {"
         "$signature"
         ""


### PR DESCRIPTION
**Pull Request (PR) description**
This pull request will fix all inconsistent parameter names so that `InstanceName` is the parameter used to set the name of the instance to configure, and `ServerName` is used to specify the NetBios or FQDN name where the instance can be found.

**This Pull Request (PR) fixes the following issues:**
Fixes #308 

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/917)
<!-- Reviewable:end -->
