### PR TITLE
BREAKING CHANGE: Rename parameters for SqlRS and SqlAGReplica

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,76 +13,97 @@
 - Changes to SqlServerDsc
   - The examples in the root of the Examples folder are obsolete. A note was
     added to the comment-based help in each example stating it is obsolete.
-    This is a temporary measure until they are replaced.
+    This is a temporary measure until they are replaced
     ([issue #904](https://github.com/PowerShell/SqlServerDsc/issues/904)).
 - Changes to SqlAG
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
+    to ServerName and InstanceName respectively
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
 - Changes to SqlAGDatabase
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
+    to ServerName and InstanceName respectively
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
   - Changed the Get-MatchingDatabaseNames function to be case insensitive when
-    matching database names. ([issue #912](https://github.com/PowerShell/SqlServerDsc/issues/912))
+    matching database names ([issue #912](https://github.com/PowerShell/SqlServerDsc/issues/912)).
 - Changes to SqlAGListener
   - BREAKING CHANGE: Parameter NodeName has been renamed to ServerName
-    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
 - Changes to SqlAGReplica
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
+    to ServerName and InstanceName respectively
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
 - Changes to SqlAlwaysOnService
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
+    to ServerName and InstanceName respectively
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
 - Changes to SqlDatabase
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
+    to ServerName and InstanceName respectively
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
 - Changes SqlDatabaseDefaultLocation
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
+    to ServerName and InstanceName respectively
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
 - Changes to SqlDatabasePermission
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
+    to ServerName and InstanceName respectively
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
 - Changes to SqlDatabaseRecoveryModel
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
+    to ServerName and InstanceName respectively
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
 - Changes to SqlDatabaseRole
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
+    to ServerName and InstanceName respectively
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
+- Changes to SqlRS
+  - BREAKING CHANGE: Parameters RSSQLServer and RSSQLInstanceName has been renamed
+    to DatabaseServerName and DatabaseInstanceName respectively
+    ([issue #923](https://github.com/PowerShell/SqlServerDsc/issues/923)).
 - Changes to SqlServerConfiguration
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
+    to ServerName and InstanceName respectively
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
 - Changes to SqlServerEndpoint
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
+    to ServerName and InstanceName respectively
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
 - Changes to SqlServerEndpointPermission
   - BREAKING CHANGE: Parameter NodeName has been renamed to ServerName
-    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
 - Changes to SqlServerEndpointState
   - BREAKING CHANGE: Parameter NodeName has been renamed to ServerName
-    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
 - Changes to SqlServerLogin
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
+    to ServerName and InstanceName respectively
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
 - Changes to SqlServerMaxDop
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
+    to ServerName and InstanceName respectively
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
 - Changes to SqlServerMemory
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
+    to ServerName and InstanceName respectively
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
 - Changes to SqlServerNetwork
   - BREAKING CHANGE: Parameters SQLServer has been renamed to ServerName
-    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
 - Changes to SqlServerOwner
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
+    to ServerName and InstanceName respectively
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
 - Changes to SqlServerPermission
   - BREAKING CHANGE: Parameter NodeName has been renamed to ServerName
-    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
 - Changes to SqlServerRole
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
+    to ServerName and InstanceName respectively
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
 - Changes to SqlServerServiceAccount
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
-    to ServerName and InstanceName respectivly ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/)).
+    to ServerName and InstanceName respectively
+    ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
 
 ## 9.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectively
     ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
+  - BREAKING CHANGE: Parameters PrimaryReplicaSQLServer and PrimaryReplicaSQLInstanceName
+    has been renamed to PrimaryReplicaServerName and PrimaryReplicaInstanceName
+    respectively ([issue #922](https://github.com/PowerShell/SqlServerDsc/issues/922)).
 - Changes to SqlAlwaysOnService
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectively

--- a/DSCResources/MSFT_SqlAGReplica/MSFT_SqlAGReplica.psm1
+++ b/DSCResources/MSFT_SqlAGReplica/MSFT_SqlAGReplica.psm1
@@ -120,10 +120,10 @@ function Get-TargetResource
     .PARAMETER InstanceName
         Name of the SQL instance to be configued.
 
-    .PARAMETER PrimaryReplicaSQLServer
+    .PARAMETER PrimaryReplicaServerName
         Hostname of the SQL Server where the primary replica is expected to be active. If the primary replica is not found here, the resource will attempt to find the host that holds the primary replica and connect to it.
 
-    .PARAMETER PrimaryReplicaSQLInstanceName
+    .PARAMETER PrimaryReplicaInstanceName
         Name of the SQL instance where the primary replica lives.
 
     .PARAMETER Ensure
@@ -180,11 +180,11 @@ function Set-TargetResource
 
         [Parameter()]
         [String]
-        $PrimaryReplicaSQLServer,
+        $PrimaryReplicaServerName,
 
         [Parameter()]
         [String]
-        $PrimaryReplicaSQLInstanceName,
+        $PrimaryReplicaInstanceName,
 
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
@@ -383,7 +383,7 @@ function Set-TargetResource
             else
             {
                 # Connect to the instance that is supposed to house the primary replica
-                $primaryReplicaServerObject = Connect-SQL -SQLServer $PrimaryReplicaSQLServer -SQLInstanceName $PrimaryReplicaSQLInstanceName
+                $primaryReplicaServerObject = Connect-SQL -SQLServer $PrimaryReplicaServerName -SQLInstanceName $PrimaryReplicaInstanceName
 
                 # Verify the Availability Group exists on the supplied primary replica
                 $primaryReplicaAvailabilityGroup = $primaryReplicaServerObject.AvailabilityGroups[$AvailabilityGroupName]
@@ -453,7 +453,7 @@ function Set-TargetResource
                 # The Availability Group doesn't exist on the primary replica
                 else
                 {
-                    throw New-TerminatingError -ErrorType AvailabilityGroupNotFound -FormatArgs $AvailabilityGroupName, $PrimaryReplicaSQLInstanceName -ErrorCategory ResourceUnavailable
+                    throw New-TerminatingError -ErrorType AvailabilityGroupNotFound -FormatArgs $AvailabilityGroupName, $PrimaryReplicaInstanceName -ErrorCategory ResourceUnavailable
                 }
             }
         }
@@ -476,10 +476,10 @@ function Set-TargetResource
     .PARAMETER InstanceName
         Name of the SQL instance to be configued.
 
-    .PARAMETER PrimaryReplicaSQLServer
+    .PARAMETER PrimaryReplicaServerName
         Hostname of the SQL Server where the primary replica is expected to be active. If the primary replica is not found here, the resource will attempt to find the host that holds the primary replica and connect to it.
 
-    .PARAMETER PrimaryReplicaSQLInstanceName
+    .PARAMETER PrimaryReplicaInstanceName
         Name of the SQL instance where the primary replica lives.
 
     .PARAMETER Ensure
@@ -536,11 +536,11 @@ function Test-TargetResource
 
         [Parameter()]
         [String]
-        $PrimaryReplicaSQLServer,
+        $PrimaryReplicaServerName,
 
         [Parameter()]
         [String]
-        $PrimaryReplicaSQLInstanceName,
+        $PrimaryReplicaInstanceName,
 
         [Parameter()]
         [ValidateSet('Present', 'Absent')]

--- a/DSCResources/MSFT_SqlAGReplica/MSFT_SqlAGReplica.schema.mof
+++ b/DSCResources/MSFT_SqlAGReplica/MSFT_SqlAGReplica.schema.mof
@@ -5,8 +5,8 @@ class MSFT_SqlAGReplica : OMI_BaseResource
     [Key, Description("The name of the availability group.")] String AvailabilityGroupName;
     [Required, Description("Hostname of the SQL Server to be configured.")] String ServerName;
     [Key, Description("Name of the SQL instance to be configured.")] String InstanceName;
-    [Write, Description("Hostname of the SQL Server where the primary replica is expected to be active. If the primary replica is not found here, the resource will attempt to find the host that holds the primary replica and connect to it.")] String PrimaryReplicaSQLServer;
-    [Write, Description("Name of the SQL instance where the primary replica lives.")] String PrimaryReplicaSQLInstanceName;
+    [Write, Description("Hostname of the SQL Server where the primary replica is expected to be active. If the primary replica is not found here, the resource will attempt to find the host that holds the primary replica and connect to it.")] String PrimaryReplicaServerName;
+    [Write, Description("Name of the SQL instance where the primary replica lives.")] String PrimaryReplicaInstanceName;
     [Write, Description("Specifies if the availability group replica should be present or absent. Default is Present."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("Specifies the replica availability mode. Default is 'AsynchronousCommit'."), ValueMap{"AsynchronousCommit","SynchronousCommit"}, Values{"AsynchronousCommit","SynchronousCommit"}] String AvailabilityMode;
     [Write, Description("Specifies the desired priority of the replicas in performing backups. The acceptable values for this parameter are: integers from 0 through 100. Of the set of replicas which are online and available, the replica that has the highest priority performs the backup. Default is 50.")] UInt32 BackupPriority;

--- a/DSCResources/MSFT_SqlRS/MSFT_SqlRS.schema.mof
+++ b/DSCResources/MSFT_SqlRS/MSFT_SqlRS.schema.mof
@@ -2,8 +2,8 @@
 class MSFT_SqlRS : OMI_BaseResource
 {
     [Key, Description("Name of the SQL Server Reporting Services instance to be configured.")] String InstanceName;
-    [Required, Description("Name of the SQL Server to host the Reporting Service database.")] String RSSQLServer;
-    [Required, Description("Name of the SQL Server instance to host the Reporting Service database.")] String RSSQLInstanceName;
+    [Required, Description("Name of the SQL Server to host the Reporting Service database.")] String DatabaseServerName;
+    [Required, Description("Name of the SQL Server instance to host the Reporting Service database.")] String DatabaseInstanceName;
     [Write, Description("Report Server Web Service virtual directory. Optional.")] String ReportServerVirtualDirectory;
     [Write, Description("Report Manager/Report Web App virtual directory name. Optional.")] String ReportsVirtualDirectory;
     [Write, Description("Report Server URL reservations. Optional. If not specified, 'http://+:80' URL reservation will be used.")] String ReportServerReservedUrl[];

--- a/Examples/Resources/SqlAGDatabase/1-AddDatabaseToAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAGDatabase/1-AddDatabaseToAvailabilityGroup.ps1
@@ -92,13 +92,13 @@ Configuration Example
             # Add the availability group replica to the availability group
             SqlAGReplica AddReplica
             {
-                Ensure                        = 'Present'
-                Name                          = $Node.NodeName
-                AvailabilityGroupName         = $Node.AvailabilityGroupName
-                ServerName                    = $Node.NodeName
-                InstanceName                  = $Node.SQLInstanceName
-                PrimaryReplicaSQLServer       = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).NodeName
-                PrimaryReplicaSQLInstanceName = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).SQLInstanceName
+                Ensure                     = 'Present'
+                Name                       = $Node.NodeName
+                AvailabilityGroupName      = $Node.AvailabilityGroupName
+                ServerName                 = $Node.NodeName
+                InstanceName               = $Node.SQLInstanceName
+                PrimaryReplicaServerName   = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).NodeName
+                PrimaryReplicaInstanceName = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).SQLInstanceName
             }
         }
 

--- a/Examples/Resources/SqlAGDatabase/2-RemoveDatabaseFromAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAGDatabase/2-RemoveDatabaseFromAvailabilityGroup.ps1
@@ -40,8 +40,8 @@ Configuration Example
             Ensure               = 'Present'
             Name                 = 'NT SERVICE\ClusSvc'
             LoginType            = 'WindowsUser'
-            ServerName            = $Node.NodeName
-            InstanceName      = $Node.SQLInstanceName
+            ServerName           = $Node.NodeName
+            InstanceName         = $Node.SQLInstanceName
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -50,7 +50,7 @@ Configuration Example
         {
             DependsOn            = '[SqlServerLogin]AddNTServiceClusSvc'
             Ensure               = 'Present'
-            ServerName             = $Node.NodeName
+            ServerName           = $Node.NodeName
             InstanceName         = $Node.SqlInstanceName
             Principal            = 'NT SERVICE\ClusSvc'
             Permission           = 'AlterAnyAvailabilityGroup', 'ViewServerState'
@@ -63,8 +63,8 @@ Configuration Example
             EndPointName         = 'HADR'
             Ensure               = 'Present'
             Port                 = 5022
-            ServerName            = $Node.NodeName
-            InstanceName      = $Node.SQLInstanceName
+            ServerName           = $Node.NodeName
+            InstanceName         = $Node.SQLInstanceName
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -75,8 +75,8 @@ Configuration Example
             {
                 Ensure               = 'Present'
                 Name                 = $Node.AvailabilityGroupName
-                InstanceName      = $Node.SQLInstanceName
-                ServerName            = $Node.NodeName
+                InstanceName         = $Node.SQLInstanceName
+                ServerName           = $Node.NodeName
                 DependsOn            = '[SqlServerEndpoint]HADREndpoint', '[SqlServerPermission]AddNTServiceClusSvcPermissions'
                 PsDscRunAsCredential = $SysAdminAccount
             }
@@ -87,13 +87,13 @@ Configuration Example
             # Add the availability group replica to the availability group
             SqlAGReplica AddReplica
             {
-                Ensure                        = 'Present'
-                Name                          = $Node.NodeName
-                AvailabilityGroupName         = $Node.AvailabilityGroupName
-                ServerName                    = $Node.NodeName
-                InstanceName                  = $Node.SQLInstanceName
-                PrimaryReplicaSQLServer       = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).NodeName
-                PrimaryReplicaSQLInstanceName = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).SQLInstanceName
+                Ensure                     = 'Present'
+                Name                       = $Node.NodeName
+                AvailabilityGroupName      = $Node.AvailabilityGroupName
+                ServerName                 = $Node.NodeName
+                InstanceName               = $Node.SQLInstanceName
+                PrimaryReplicaServerName   = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).NodeName
+                PrimaryReplicaInstanceName = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).SQLInstanceName
             }
         }
 

