### PR TITLE
SqlServerNetwork: Add PsDscRunAsCredential parameter to examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change log for SqlServerDsc
 
 ## Unreleased
+- Changes to xSQLServerNetwork
+  - added parameter sysadmin account to the example
 
 - Changes to SqlAlias
   - Fixed issue where exception was thrown if reg keys did not exist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 - Changes to xSQLServerNetwork
-  - added parameter sysadmin account to the example
+  - added sysadmin account parameter usage to the examples
 
 - Changes to SqlAlias
   - Fixed issue where exception was thrown if reg keys did not exist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log for SqlServerDsc
 
 ## Unreleased
+
 - Changes to xSQLServerNetwork
   - added sysadmin account parameter usage to the examples
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,11 @@
 
 ## Unreleased
 
-- Changes to xSQLServerNetwork
-  - added sysadmin account parameter usage to the examples
-
 - Changes to SqlAlias
   - Fixed issue where exception was thrown if reg keys did not exist
     ([issue #949](https://github.com/PowerShell/SqlServerDsc/issues/949)).
+- Changes to SqlServerNetwork
+  - Added sysadmin account parameter usage to the examples.
 - Changes to SqlServiceAccount
   - Default services are now properly detected
     ([issue #930](https://github.com/PowerShell/SqlServerDsc/issues/930)).

--- a/Examples/Resources/SqlServerNetwork/1-EnableTcpIpWithStaticPort.ps1
+++ b/Examples/Resources/SqlServerNetwork/1-EnableTcpIpWithStaticPort.ps1
@@ -19,12 +19,13 @@ Configuration Example
     {
         SqlServerNetwork 'ChangeTcpIpOnDefaultInstance'
         {
-            InstanceName   = 'MSSQLSERVER'
-            ProtocolName   = 'Tcp'
-            IsEnabled      = $true
-            TCPDynamicPort = $false
-            TCPPort        = 4509
-            RestartService = $true
+            InstanceName         = 'MSSQLSERVER'
+            ProtocolName         = 'Tcp'
+            IsEnabled            = $true
+            TCPDynamicPort       = $false
+            TCPPort              = 4509
+            RestartService       = $true
+            PsDscRunAsCredential = $SysAdminAccount
         }
     }
 }

--- a/Examples/Resources/SqlServerNetwork/1-EnableTcpIpWithStaticPort.ps1
+++ b/Examples/Resources/SqlServerNetwork/1-EnableTcpIpWithStaticPort.ps1
@@ -2,6 +2,7 @@
 .EXAMPLE
     This example will enable TCP/IP protocol and set the custom static port to 4509.
     When RestartService is set to $true the resource will also restart the SQL service.
+    The resource will be run as the account provided in $SystemAdministratorAccount.
 #>
 Configuration Example
 {
@@ -10,7 +11,7 @@ Configuration Example
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SystemAdministratorAccount
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -25,7 +26,7 @@ Configuration Example
             TCPDynamicPort       = $false
             TCPPort              = 4509
             RestartService       = $true
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SystemAdministratorAccount
         }
     }
 }

--- a/Examples/Resources/SqlServerNetwork/2-EnableTcpIpWithDynamicPort.ps1
+++ b/Examples/Resources/SqlServerNetwork/2-EnableTcpIpWithDynamicPort.ps1
@@ -2,6 +2,7 @@
 .EXAMPLE
     This example will enable TCP/IP protocol and set the custom static port to 4509.
     When RestartService is set to $true the resource will also restart the SQL service.
+    The resource will be run as the account provided in $SystemAdministratorAccount.
 #>
 Configuration Example
 {
@@ -10,7 +11,7 @@ Configuration Example
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SystemAdministratorAccount
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -24,7 +25,7 @@ Configuration Example
             IsEnabled            = $true
             TCPDynamicPort       = $true
             RestartService       = $true
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SystemAdministratorAccount
         }
     }
 }

--- a/Examples/Resources/SqlServerNetwork/2-EnableTcpIpWithDynamicPort.ps1
+++ b/Examples/Resources/SqlServerNetwork/2-EnableTcpIpWithDynamicPort.ps1
@@ -19,11 +19,12 @@ Configuration Example
     {
         SqlServerNetwork 'ChangeTcpIpOnDefaultInstance'
         {
-            InstanceName   = 'MSSQLSERVER'
-            ProtocolName   = 'Tcp'
-            IsEnabled      = $true
-            TCPDynamicPort = $true
-            RestartService = $true
+            InstanceName         = 'MSSQLSERVER'
+            ProtocolName         = 'Tcp'
+            IsEnabled            = $true
+            TCPDynamicPort       = $true
+            RestartService       = $true
+            PsDscRunAsCredential = $SysAdminAccount
         }
     }
 }


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to SqlServerNetwork
  - Added sysadmin account parameter usage to the examples.

***Note:** This continues the work that @pesetskyps started in PR #840.*

**This Pull Request (PR) fixes the following issues:**
None

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/963)
<!-- Reviewable:end -->
