### PR TITLE
SqlAg & SqlReplica: Removes SQLServerNetName in favor of EndpointHostName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@
   - BREAKING CHANGE: Parameters PrimaryReplicaSQLServer and PrimaryReplicaSQLInstanceName
     has been renamed to PrimaryReplicaServerName and PrimaryReplicaInstanceName
     respectively ([issue #922](https://github.com/PowerShell/SqlServerDsc/issues/922)).
+  - The read-only property SQLServerNetName was removed in favor of EndpointHostName
+    ([issue #924](https://github.com/PowerShell/SqlServerDsc/issues/924)).
+    Get-TargetResource will return the value of property [NetName](https://technet.microsoft.com/en-us/library/microsoft.sqlserver.management.smo.server.netname(v=sql.105).aspx)
+    as the default value if EndpointHostName parameter is not assigned a value.
 - Changes to SqlAlwaysOnService
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectively

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectively
     ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
-  - BREAKING CHANGE: The read-only property SQLServerNetName was removed in favor of EndpointHostName
-    ([issue #924](https://github.com/PowerShell/SqlServerDsc/issues/924)).
+  - BREAKING CHANGE: The read-only property SQLServerNetName was removed in favor
+    of EndpointHostName ([issue #924](https://github.com/PowerShell/SqlServerDsc/issues/924)).
     Get-TargetResource will return the value of property [NetName](https://technet.microsoft.com/en-us/library/microsoft.sqlserver.management.smo.server.netname(v=sql.105).aspx)
     as the default value if EndpointHostName parameter is not assigned a value.
 - Changes to SqlAGDatabase
@@ -41,8 +41,8 @@
   - BREAKING CHANGE: Parameters PrimaryReplicaSQLServer and PrimaryReplicaSQLInstanceName
     has been renamed to PrimaryReplicaServerName and PrimaryReplicaInstanceName
     respectively ([issue #922](https://github.com/PowerShell/SqlServerDsc/issues/922)).
-  - BREAKING CHANGE: The read-only property SQLServerNetName was removed in favor of EndpointHostName
-    ([issue #924](https://github.com/PowerShell/SqlServerDsc/issues/924)).
+  - BREAKING CHANGE: The read-only property SQLServerNetName was removed in favor
+    of EndpointHostName ([issue #924](https://github.com/PowerShell/SqlServerDsc/issues/924)).
     Get-TargetResource will return the value of property [NetName](https://technet.microsoft.com/en-us/library/microsoft.sqlserver.management.smo.server.netname(v=sql.105).aspx)
     as the default value if EndpointHostName parameter is not assigned a value.
 - Changes to SqlAlwaysOnService

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@
     ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
   - BREAKING CHANGE: The read-only property SQLServerNetName was removed in favor
     of EndpointHostName ([issue #924](https://github.com/PowerShell/SqlServerDsc/issues/924)).
-    Get-TargetResource will return the value of property [NetName](https://technet.microsoft.com/en-us/library/microsoft.sqlserver.management.smo.server.netname(v=sql.105).aspx)
-    as the default value if EndpointHostName parameter is not assigned a value.
+    Get-TargetResource will now return the value of property [NetName](https://technet.microsoft.com/en-us/library/microsoft.sqlserver.management.smo.server.netname(v=sql.105).aspx)
+    for the property EndpointHostName.
 - Changes to SqlAGDatabase
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectively
@@ -43,8 +43,8 @@
     respectively ([issue #922](https://github.com/PowerShell/SqlServerDsc/issues/922)).
   - BREAKING CHANGE: The read-only property SQLServerNetName was removed in favor
     of EndpointHostName ([issue #924](https://github.com/PowerShell/SqlServerDsc/issues/924)).
-    Get-TargetResource will return the value of property [NetName](https://technet.microsoft.com/en-us/library/microsoft.sqlserver.management.smo.server.netname(v=sql.105).aspx)
-    as the default value if EndpointHostName parameter is not assigned a value.
+    Get-TargetResource will now return the value of property [NetName](https://technet.microsoft.com/en-us/library/microsoft.sqlserver.management.smo.server.netname(v=sql.105).aspx)
+    for the property EndpointHostName.
 - Changes to SqlAlwaysOnService
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectively

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectively
     ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
+  - The read-only property SQLServerNetName was removed in favor of EndpointHostName
+    ([issue #924](https://github.com/PowerShell/SqlServerDsc/issues/924)).
+    Get-TargetResource will return the value of property [NetName](https://technet.microsoft.com/en-us/library/microsoft.sqlserver.management.smo.server.netname(v=sql.105).aspx)
+    as the default value if EndpointHostName parameter is not assigned a value.
 - Changes to SqlAGDatabase
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectively

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
   - BREAKING CHANGE: Parameters SQLServer and SQLInstanceName has been renamed
     to ServerName and InstanceName respectively
     ([issue #308](https://github.com/PowerShell/SqlServerDsc/issues/308)).
-  - The read-only property SQLServerNetName was removed in favor of EndpointHostName
+  - BREAKING CHANGE: The read-only property SQLServerNetName was removed in favor of EndpointHostName
     ([issue #924](https://github.com/PowerShell/SqlServerDsc/issues/924)).
     Get-TargetResource will return the value of property [NetName](https://technet.microsoft.com/en-us/library/microsoft.sqlserver.management.smo.server.netname(v=sql.105).aspx)
     as the default value if EndpointHostName parameter is not assigned a value.
@@ -41,7 +41,7 @@
   - BREAKING CHANGE: Parameters PrimaryReplicaSQLServer and PrimaryReplicaSQLInstanceName
     has been renamed to PrimaryReplicaServerName and PrimaryReplicaInstanceName
     respectively ([issue #922](https://github.com/PowerShell/SqlServerDsc/issues/922)).
-  - The read-only property SQLServerNetName was removed in favor of EndpointHostName
+  - BREAKING CHANGE: The read-only property SQLServerNetName was removed in favor of EndpointHostName
     ([issue #924](https://github.com/PowerShell/SqlServerDsc/issues/924)).
     Get-TargetResource will return the value of property [NetName](https://technet.microsoft.com/en-us/library/microsoft.sqlserver.management.smo.server.netname(v=sql.105).aspx)
     as the default value if EndpointHostName parameter is not assigned a value.

--- a/DSCResources/MSFT_SqlAG/MSFT_SqlAG.psm1
+++ b/DSCResources/MSFT_SqlAG/MSFT_SqlAG.psm1
@@ -76,7 +76,7 @@ function Get-TargetResource
         $alwaysOnAvailabilityGroupResource.HealthCheckTimeout = $availabilityGroup.HealthCheckTimeout
         $alwaysOnAvailabilityGroupResource.EndpointURL = $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].EndpointUrl
         $alwaysOnAvailabilityGroupResource.EndpointPort = $endpointPort
-        $alwaysOnAvailabilityGroupResource.SQLServerNetName = $serverObject.NetName
+        $alwaysOnAvailabilityGroupResource.EndpointHostName = $serverObject.NetName
         $alwaysOnAvailabilityGroupResource.Version = $sqlMajorVersion
 
         # Add properties that are only present in SQL 2016 or newer
@@ -700,7 +700,7 @@ function Test-TargetResource
 
                 if ( -not $EndpointHostName )
                 {
-                    $EndpointHostName = $getTargetResourceResult.SQLServerNetName
+                    $EndpointHostName = $getTargetResourceResult.EndpointHostName
                 }
 
                 # Verify the hostname in the endpoint URL is correct

--- a/DSCResources/MSFT_SqlAG/MSFT_SqlAG.schema.mof
+++ b/DSCResources/MSFT_SqlAG/MSFT_SqlAG.schema.mof
@@ -20,7 +20,6 @@ class MSFT_SqlAG : OMI_BaseResource
     [Write, Description("Specifies that the resource will only determine if a change is needed if the target node is the active host of the SQL Server Instance.")] Boolean ProcessOnlyOnActiveNode;
     [Read, Description("Gets the Endpoint URL of the availability group replica endpoint.")] String EndpointUrl;
     [Read, Description("Gets the port the database mirroring endpoint is listening on.")] UInt32 EndpointPort;
-    [Read, Description("Gets the hostname the SQL Server instance is listening on.")] String SQLServerNetName;
     [Read, Description("Gets the major version of the SQL Server instance.")] UInt32 Version;
     [Read, Description("Determines if the current node is actively hosting the SQL Server instance.")] Boolean IsActiveNode;
 };

--- a/DSCResources/MSFT_SqlAGReplica/MSFT_SqlAGReplica.psm1
+++ b/DSCResources/MSFT_SqlAGReplica/MSFT_SqlAGReplica.psm1
@@ -71,7 +71,7 @@ function Get-TargetResource
         ServerName                    = $ServerName
         InstanceName                  = $InstanceName
         EndpointPort                  = $endpointPort
-        SQLServerNetName              = $serverObject.NetName
+        EndpointHostName              = $serverObject.NetName
     }
 
     # Get the availability group
@@ -672,7 +672,7 @@ function Test-TargetResource
 
                 if ( -not $EndpointHostName )
                 {
-                    $EndpointHostName = $getTargetResourceResult.SQLServerNetName
+                    $EndpointHostName = $getTargetResourceResult.EndpointHostName
                 }
 
                 # Verify the hostname in the endpoint URL is correct

--- a/DSCResources/MSFT_SqlAGReplica/MSFT_SqlAGReplica.schema.mof
+++ b/DSCResources/MSFT_SqlAGReplica/MSFT_SqlAGReplica.schema.mof
@@ -19,6 +19,5 @@ class MSFT_SqlAGReplica : OMI_BaseResource
     [Write, Description("Specifies that the resource will only determine if a change is needed if the target node is the active host of the SQL Server instance.")] Boolean ProcessOnlyOnActiveNode;
     [Read, Description("Output the network port the endpoint is listening on. Used by Get-TargetResource.")] Uint16 EndpointPort;
     [Read, Description("Output the endpoint URL of the Availability Group Replica. Used by Get-TargetResource.")] String EndpointUrl;
-    [Read, Description("Output the NetName property from the SQL Server object. Used by Get-TargetResource.")] String SqlServerNetName;
     [Read, Description("Determines if the current node is actively hosting the SQL Server instance.")] Boolean IsActiveNode;
 };

--- a/README.md
+++ b/README.md
@@ -389,8 +389,6 @@ Always On Availability Group Replica.
   listening on. Used by Get-TargetResource.
 * **`[String]` EndpointUrl** _(Read)_: Output the endpoint URL of the
   Availability Group Replica. Used by Get-TargetResource.
-* **`[String]` SQLServerNetName** _(Read)_: Output the NetName property from the
-  SQL Server object.
 * **`[Boolean]` IsActiveNode** _(Read)_: Determines if the current node is
   actively hosting the SQL Server instance.
 

--- a/README.md
+++ b/README.md
@@ -262,8 +262,6 @@ It will also manage the Availability Group replica on the specified node.
   availability group replica endpoint.
 * **`[Uint32]` EndpointPort** _(Read)_: Gets the port the database mirroring
   endpoint is listening on
-* **`[String]` SQLServerNetName** _(Read)_: Gets the hostname the SQL Server
-  instance is listening on.
 * **`[Uint32]` Version** _(Read)_: Gets the major version of the SQL Server
   instance.
 * **`[Boolean]` IsActiveNode** _(Read)_: Determines if the current node is

--- a/Tests/Unit/MSFT_SqlAGReplica.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAGReplica.Tests.ps1
@@ -567,7 +567,7 @@ try
                     $getTargetResourceResult.ReadOnlyRoutingList | Should -BeNullOrEmpty
                     $getTargetResourceResult.ServerName | Should -Be $mockServerName
                     $getTargetResourceResult.InstanceName | Should -Be $mockInstanceName
-                    $getTargetResourceResult.SQLServerNetName | Should -Be $mockServerName
+                    $getTargetResourceResult.EndpointHostName | Should -Be $mockServerName
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 }
@@ -595,7 +595,7 @@ try
                     $getTargetResourceResult.ReadOnlyRoutingList | Should -Be $mockServerName
                     $getTargetResourceResult.ServerName | Should -Be $mockServerName
                     $getTargetResourceResult.InstanceName | Should -Be $mockInstanceName
-                    $getTargetResourceResult.SQLServerNetName | Should -Be $mockServerName
+                    $getTargetResourceResult.EndpointHostName | Should -Be $mockServerName
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 }


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to SqlAG
  - BREAKING CHANGE: The read-only property SQLServerNetName was removed in favor of EndpointHostName (issue #924). Get-TargetResource will return the value of property [NetName](https://technet.microsoft.com/en-us/library/microsoft.sqlserver.management.smo.server.netname(v=sql.105).aspx)
    as the default value if EndpointHostName parameter is not assigned a value.
- Changes to SqlAGReplica
  - BREAKING CHANGE: The read-only property SQLServerNetName was removed in favor of EndpointHostName (issue #924). Get-TargetResource will return the value of property [NetName](https://technet.microsoft.com/en-us/library/microsoft.sqlserver.management.smo.server.netname(v=sql.105).aspx)
    as the default value if EndpointHostName parameter is not assigned a value.

**This Pull Request (PR) fixes the following issues:**
Fixes #924 

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/938)
<!-- Reviewable:end -->