--- a/Examples/Resources/SqlAGDatabase/3-MatchDefinedDatabaseInAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAGDatabase/3-MatchDefinedDatabaseInAvailabilityGroup.ps1
@@ -40,8 +40,8 @@ Configuration Example
             Ensure               = 'Present'
             Name                 = 'NT SERVICE\ClusSvc'
             LoginType            = 'WindowsUser'
-            ServerName            = $Node.NodeName
-            InstanceName      = $Node.SQLInstanceName
+            ServerName           = $Node.NodeName
+            InstanceName         = $Node.SQLInstanceName
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -50,7 +50,7 @@ Configuration Example
         {
             DependsOn            = '[SqlServerLogin]AddNTServiceClusSvc'
             Ensure               = 'Present'
-            ServerName             = $Node.NodeName
+            ServerName           = $Node.NodeName
             InstanceName         = $Node.SqlInstanceName
             Principal            = 'NT SERVICE\ClusSvc'
             Permission           = 'AlterAnyAvailabilityGroup', 'ViewServerState'
@@ -63,8 +63,8 @@ Configuration Example
             EndPointName         = 'HADR'
             Ensure               = 'Present'
             Port                 = 5022
-            ServerName            = $Node.NodeName
-            InstanceName      = $Node.SQLInstanceName
+            ServerName           = $Node.NodeName
+            InstanceName         = $Node.SQLInstanceName
             PsDscRunAsCredential = $SysAdminAccount
         }
 
