### PR TITLE
SqlServerDsc: Adding note to obsolete examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@
 - Changes to CONTRIBUTING.md
   - Added details to the naming convention used in SqlServerDsc.
 - Changes to SqlServerDsc
-  - The examples in the root of the Examples folder are obsolete. Those examples
-    now have a note saying so, in the comment-based help, until they can be replaced
+  - The examples in the root of the Examples folder are obsolete. A note was
+    added to the comment-based help in each example stating it is obsolete.
+    This is a temporary measure until they are replaced.
     ([issue #904](https://github.com/PowerShell/SqlServerDsc/issues/904)).
 - Changes to SqlAGDatabase
   - Changed the Get-MatchingDatabaseNames function to be case insensitive when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@
   - Impact to all resources
 - Changes to CONTRIBUTING.md
   - Added details to the naming convention used in SqlServerDsc.
+- Changes to SqlServerDsc
+  - The examples in the root of the Examples folder are obsolete. Those examples
+    now have a note saying so, in the comment-based help, until they can be replaced
+    ([issue #904](https://github.com/PowerShell/SqlServerDsc/issues/904)).
 - Changes to SqlAGDatabase
   - Changed the Get-MatchingDatabaseNames function to be case insensitive when
-  matching database names. ([issue #912](https://github.com/PowerShell/SqlServerDsc/issues/912))
+    matching database names. ([issue #912](https://github.com/PowerShell/SqlServerDsc/issues/912))
 
 ## 9.0.0.0
 

--- a/Examples/DSCClusterSqlBuild.ps1
+++ b/Examples/DSCClusterSqlBuild.ps1
@@ -1,16 +1,14 @@
 <#
     .NOTES
-        THIS EXAMPLE IS OBSOLETE. Due to major changes to the resource modules
-        (this and other modules) over the last few months this example has not
-        been updated to reflect those changes.
-        Please refer to the examples in each individual resource example folder
-        for updated examples.
-        https://github.com/PowerShell/SqlServerDsc/tree/dev/Examples/Resources
+        THIS EXAMPLE IS OBSOLETE. Due to major changes in the resource modules
+        over the last several versions, this example has not been updated to reflect
+        those changes.
+        Please refer to the resource example folder for updated examples.
+        https://github.com/PowerShell/SqlServerDsc/tree/master/Examples/Resources
 
         There is an issue open to replace this example, please see issue
         https://github.com/PowerShell/SqlServerDsc/issues/462
 #>
-
 $StartTime = [System.Diagnostics.Stopwatch]::StartNew()
 Function check-even($num){[bool]!($num%2)}
 

--- a/Examples/DSCClusterSqlBuild.ps1
+++ b/Examples/DSCClusterSqlBuild.ps1
@@ -1,4 +1,16 @@
-#requires -Version 5
+<#
+    .NOTES
+        THIS EXAMPLE IS OBSOLETE. Due to major changes to the resource modules
+        (this and other modules) over the last few months this example has not
+        been updated to reflect those changes.
+        Please refer to the examples in each individual resource example folder
+        for updated examples.
+        https://github.com/PowerShell/SqlServerDsc/tree/dev/Examples/Resources
+
+        There is an issue open to replace this example, please see issue
+        https://github.com/PowerShell/SqlServerDsc/issues/462
+#>
+
 $StartTime = [System.Diagnostics.Stopwatch]::StartNew()
 Function check-even($num){[bool]!($num%2)}
 

--- a/Examples/DSCFCISqlBuild.ps1
+++ b/Examples/DSCFCISqlBuild.ps1
@@ -1,4 +1,16 @@
-#requires -Version 5
+<#
+    .NOTES
+        THIS EXAMPLE IS OBSOLETE. Due to major changes to the resource modules
+        (this and other modules) over the last few months this example has not
+        been updated to reflect those changes.
+        Please refer to the examples in each individual resource example folder
+        for updated examples.
+        https://github.com/PowerShell/SqlServerDsc/tree/dev/Examples/Resources
+
+        There is an issue open to replace this example, please see issue
+        https://github.com/PowerShell/SqlServerDsc/issues/462
+#>
+
 $computers = 'OHSQL9034N1','OHSQL9034N2','OHSQL9034N3'
 $OutputPath = 'F:\DSCConfig'
 

--- a/Examples/DSCFCISqlBuild.ps1
+++ b/Examples/DSCFCISqlBuild.ps1
@@ -1,16 +1,14 @@
 <#
     .NOTES
-        THIS EXAMPLE IS OBSOLETE. Due to major changes to the resource modules
-        (this and other modules) over the last few months this example has not
-        been updated to reflect those changes.
-        Please refer to the examples in each individual resource example folder
-        for updated examples.
-        https://github.com/PowerShell/SqlServerDsc/tree/dev/Examples/Resources
+        THIS EXAMPLE IS OBSOLETE. Due to major changes in the resource modules
+        over the last several versions, this example has not been updated to reflect
+        those changes.
+        Please refer to the resource example folder for updated examples.
+        https://github.com/PowerShell/SqlServerDsc/tree/master/Examples/Resources
 
         There is an issue open to replace this example, please see issue
         https://github.com/PowerShell/SqlServerDsc/issues/462
 #>
-
 $computers = 'OHSQL9034N1','OHSQL9034N2','OHSQL9034N3'
 $OutputPath = 'F:\DSCConfig'
 

--- a/Examples/DSCSQLBuildEncrypted.ps1
+++ b/Examples/DSCSQLBuildEncrypted.ps1
@@ -1,4 +1,15 @@
-#requires -Version 5
+<#
+    .NOTES
+        THIS EXAMPLE IS OBSOLETE. Due to major changes to the resource modules
+        (this and other modules) over the last few months this example has not
+        been updated to reflect those changes.
+        Please refer to the examples in each individual resource example folder
+        for updated examples.
+        https://github.com/PowerShell/SqlServerDsc/tree/dev/Examples/Resources
+
+        There is an issue open to replace this example, please see issue
+        https://github.com/PowerShell/SqlServerDsc/issues/462
+#>
 $StartTime = [System.Diagnostics.Stopwatch]::StartNew()
 
 $computers = 'OHSQL9012'

--- a/Examples/DSCSQLBuildEncrypted.ps1
+++ b/Examples/DSCSQLBuildEncrypted.ps1
@@ -1,11 +1,10 @@
 <#
     .NOTES
-        THIS EXAMPLE IS OBSOLETE. Due to major changes to the resource modules
-        (this and other modules) over the last few months this example has not
-        been updated to reflect those changes.
-        Please refer to the examples in each individual resource example folder
-        for updated examples.
-        https://github.com/PowerShell/SqlServerDsc/tree/dev/Examples/Resources
+        THIS EXAMPLE IS OBSOLETE. Due to major changes in the resource modules
+        over the last several versions, this example has not been updated to reflect
+        those changes.
+        Please refer to the resource example folder for updated examples.
+        https://github.com/PowerShell/SqlServerDsc/tree/master/Examples/Resources
 
         There is an issue open to replace this example, please see issue
         https://github.com/PowerShell/SqlServerDsc/issues/462

--- a/Examples/DSCSqlBuild.ps1
+++ b/Examples/DSCSqlBuild.ps1
@@ -1,11 +1,10 @@
 <#
     .NOTES
-        THIS EXAMPLE IS OBSOLETE. Due to major changes to the resource modules
-        (this and other modules) over the last few months this example has not
-        been updated to reflect those changes.
-        Please refer to the examples in each individual resource example folder
-        for updated examples.
-        https://github.com/PowerShell/SqlServerDsc/tree/dev/Examples/Resources
+        THIS EXAMPLE IS OBSOLETE. Due to major changes in the resource modules
+        over the last several versions, this example has not been updated to reflect
+        those changes.
+        Please refer to the resource example folder for updated examples.
+        https://github.com/PowerShell/SqlServerDsc/tree/master/Examples/Resources
 
         There is an issue open to replace this example, please see issue
         https://github.com/PowerShell/SqlServerDsc/issues/462

--- a/Examples/DSCSqlBuild.ps1
+++ b/Examples/DSCSqlBuild.ps1
@@ -1,4 +1,15 @@
-#requires -Version 5
+<#
+    .NOTES
+        THIS EXAMPLE IS OBSOLETE. Due to major changes to the resource modules
+        (this and other modules) over the last few months this example has not
+        been updated to reflect those changes.
+        Please refer to the examples in each individual resource example folder
+        for updated examples.
+        https://github.com/PowerShell/SqlServerDsc/tree/dev/Examples/Resources
+
+        There is an issue open to replace this example, please see issue
+        https://github.com/PowerShell/SqlServerDsc/issues/462
+#>
 $StartTime = [System.Diagnostics.Stopwatch]::StartNew()
 
 $computers = 'OHSQL9015'

--- a/Examples/SQL-ClusterDB.ps1
+++ b/Examples/SQL-ClusterDB.ps1
@@ -1,11 +1,10 @@
 <#
     .NOTES
-        THIS EXAMPLE IS OBSOLETE. Due to major changes to the resource modules
-        (this and other modules) over the last few months this example has not
-        been updated to reflect those changes.
-        Please refer to the examples in each individual resource example folder
-        for updated examples.
-        https://github.com/PowerShell/SqlServerDsc/tree/dev/Examples/Resources
+        THIS EXAMPLE IS OBSOLETE. Due to major changes in the resource modules
+        over the last several versions, this example has not been updated to reflect
+        those changes.
+        Please refer to the resource example folder for updated examples.
+        https://github.com/PowerShell/SqlServerDsc/tree/master/Examples/Resources
 
         There is an issue open to replace this example, please see issue
         https://github.com/PowerShell/SqlServerDsc/issues/462

--- a/Examples/SQL-ClusterDB.ps1
+++ b/Examples/SQL-ClusterDB.ps1
@@ -1,5 +1,15 @@
-#requires -Version 5
+<#
+    .NOTES
+        THIS EXAMPLE IS OBSOLETE. Due to major changes to the resource modules
+        (this and other modules) over the last few months this example has not
+        been updated to reflect those changes.
+        Please refer to the examples in each individual resource example folder
+        for updated examples.
+        https://github.com/PowerShell/SqlServerDsc/tree/dev/Examples/Resources
 
+        There is an issue open to replace this example, please see issue
+        https://github.com/PowerShell/SqlServerDsc/issues/462
+#>
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
 param ()
 

--- a/Examples/SQL-Standalone.ps1
+++ b/Examples/SQL-Standalone.ps1
@@ -1,11 +1,10 @@
 <#
     .NOTES
-        THIS EXAMPLE IS OBSOLETE. Due to major changes to the resource modules
-        (this and other modules) over the last few months this example has not
-        been updated to reflect those changes.
-        Please refer to the examples in each individual resource example folder
-        for updated examples.
-        https://github.com/PowerShell/SqlServerDsc/tree/dev/Examples/Resources
+        THIS EXAMPLE IS OBSOLETE. Due to major changes in the resource modules
+        over the last several versions, this example has not been updated to reflect
+        those changes.
+        Please refer to the resource example folder for updated examples.
+        https://github.com/PowerShell/SqlServerDsc/tree/master/Examples/Resources
 
         There is an issue open to replace this example, please see issue
         https://github.com/PowerShell/SqlServerDsc/issues/462

--- a/Examples/SQL-Standalone.ps1
+++ b/Examples/SQL-Standalone.ps1
@@ -1,5 +1,15 @@
-#requires -Version 5
+<#
+    .NOTES
+        THIS EXAMPLE IS OBSOLETE. Due to major changes to the resource modules
+        (this and other modules) over the last few months this example has not
+        been updated to reflect those changes.
+        Please refer to the examples in each individual resource example folder
+        for updated examples.
+        https://github.com/PowerShell/SqlServerDsc/tree/dev/Examples/Resources
 
+        There is an issue open to replace this example, please see issue
+        https://github.com/PowerShell/SqlServerDsc/issues/462
+#>
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
 param ()
 

--- a/Examples/SQLPush_SingleServer.ps1
+++ b/Examples/SQLPush_SingleServer.ps1
@@ -1,11 +1,10 @@
 <#
     .NOTES
-        THIS EXAMPLE IS OBSOLETE. Due to major changes to the resource modules
-        (this and other modules) over the last few months this example has not
-        been updated to reflect those changes.
-        Please refer to the examples in each individual resource example folder
-        for updated examples.
-        https://github.com/PowerShell/SqlServerDsc/tree/dev/Examples/Resources
+        THIS EXAMPLE IS OBSOLETE. Due to major changes in the resource modules
+        over the last several versions, this example has not been updated to reflect
+        those changes.
+        Please refer to the resource example folder for updated examples.
+        https://github.com/PowerShell/SqlServerDsc/tree/master/Examples/Resources
 
         There is an issue open to replace this example, please see issue
         https://github.com/PowerShell/SqlServerDsc/issues/462

--- a/Examples/SQLPush_SingleServer.ps1
+++ b/Examples/SQLPush_SingleServer.ps1
@@ -1,4 +1,15 @@
-#requires -Version 5
+<#
+    .NOTES
+        THIS EXAMPLE IS OBSOLETE. Due to major changes to the resource modules
+        (this and other modules) over the last few months this example has not
+        been updated to reflect those changes.
+        Please refer to the examples in each individual resource example folder
+        for updated examples.
+        https://github.com/PowerShell/SqlServerDsc/tree/dev/Examples/Resources
+
+        There is an issue open to replace this example, please see issue
+        https://github.com/PowerShell/SqlServerDsc/issues/462
+#>
 $computers = 'OHSQL1016'
 $OutputPath = 'D:\DSCLocal'
 $cim = New-CimSession -ComputerName $computers


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to SqlServerDsc
  - The examples in the root of the Examples folder are obsolete. Those examples
    now have a note saying so, in the comment-based help, until they can be replaced (issue #904).

**This Pull Request (PR) fixes the following issues:**
Fixes #904 

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/920)
<!-- Reviewable:end -->