@@ -75,8 +75,8 @@ Configuration Example
             {
                 Ensure               = 'Present'
                 Name                 = $Node.AvailabilityGroupName
-                InstanceName      = $Node.SQLInstanceName
-                ServerName            = $Node.NodeName
+                InstanceName         = $Node.SQLInstanceName
+                ServerName           = $Node.NodeName
                 DependsOn            = '[SqlServerEndpoint]HADREndpoint', '[SqlServerPermission]AddNTServiceClusSvcPermissions'
                 PsDscRunAsCredential = $SysAdminAccount
             }
@@ -87,13 +87,13 @@ Configuration Example
             # Add the availability group replica to the availability group
             SqlAGReplica AddReplica
             {
-                Ensure                        = 'Present'
-                Name                          = $Node.NodeName
-                AvailabilityGroupName         = $Node.AvailabilityGroupName
-                ServerName                    = $Node.NodeName
-                InstanceName                  = $Node.SQLInstanceName
-                PrimaryReplicaSQLServer       = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).NodeName
-                PrimaryReplicaSQLInstanceName = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).SQLInstanceName
+                Ensure                     = 'Present'
+                Name                       = $Node.NodeName
+                AvailabilityGroupName      = $Node.AvailabilityGroupName
+                ServerName                 = $Node.NodeName
+                InstanceName               = $Node.SQLInstanceName
+                PrimaryReplicaServerName   = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).NodeName
+                PrimaryReplicaInstanceName = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).SQLInstanceName
             }
         }
 

--- a/Examples/Resources/SqlAGReplica/1-CreateAvailabilityGroupReplica.ps1
+++ b/Examples/Resources/SqlAGReplica/1-CreateAvailabilityGroupReplica.ps1
@@ -94,14 +94,14 @@ Configuration Example
             # Add the availability group replica to the availability group
             SqlAGReplica AddReplica
             {
-                Ensure                        = 'Present'
-                Name                          = $Node.NodeName
-                AvailabilityGroupName         = $Node.AvailabilityGroupName
-                ServerName                    = $Node.NodeName
-                InstanceName                  = $Node.SQLInstanceName
-                PrimaryReplicaSQLServer       = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).NodeName
-                PrimaryReplicaSQLInstanceName = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).SQLInstanceName
-                ProcessOnlyOnActiveNode       = $Node.ProcessOnlyOnActiveNode
+                Ensure                     = 'Present'
+                Name                       = $Node.NodeName
+                AvailabilityGroupName      = $Node.AvailabilityGroupName
+                ServerName                 = $Node.NodeName
+                InstanceName               = $Node.SQLInstanceName
+                PrimaryReplicaServerName   = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).NodeName
+                PrimaryReplicaInstanceName = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).SQLInstanceName
+                ProcessOnlyOnActiveNode    = $Node.ProcessOnlyOnActiveNode
             }
         }
     }

--- a/Examples/Resources/SqlAGReplica/2-RemoveAvailabilityGroupReplica.ps1
+++ b/Examples/Resources/SqlAGReplica/2-RemoveAvailabilityGroupReplica.ps1
@@ -87,13 +87,13 @@ Configuration Example
             # Add the availability group replica to the availability group
             SqlAGReplica AddReplica
             {
-                Ensure                        = 'Absent'
-                Name                          = $Node.NodeName
-                AvailabilityGroupName         = $Node.AvailabilityGroupName
-                ServerName                    = $Node.NodeName
-                InstanceName                  = $Node.SQLInstanceName
-                PrimaryReplicaSQLServer       = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).NodeName
-                PrimaryReplicaSQLInstanceName = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).SQLInstanceName
+                Ensure                     = 'Absent'
+                Name                       = $Node.NodeName
+                AvailabilityGroupName      = $Node.AvailabilityGroupName
+                ServerName                 = $Node.NodeName
+                InstanceName               = $Node.SQLInstanceName
+                PrimaryReplicaServerName   = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).NodeName
+                PrimaryReplicaInstanceName = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).SQLInstanceName
             }
         }
     }

--- a/Examples/Resources/SqlRS/1-DefaultConfiguration.ps1
+++ b/Examples/Resources/SqlRS/1-DefaultConfiguration.ps1
@@ -14,9 +14,9 @@ Configuration Example
     node localhost {
         SqlRS DefaultConfiguration
         {
-            InstanceName = 'MSSQLSERVER'
-            RSSQLServer = 'localhost'
-            RSSQLInstanceName = 'MSSQLSERVER'
+            InstanceName         = 'MSSQLSERVER'
+            DatabaseServerName   = 'localhost'
+            DatabaseInstanceName = 'MSSQLSERVER'
         }
     }
 }

--- a/Examples/Resources/SqlRS/2-CustomConfiguration.ps1
+++ b/Examples/Resources/SqlRS/2-CustomConfiguration.ps1
@@ -19,13 +19,13 @@ Configuration Example
     node localhost {
         SqlRS DefaultConfiguration
         {
-            InstanceName = 'MSSQLSERVER'
-            RSSQLServer = 'localhost'
-            RSSQLInstanceName = 'MSSQLSERVER'
+            InstanceName                 = 'MSSQLSERVER'
+            DatabaseServerName           = 'localhost'
+            DatabaseInstanceName         = 'MSSQLSERVER'
             ReportServerVirtualDirectory = 'MyReportServer'
-            ReportsVirtualDirectory = 'MyReports'
-            ReportServerReservedUrl = @('http://+:80', 'https://+:443')
-            ReportsReservedUrl = @('http://+:80', 'https://+:443')
+            ReportsVirtualDirectory      = 'MyReports'
+            ReportServerReservedUrl      = @('http://+:80', 'https://+:443')
+            ReportsReservedUrl           = @('http://+:80', 'https://+:443')
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -1198,9 +1198,9 @@ Initializes and configures SQL Reporting Services server.
 
 * **`[String]` InstanceName** _(Key)_: Name of the SQL Server Reporting Services
   instance to be configured.
-* **`[String]` RSSQLServer** _(Required)_: Name of the SQL Server to host the
+* **`[String]` DatabaseServerName** _(Required)_: Name of the SQL Server to host the
   Reporting Service database.
-* **`[String]` RSSQLInstanceName** _(Required)_: Name of the SQL Server instance
+* **`[String]` DatabaseInstanceName** _(Required)_: Name of the SQL Server instance
   to host the Reporting Service database.
 * **`[String]` ReportServerVirtualDir** _(Write)_: Report Server Web Service virtual
   directory. Optional.

--- a/README.md
+++ b/README.md
@@ -1198,8 +1198,8 @@ Initializes and configures SQL Reporting Services server.
 
 * **`[String]` InstanceName** _(Key)_: Name of the SQL Server Reporting Services
   instance to be configured.
-* **`[String]` DatabaseServerName** _(Required)_: Name of the SQL Server to host the
-  Reporting Service database.
+* **`[String]` DatabaseServerName** _(Required)_: Name of the SQL Server to host
+  the Reporting Service database.
 * **`[String]` DatabaseInstanceName** _(Required)_: Name of the SQL Server instance
   to host the Reporting Service database.
 * **`[String]` ReportServerVirtualDir** _(Write)_: Report Server Web Service virtual

--- a/README.md
+++ b/README.md
@@ -349,11 +349,11 @@ Always On Availability Group Replica.
 * **`[String]` AvailabilityGroupName** _(Key)_: The name of the availability group.
 * **`[String]` ServerName** _(Required)_: Hostname of the SQL Server to be configured.
 * **`[String]` InstanceName** _(Key)_: Name of the SQL instance to be configured.
-* **`[String]` PrimaryReplicaSQLServer** _(Write)_: Hostname of the SQL Server where
+* **`[String]` PrimaryReplicaServerName** _(Write)_: Hostname of the SQL Server where
   the primary replica is expected to be active. If the primary replica is not found
   here, the resource will attempt to find the host that holds the primary replica
   and connect to it.
-* **`[String]` PrimaryReplicaSQLInstanceName** _(Write)_: Name of the SQL instance
+* **`[String]` PrimaryReplicaInstanceName** _(Write)_: Name of the SQL instance
   where the primary replica lives.
 * **`[String]` Ensure** _(Write)_: Specifies if the availability group replica should
   be present or absent. Default is Present. { *Present* | Absent }

--- a/Tests/Integration/MSFT_SqlRS.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlRS.Integration.Tests.ps1
@@ -43,8 +43,8 @@ try
     . $configFile
 
     $mockInstanceName = $ConfigurationData.AllNodes.InstanceName
-    $mockRSSQLServer = $ConfigurationData.AllNodes.RSSQLServer
-    $mockRSSQLInstanceName = $ConfigurationData.AllNodes.RSSQLInstanceName
+    $mockDatabaseServerName = $ConfigurationData.AllNodes.DatabaseServerName
+    $mockDatabaseInstanceName = $ConfigurationData.AllNodes.DatabaseInstanceName
 
     Describe "$($script:DSCResourceName)_Integration" {
         BeforeAll {
@@ -94,8 +94,8 @@ try
                 }
 
                 $resourceCurrentState.InstanceName | Should -Be $mockInstanceName
-                $resourceCurrentState.RSSQLServer | Should -Be $mockRSSQLServer
-                $resourceCurrentState.RSSQLInstanceName | Should -Be $mockRSSQLInstanceName
+                $resourceCurrentState.DatabaseServerName | Should -Be $mockDatabaseServerName
+                $resourceCurrentState.DatabaseInstanceName | Should -Be $mockDatabaseInstanceName
                 $resourceCurrentState.IsInitialized | Should -Be $true
             }
 

--- a/Tests/Integration/MSFT_SqlRS.config.ps1
+++ b/Tests/Integration/MSFT_SqlRS.config.ps1
@@ -22,8 +22,8 @@ $ConfigurationData = @{
             ImagePath                   = "$env:TEMP\SQL2016.iso"
             DriveLetter                 = $mockIsoMediaDriveLetter
 
-            RSSQLServer                 = $env:COMPUTERNAME
-            RSSQLInstanceName           = 'DSCSQL2016'
+            DatabaseServerName          = $env:COMPUTERNAME
+            DatabaseInstanceName        = 'DSCSQL2016'
 
             PSDscAllowPlainTextPassword = $true
         }
@@ -118,8 +118,8 @@ Configuration MSFT_SqlRS_InstallReportingServices_Config
                 Instance for Reporting Services databases.
                 Note: This instance is created in a prior integration test.
             #>
-            RSSQLServer          = $Node.RSSQLServer
-            RSSQLInstanceName    = $Node.RSSQLInstanceName
+            DatabaseServerName   = $Node.DatabaseServerName
+            DatabaseInstanceName = $Node.DatabaseInstanceName
 
             PsDscRunAsCredential = $SqlInstallCredential
 

--- a/Tests/Unit/MSFT_SqlAGReplica.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAGReplica.Tests.ps1
@@ -39,8 +39,8 @@ try
 
         $mockServerName = 'Server1'
         $mockInstanceName = 'MSSQLSERVER'
-        $mockPrimaryReplicaSQLServer = 'Server2'
-        $mockPrimaryReplicaSQLInstanceName = 'MSSQLSERVER'
+        $mockPrimaryReplicaServerName = 'Server2'
+        $mockPrimaryReplicaInstanceName = 'MSSQLSERVER'
         $mockAvailabilityGroupName = 'AG_AllServers'
         $mockAvailabilityGroupReplicaName = $mockServerName
         $mockEnsure = 'Present'
@@ -737,8 +737,8 @@ try
                         AvailabilityGroupName         = $mockAvailabilityGroup2Name
                         ServerName                    = $mockServerName
                         InstanceName                  = $mockInstanceName
-                        PrimaryReplicaSQLServer       = $mockPrimaryReplicaSQLServer
-                        PrimaryReplicaSQLInstanceName = $mockPrimaryReplicaSQLInstanceName
+                        PrimaryReplicaServerName      = $mockPrimaryReplicaServerName
+                        PrimaryReplicaInstanceName    = $mockPrimaryReplicaInstanceName
                         Ensure                        = $mockEnsure
                         AvailabilityMode              = $mockAvailabilityMode
                         BackupPriority                = $mockBackupPriority
@@ -918,7 +918,7 @@ try
 
                 It 'Should create the availability group replica when primary replica server is incorrectly supplied and the availability group exists' {
 
-                    $setTargetResourceParameters.PrimaryReplicaSQLServer = $mockServer3Name
+                    $setTargetResourceParameters.PrimaryReplicaServerName = $mockServer3Name
 
                     { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
 
@@ -1076,8 +1076,8 @@ try
                         AvailabilityGroupName         = $mockAvailabilityGroupName
                         ServerName                    = $mockServerName
                         InstanceName                  = $mockInstanceName
-                        PrimaryReplicaSQLServer       = $mockPrimaryReplicaSQLServer
-                        PrimaryReplicaSQLInstanceName = $mockPrimaryReplicaSQLInstanceName
+                        PrimaryReplicaServerName      = $mockPrimaryReplicaServerName
+                        PrimaryReplicaInstanceName    = $mockPrimaryReplicaInstanceName
                         Ensure                        = $mockEnsure
                         AvailabilityMode              = $mockAvailabilityMode
                         BackupPriority                = $mockBackupPriority
@@ -1278,8 +1278,8 @@ try
                     AvailabilityGroupName         = $mockAvailabilityGroupName
                     ServerName                    = $mockServerName
                     InstanceName                  = $mockInstanceName
-                    PrimaryReplicaSQLServer       = $mockPrimaryReplicaSQLServer
-                    PrimaryReplicaSQLInstanceName = $mockPrimaryReplicaSQLInstanceName
+                    PrimaryReplicaServerName      = $mockPrimaryReplicaServerName
+                    PrimaryReplicaInstanceName    = $mockPrimaryReplicaInstanceName
                     Ensure                        = $mockEnsure
                     AvailabilityMode              = $mockAvailabilityMode
                     BackupPriority                = $mockBackupPriority

--- a/Tests/Unit/MSFT_SqlRS.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlRS.Tests.ps1
@@ -197,9 +197,9 @@ try
                 Mock -CommandName Get-ItemProperty -MockWith $mockGetItemProperty -Verifiable
 
                 $defaultParameters = @{
-                    InstanceName      = $mockNamedInstanceName
-                    RSSQLServer       = $mockReportingServicesDatabaseServerName
-                    RSSQLInstanceName = $mockReportingServicesDatabaseNamedInstanceName
+                    InstanceName         = $mockNamedInstanceName
+                    DatabaseServerName   = $mockReportingServicesDatabaseServerName
+                    DatabaseInstanceName = $mockReportingServicesDatabaseNamedInstanceName
                 }
             }
 
@@ -225,8 +225,8 @@ try
                 It 'Should return the same values as passed as parameters' {
                     $resultGetTargetResource = Get-TargetResource @defaultParameters
                     $resultGetTargetResource.InstanceName | Should -Be $mockNamedInstanceName
-                    $resultGetTargetResource.RSSQLServer | Should -Be $mockReportingServicesDatabaseServerName
-                    $resultGetTargetResource.RSSQLInstanceName | Should -Be $mockReportingServicesDatabaseNamedInstanceName
+                    $resultGetTargetResource.DatabaseServerName | Should -Be $mockReportingServicesDatabaseServerName
+                    $resultGetTargetResource.DatabaseInstanceName | Should -Be $mockReportingServicesDatabaseNamedInstanceName
                     $resultGetTargetResource | Should -BeOfType [System.Collections.Hashtable]
                 }
 
@@ -260,8 +260,8 @@ try
                 It 'Should return the same values as passed as parameters' {
                     $resultGetTargetResource = Get-TargetResource @testParameters
                     $resultGetTargetResource.InstanceName | Should -Be $mockDefaultInstanceName
-                    $resultGetTargetResource.RSSQLServer | Should -Be $mockReportingServicesDatabaseServerName
-                    $resultGetTargetResource.RSSQLInstanceName | Should -Be $mockReportingServicesDatabaseDefaultInstanceName
+                    $resultGetTargetResource.DatabaseServerName | Should -Be $mockReportingServicesDatabaseServerName
+                    $resultGetTargetResource.DatabaseInstanceName | Should -Be $mockReportingServicesDatabaseDefaultInstanceName
                     $resultGetTargetResource | Should -BeOfType [System.Collections.Hashtable]
                 }
 
@@ -327,9 +327,9 @@ try
                         }
 
                         $defaultParameters = @{
-                            InstanceName      = $mockNamedInstanceName
-                            RSSQLServer       = $mockReportingServicesDatabaseServerName
-                            RSSQLInstanceName = $mockReportingServicesDatabaseNamedInstanceName
+                            InstanceName         = $mockNamedInstanceName
+                            DatabaseServerName   = $mockReportingServicesDatabaseServerName
+                            DatabaseInstanceName = $mockReportingServicesDatabaseNamedInstanceName
                         }
                     }
 
@@ -410,8 +410,8 @@ try
 
                         $testParameters = @{
                             InstanceName                 = $mockNamedInstanceName
-                            RSSQLServer                  = $mockReportingServicesDatabaseServerName
-                            RSSQLInstanceName            = $mockReportingServicesDatabaseNamedInstanceName
+                            DatabaseServerName           = $mockReportingServicesDatabaseServerName
+                            DatabaseInstanceName         = $mockReportingServicesDatabaseNamedInstanceName
                             ReportServerVirtualDirectory = 'ReportServer_NewName'
                             ReportsVirtualDirectory      = 'Reports_NewName'
                             ReportServerReservedUrl      = 'https://+:4443'
@@ -465,9 +465,9 @@ try
                         } -Verifiable
 
                         $defaultParameters = @{
-                            InstanceName      = $mockDefaultInstanceName
-                            RSSQLServer       = $mockReportingServicesDatabaseServerName
-                            RSSQLInstanceName = $mockReportingServicesDatabaseDefaultInstanceName
+                            InstanceName         = $mockDefaultInstanceName
+                            DatabaseServerName   = $mockReportingServicesDatabaseServerName
+                            DatabaseInstanceName = $mockReportingServicesDatabaseDefaultInstanceName
                         }
                     }
 
@@ -515,9 +515,9 @@ try
                         } -Verifiable
 
                         $testParameters = @{
-                            InstanceName      = $mockNamedInstanceName
-                            RSSQLServer       = $mockReportingServicesDatabaseServerName
-                            RSSQLInstanceName = $mockReportingServicesDatabaseNamedInstanceName
+                            InstanceName         = $mockNamedInstanceName
+                            DatabaseServerName   = $mockReportingServicesDatabaseServerName
+                            DatabaseInstanceName = $mockReportingServicesDatabaseNamedInstanceName
                         }
                     }
 
@@ -539,8 +539,8 @@ try
 
                         $testParameters = @{
                             InstanceName                 = $mockNamedInstanceName
-                            RSSQLServer                  = $mockReportingServicesDatabaseServerName
-                            RSSQLInstanceName            = $mockReportingServicesDatabaseNamedInstanceName
+                            DatabaseServerName           = $mockReportingServicesDatabaseServerName
+                            DatabaseInstanceName         = $mockReportingServicesDatabaseNamedInstanceName
                             ReportsVirtualDirectory      = $mockVirtualDirectoryReportsName
                             ReportServerVirtualDirectory = 'ReportServer_NewName'
                         }
@@ -564,8 +564,8 @@ try
 
                         $testParameters = @{
                             InstanceName                 = $mockNamedInstanceName
-                            RSSQLServer                  = $mockReportingServicesDatabaseServerName
-                            RSSQLInstanceName            = $mockReportingServicesDatabaseNamedInstanceName
+                            DatabaseServerName           = $mockReportingServicesDatabaseServerName
+                            DatabaseInstanceName         = $mockReportingServicesDatabaseNamedInstanceName
                             ReportServerVirtualDirectory = $mockVirtualDirectoryReportServerName
                             ReportsVirtualDirectory      = 'Reports_NewName'
                         }
@@ -588,8 +588,8 @@ try
 
                         $testParameters = @{
                             InstanceName            = $mockNamedInstanceName
-                            RSSQLServer             = $mockReportingServicesDatabaseServerName
-                            RSSQLInstanceName       = $mockReportingServicesDatabaseNamedInstanceName
+                            DatabaseServerName      = $mockReportingServicesDatabaseServerName
+                            DatabaseInstanceName    = $mockReportingServicesDatabaseNamedInstanceName
                             ReportServerReservedUrl = 'https://+:443'
                         }
                     }
@@ -610,10 +610,10 @@ try
                         } -Verifiable
 
                         $testParameters = @{
-                            InstanceName       = $mockNamedInstanceName
-                            RSSQLServer        = $mockReportingServicesDatabaseServerName
-                            RSSQLInstanceName  = $mockReportingServicesDatabaseNamedInstanceName
-                            ReportsReservedUrl = 'https://+:443'
+                            InstanceName         = $mockNamedInstanceName
+                            DatabaseServerName   = $mockReportingServicesDatabaseServerName
+                            DatabaseInstanceName = $mockReportingServicesDatabaseNamedInstanceName
+                            ReportsReservedUrl   = 'https://+:443'
                         }
                     }
 
@@ -633,9 +633,9 @@ try
                     } -Verifiable
 
                     $defaultParameters = @{
-                        InstanceName      = $mockNamedInstanceName
-                        RSSQLServer       = $mockReportingServicesDatabaseServerName
-                        RSSQLInstanceName = $mockReportingServicesDatabaseNamedInstanceName
+                        InstanceName         = $mockNamedInstanceName
+                        DatabaseServerName   = $mockReportingServicesDatabaseServerName
+                        DatabaseInstanceName = $mockReportingServicesDatabaseNamedInstanceName
                     }
                 }
 


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to SqlRS
  - BREAKING CHANGE: Parameters RSSQLServer and RSSQLInstanceName has been renamed
    to DatabaseServerName and DatabaseInstanceName respectively (issue #923).
- Changes to SqlAGReplica
  - BREAKING CHANGE: Parameters PrimaryReplicaSQLServer and PrimaryReplicaSQLInstanceName
    has been renamed to PrimaryReplicaServerName and PrimaryReplicaInstanceName
    respectively (issue #922).

**This Pull Request (PR) fixes the following issues:**
Fixes #922 
Fixes #923 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/932)
<!-- Reviewable:end -->
