### PR TITLE
xSQLServer: Named parameters for New-Object cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Changes to SqlServer
+  - Updated so that named parameters are used for New-Object cmdlet. This was
+    done to follow the style guideline.
 - Changes to SqlAlias
   - Fixed issue where exception was thrown if reg keys did not exist
     ([issue #949](https://github.com/PowerShell/SqlServerDsc/issues/949)).

--- a/Tests/Unit/MSFT_SqlAGListener.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAGListener.Tests.ps1
@@ -56,26 +56,26 @@ try
 
         $mockConnectSql = {
             return New-Object -TypeName Object |
-                Add-Member ScriptProperty AvailabilityGroups {
+                Add-Member -MemberType ScriptProperty -Name AvailabilityGroups -Value {
                 return @(
                     @{
                         $mockDynamicAvailabilityGroup = New-Object -TypeName Object |
-                            Add-Member ScriptProperty AvailabilityGroupListeners {
+                            Add-Member -MemberType ScriptProperty -Name AvailabilityGroupListeners -Value {
                             @(
                                 @{
                                     $mockDynamicListenerName = New-Object -TypeName Object |
-                                        Add-Member NoteProperty PortNumber $mockDynamicPortNumber -PassThru |
-                                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                                        Add-Member -MemberType NoteProperty -Name PortNumber -Value $mockDynamicPortNumber -PassThru |
+                                        Add-Member -MemberType ScriptProperty -Name AvailabilityGroupListenerIPAddresses -Value {
                                         return @(
                                             # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
                                             (New-Object -TypeName Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                                    Add-Member NoteProperty IsDHCP $mockDynamicIsDhcp -PassThru |
-                                                    Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                                                    Add-Member -MemberType NoteProperty -Name IsDHCP -Value $mockDynamicIsDhcp -PassThru |
+                                                    Add-Member -MemberType NoteProperty -Name IPAddress -Value '192.168.0.1' -PassThru |
+                                                    Add-Member -MemberType NoteProperty -Name SubnetMask -Value '255.255.255.0' -PassThru
                                             )
                                         )
                                     } -PassThru |
-                                        Add-Member ScriptMethod Drop {
+                                        Add-Member -MemberType ScriptMethod -Name Drop -Value {
                                         $script:mockMethodDropRan = $true
                                     } -PassThru -Force
                                 }
@@ -249,14 +249,14 @@ try
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                     return New-Object -TypeName Object |
-                        Add-Member NoteProperty PortNumber 5030 -PassThru |
-                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                        Add-Member -MemberType NoteProperty -Name PortNumber -Value 5030 -PassThru |
+                        Add-Member -MemberType ScriptProperty -Name AvailabilityGroupListenerIPAddresses -Value {
                         return @(
                             # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
                             (New-Object -TypeName Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                    Add-Member NoteProperty IsDHCP $false -PassThru |
-                                    Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                                    Add-Member -MemberType NoteProperty -Name IsDHCP -Value $false -PassThru |
+                                    Add-Member -MemberType NoteProperty -Name IPAddress -Value '192.168.0.1' -PassThru |
+                                    Add-Member -MemberType NoteProperty -Name SubnetMask -Value '255.255.255.0' -PassThru
                             )
                         )
                     } -PassThru -Force
@@ -307,14 +307,14 @@ try
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                     return New-Object -TypeName Object |
-                        Add-Member NoteProperty PortNumber 5555 -PassThru |
-                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                        Add-Member -MemberType NoteProperty -Name PortNumber -Value 5555 -PassThru |
+                        Add-Member -MemberType ScriptProperty -Name AvailabilityGroupListenerIPAddresses -Value {
                         return @(
                             # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
                             (New-Object -TypeName Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                    Add-Member NoteProperty IsDHCP $false -PassThru |
-                                    Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                                    Add-Member -MemberType NoteProperty -Name IsDHCP -Value $false -PassThru |
+                                    Add-Member -MemberType NoteProperty -Name IPAddress -Value '192.168.0.1' -PassThru |
+                                    Add-Member -MemberType NoteProperty -Name SubnetMask -Value '255.255.255.0' -PassThru
                             )
                         )
                     } -PassThru -Force
@@ -337,14 +337,14 @@ try
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                     return New-Object -TypeName Object |
-                        Add-Member NoteProperty PortNumber 5030 -PassThru |
-                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                        Add-Member -MemberType NoteProperty -Name PortNumber -Value 5030 -PassThru |
+                        Add-Member -MemberType ScriptProperty -Name AvailabilityGroupListenerIPAddresses -Value {
                         return @(
                             # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
                             (New-Object -TypeName Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                    Add-Member NoteProperty IsDHCP $true -PassThru |
-                                    Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                                    Add-Member -MemberType NoteProperty -Name IsDHCP -Value $true -PassThru |
+                                    Add-Member -MemberType NoteProperty -Name IPAddress -Value '192.168.0.1' -PassThru |
+                                    Add-Member -MemberType NoteProperty -Name SubnetMask -Value '255.255.255.0' -PassThru
                             )
                         )
                     } -PassThru -Force
@@ -374,14 +374,14 @@ try
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                     return New-Object -TypeName Object |
-                        Add-Member NoteProperty PortNumber 5555 -PassThru |
-                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                        Add-Member -MemberType NoteProperty -Name PortNumber -Value 5555 -PassThru |
+                        Add-Member -MemberType ScriptProperty -Name AvailabilityGroupListenerIPAddresses -Value {
                         return @(
                             # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
                             (New-Object -TypeName Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                    Add-Member NoteProperty IsDHCP $true -PassThru |
-                                    Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                                    Add-Member -MemberType NoteProperty -Name IsDHCP -Value $true -PassThru |
+                                    Add-Member -MemberType NoteProperty -Name IPAddress -Value '192.168.0.1' -PassThru |
+                                    Add-Member -MemberType NoteProperty -Name SubnetMask -Value '255.255.255.0' -PassThru
                             )
                         )
                     } -PassThru -Force
@@ -415,14 +415,14 @@ try
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                     return New-Object -TypeName Object |
-                        Add-Member NoteProperty PortNumber 5030 -PassThru |
-                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                        Add-Member -MemberType NoteProperty -Name PortNumber -Value 5030 -PassThru |
+                        Add-Member -MemberType ScriptProperty -Name AvailabilityGroupListenerIPAddresses -Value {
                         return @(
                             # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
                             (New-Object -TypeName Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                    Add-Member NoteProperty IsDHCP $false -PassThru |
-                                    Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                                    Add-Member -MemberType NoteProperty -Name IsDHCP -Value $false -PassThru |
+                                    Add-Member -MemberType NoteProperty -Name IPAddress -Value '192.168.0.1' -PassThru |
+                                    Add-Member -MemberType NoteProperty -Name SubnetMask -Value '255.255.255.0' -PassThru
                             )
                         )
                     } -PassThru -Force
@@ -463,14 +463,14 @@ try
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                     return New-Object -TypeName Object |
-                        Add-Member NoteProperty PortNumber 5030 -PassThru |
-                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                        Add-Member -MemberType NoteProperty -Name PortNumber -Value 5030 -PassThru |
+                        Add-Member -MemberType ScriptProperty -Name AvailabilityGroupListenerIPAddresses -Value {
                         return @(
                             # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
                             (New-Object -TypeName Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                    Add-Member NoteProperty IsDHCP $true -PassThru |
-                                    Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                                    Add-Member -MemberType NoteProperty -Name IsDHCP -Value $true -PassThru |
+                                    Add-Member -MemberType NoteProperty -Name IPAddress -Value '192.168.0.1' -PassThru |
+                                    Add-Member -MemberType NoteProperty -Name SubnetMask -Value '255.255.255.0' -PassThru
                             )
                         )
                     } -PassThru -Force

--- a/Tests/Unit/MSFT_SqlAGListener.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAGListener.Tests.ps1
@@ -55,20 +55,20 @@ try
         $script:mockMethodDropRan = $false
 
         $mockConnectSql = {
-            return New-Object Object |
+            return New-Object -TypeName Object |
                 Add-Member ScriptProperty AvailabilityGroups {
                 return @(
                     @{
-                        $mockDynamicAvailabilityGroup = New-Object Object |
+                        $mockDynamicAvailabilityGroup = New-Object -TypeName Object |
                             Add-Member ScriptProperty AvailabilityGroupListeners {
                             @(
                                 @{
-                                    $mockDynamicListenerName = New-Object Object |
+                                    $mockDynamicListenerName = New-Object -TypeName Object |
                                         Add-Member NoteProperty PortNumber $mockDynamicPortNumber -PassThru |
                                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                                         return @(
                                             # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                            (New-Object -TypeName Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                                     Add-Member NoteProperty IsDHCP $mockDynamicIsDhcp -PassThru |
                                                     Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
                                                     Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
@@ -248,12 +248,12 @@ try
 
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-                    return New-Object Object |
+                    return New-Object -TypeName Object |
                         Add-Member NoteProperty PortNumber 5030 -PassThru |
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                         return @(
                             # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                            (New-Object -TypeName Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $false -PassThru |
                                     Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
@@ -306,12 +306,12 @@ try
 
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-                    return New-Object Object |
+                    return New-Object -TypeName Object |
                         Add-Member NoteProperty PortNumber 5555 -PassThru |
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                         return @(
                             # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                            (New-Object -TypeName Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $false -PassThru |
                                     Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
@@ -336,12 +336,12 @@ try
             Context 'When the system is not in the desired state (for DHCP)' {
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-                    return New-Object Object |
+                    return New-Object -TypeName Object |
                         Add-Member NoteProperty PortNumber 5030 -PassThru |
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                         return @(
                             # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                            (New-Object -TypeName Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $true -PassThru |
                                     Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
@@ -373,12 +373,12 @@ try
 
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-                    return New-Object Object |
+                    return New-Object -TypeName Object |
                         Add-Member NoteProperty PortNumber 5555 -PassThru |
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                         return @(
                             # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                            (New-Object -TypeName Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $true -PassThru |
                                     Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
@@ -414,12 +414,12 @@ try
 
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-                    return New-Object Object |
+                    return New-Object -TypeName Object |
                         Add-Member NoteProperty PortNumber 5030 -PassThru |
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                         return @(
                             # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                            (New-Object -TypeName Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $false -PassThru |
                                     Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
@@ -462,12 +462,12 @@ try
             Context 'When the system is in the desired state (for DHCP)' {
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-                    return New-Object Object |
+                    return New-Object -TypeName Object |
                         Add-Member NoteProperty PortNumber 5030 -PassThru |
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                         return @(
                             # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                            (New-Object -TypeName Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $true -PassThru |
                                     Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru

--- a/Tests/Unit/MSFT_SqlAlias.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAlias.Tests.ps1
@@ -98,7 +98,7 @@ try
 
         # Mocking 64-bit OS
         Mock -CommandName Get-CimInstance -MockWith {
-            return New-Object Object |
+            return New-Object -TypeName Object |
                 Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '64-bit' -PassThru -Force
         } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -290,7 +290,7 @@ try
 
             # Mocking 64-bit OS
             Mock -CommandName Get-CimInstance -MockWith {
-                return New-Object Object |
+                return New-Object -TypeName Object |
                     Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '64-bit' -PassThru -Force
             } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -335,7 +335,7 @@ try
 
         # Mocking 32-bit OS
         Mock -CommandName Get-CimInstance -MockWith {
-            return New-Object Object |
+            return New-Object -TypeName Object |
                 Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '32-bit' -PassThru -Force
         } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -518,7 +518,7 @@ try
 
         # Mocking 64-bit OS
         Mock -CommandName Get-CimInstance -MockWith {
-            return New-Object Object |
+            return New-Object -TypeName Object |
                 Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '64-bit' -PassThru -Force
         } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -647,7 +647,7 @@ try
 
         # Mocking 32-bit OS
         Mock -CommandName Get-CimInstance -MockWith {
-            return New-Object Object |
+            return New-Object -TypeName Object |
                 Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '32-bit' -PassThru -Force
         } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -696,7 +696,7 @@ try
 
         # Mocking 64-bit OS
         Mock -CommandName Get-CimInstance -MockWith {
-            return New-Object Object |
+            return New-Object -TypeName Object |
                 Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '64-bit' -PassThru -Force
         } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -760,7 +760,7 @@ try
 
         # Mocking 32-bit OS
         Mock -CommandName Get-CimInstance -MockWith {
-            return New-Object Object |
+            return New-Object -TypeName Object |
                 Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '32-bit' -PassThru -Force
         } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -839,7 +839,7 @@ try
 
         # Mocking 64-bit OS
         Mock -CommandName Get-CimInstance -MockWith {
-            return New-Object Object |
+            return New-Object -TypeName Object |
                 Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '64-bit' -PassThru -Force
         } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -941,7 +941,7 @@ try
 
         # Mocking 32-bit OS
         Mock -CommandName Get-CimInstance -MockWith {
-            return New-Object Object |
+            return New-Object -TypeName Object |
                 Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '32-bit' -PassThru -Force
         } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -1063,7 +1063,7 @@ try
 
         # Mocking 64-bit OS
         Mock -CommandName Get-CimInstance -MockWith {
-            return New-Object Object |
+            return New-Object -TypeName Object |
                 Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '64-bit' -PassThru -Force
         } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
 

--- a/Tests/Unit/MSFT_SqlAlwaysOnService.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAlwaysOnService.Tests.ps1
@@ -45,7 +45,7 @@ try
     Describe "$($script:DSCResourceName)\Get-TargetResource" {
         Context 'When HADR is disabled' {
             Mock -CommandName Connect-SQL -MockWith {
-                return New-Object PSObject -Property @{
+                return New-Object -TypeName PSObject -Property @{
                     IsHadrEnabled = $false
                 }
             } -ModuleName $script:DSCResourceName -Verifiable
@@ -69,7 +69,7 @@ try
 
         Context 'When HADR is enabled' {
             Mock -CommandName Connect-SQL -MockWith {
-                return New-Object PSObject -Property @{
+                return New-Object -TypeName PSObject -Property @{
                     IsHadrEnabled = $true
                 }
             } -ModuleName $script:DSCResourceName -Verifiable
@@ -94,7 +94,7 @@ try
         # This it regression test for issue #519.
         Context 'When Server.IsHadrEnabled returns $null' {
             Mock -CommandName Connect-SQL -MockWith {
-                return New-Object PSObject -Property @{
+                return New-Object -TypeName PSObject -Property @{
                     IsHadrEnabled = $null
                 }
             } -ModuleName $script:DSCResourceName -Verifiable
@@ -125,7 +125,7 @@ try
         Context 'When HADR is not in the desired state' {
             It 'Should enable SQL Always On when Ensure is set to Present' {
                 Mock -CommandName Connect-SQL -MockWith {
-                    return New-Object PSObject -Property @{
+                    return New-Object -TypeName PSObject -Property @{
                         IsHadrEnabled = $true
                     }
                 } -ModuleName $script:DSCResourceName -Verifiable
@@ -139,7 +139,7 @@ try
 
             It 'Should disable SQL Always On when Ensure is set to Absent' {
                 Mock -CommandName Connect-SQL -MockWith {
-                    return New-Object PSObject -Property @{
+                    return New-Object -TypeName PSObject -Property @{
                         IsHadrEnabled = $false
                     }
                 } -ModuleName $script:DSCResourceName -Verifiable
@@ -153,7 +153,7 @@ try
 
             It 'Should enable SQL Always On on a named instance when Ensure is set to Present' {
                 Mock -CommandName Connect-SQL -MockWith {
-                    return New-Object PSObject -Property @{
+                    return New-Object -TypeName PSObject -Property @{
                         IsHadrEnabled = $true
                     }
                 } -ModuleName $script:DSCResourceName -Verifiable
@@ -167,7 +167,7 @@ try
 
             It 'Should disable SQL Always On on a named instance when Ensure is set to Absent' {
                 Mock -CommandName Connect-SQL -MockWith {
-                    return New-Object PSObject -Property @{
+                    return New-Object -TypeName PSObject -Property @{
                         IsHadrEnabled = $false
                     }
                 } -ModuleName $script:DSCResourceName -Verifiable
@@ -181,7 +181,7 @@ try
 
             It 'Should throw the correct error message when Ensure is set to Present, but IsHadrEnabled is $false' {
                 Mock -CommandName Connect-SQL -MockWith {
-                    return New-Object PSObject -Property @{
+                    return New-Object -TypeName PSObject -Property @{
                         IsHadrEnabled = $false
                     }
                 } -ModuleName $script:DSCResourceName -Verifiable
@@ -196,7 +196,7 @@ try
 
             It 'Should throw the correct error message when Ensure is set to Absent, but IsHadrEnabled is $true' {
                 Mock -CommandName Connect-SQL -MockWith {
-                    return New-Object PSObject -Property @{
+                    return New-Object -TypeName PSObject -Property @{
                         IsHadrEnabled = $true
                     }
                 } -ModuleName $script:DSCResourceName -Verifiable
@@ -214,7 +214,7 @@ try
     Describe "$($script:DSCResourceName)\Test-TargetResource" {
         Context 'When HADR is not in the desired state' {
             Mock -CommandName Connect-SQL -MockWith {
-                return New-Object PSObject -Property @{
+                return New-Object -TypeName PSObject -Property @{
                     IsHadrEnabled = $true
                 }
             } -ModuleName $script:DSCResourceName -Verifiable
@@ -226,7 +226,7 @@ try
 
         Context 'When HADR is in the desired state' {
             Mock -CommandName Connect-SQL -MockWith {
-                return New-Object PSObject -Property @{
+                return New-Object -TypeName PSObject -Property @{
                     IsHadrEnabled = $true
                 }
             } -ModuleName $script:DSCResourceName -Verifiable

--- a/Tests/Unit/MSFT_SqlDatabase.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabase.Tests.ps1
@@ -57,26 +57,26 @@ try
         $mockConnectSQL = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockInstanceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockServerName -PassThru |
                         Add-Member -MemberType NoteProperty -Name Collation -Value $mockSqlDatabaseCollation -PassThru |
                         Add-Member -MemberType ScriptMethod -Name EnumCollations -Value {
                         return @(
-                            ( New-Object Object |
+                            ( New-Object -TypeName Object |
                                     Add-Member -MemberType NoteProperty Name -Value $mockSqlDatabaseCollation -PassThru
                             ),
-                            ( New-Object Object |
+                            ( New-Object -TypeName Object |
                                     Add-Member -MemberType NoteProperty Name -Value 'SQL_Latin1_General_CP1_CS_AS' -PassThru
                             ),
-                            ( New-Object Object |
+                            ( New-Object -TypeName Object |
                                     Add-Member -MemberType NoteProperty Name -Value 'SQL_Latin1_General_Pref_CP850_CI_AS' -PassThru
                             )
                         )
                     } -PassThru -Force |
                         Add-Member -MemberType ScriptProperty -Name Databases -Value {
                         return @{
-                            $mockSqlDatabaseName = ( New-Object Object |
+                            $mockSqlDatabaseName = ( New-Object -TypeName Object |
                                     Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlDatabaseName -PassThru |
                                     Add-Member -MemberType NoteProperty -Name Collation -Value $mockSqlDatabaseCollation -PassThru |
                                     Add-Member -MemberType ScriptMethod -Name Drop -Value {
@@ -107,7 +107,7 @@ try
         $mockNewObjectDatabase = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlDatabaseName -PassThru |
                         Add-Member -MemberType NoteProperty -Name Collation -Value '' -PassThru |
                         Add-Member -MemberType ScriptMethod -Name Create -Value {

--- a/Tests/Unit/MSFT_SqlDatabaseDefaultLocation.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabaseDefaultLocation.Tests.ps1
@@ -64,7 +64,7 @@ try
         }
 
         $mockConnectSQL = {
-            return New-Object Object -TypeName Microsoft.SqlServer.Management.Smo.Server |
+            return New-Object -TypeName Object -TypeName Microsoft.SqlServer.Management.Smo.Server |
                 Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockInstanceName -PassThru -Force |
                 Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockServerName -PassThru -Force |
                 Add-Member -MemberType NoteProperty -Name DefaultFile -Value $mockSqlDataPath -PassThru -Force |

--- a/Tests/Unit/MSFT_SqlDatabaseDefaultLocation.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabaseDefaultLocation.Tests.ps1
@@ -64,7 +64,7 @@ try
         }
 
         $mockConnectSQL = {
-            return New-Object -TypeName Object -TypeName Microsoft.SqlServer.Management.Smo.Server |
+            return New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server |
                 Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockInstanceName -PassThru -Force |
                 Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockServerName -PassThru -Force |
                 Add-Member -MemberType NoteProperty -Name DefaultFile -Value $mockSqlDataPath -PassThru -Force |

--- a/Tests/Unit/MSFT_SqlDatabaseOwner.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabaseOwner.Tests.ps1
@@ -54,13 +54,13 @@ try
         $mockConnectSQL = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockInstanceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockServerName -PassThru |
                         Add-Member -MemberType ScriptProperty -Name Databases -Value {
                         return @{
                             $mockSqlDatabaseName = @((
-                                    New-Object Object |
+                                    New-Object -TypeName Object |
                                         Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlDatabaseName -PassThru |
                                         Add-Member -MemberType NoteProperty -Name Owner -Value $mockDatabaseOwner -PassThru |
                                         Add-Member -MemberType ScriptMethod -Name SetOwner -Value {
@@ -81,7 +81,7 @@ try
                         Add-Member -MemberType ScriptProperty -Name Logins -Value {
                         return @{
                             $mockSqlServerLogin = @((
-                                    New-Object Object |
+                                    New-Object -TypeName Object |
                                         Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru
                                 ))
                         }

--- a/Tests/Unit/MSFT_SqlDatabasePermission.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabasePermission.Tests.ps1
@@ -66,18 +66,18 @@ try
         $mockConnectSQL = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockInstanceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockServerName -PassThru |
                         Add-Member -MemberType ScriptProperty -Name Databases -Value {
                         return @{
                             $mockSqlDatabaseName = @((
-                                    New-Object Object |
+                                    New-Object -TypeName Object |
                                         Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlDatabaseName -PassThru |
                                         Add-Member -MemberType ScriptProperty -Name Users -Value {
                                         return @{
                                             $mockSqlServerLogin = @((
-                                                    New-Object Object |
+                                                    New-Object -TypeName Object |
                                                         Add-Member -MemberType ScriptMethod -Name IsMember -Value {
                                                         return $true
                                                     } -PassThru
@@ -99,14 +99,14 @@ try
                                         if ( $SqlServerLogin -eq $mockExpectedSqlServerLogin )
                                         {
                                             $mockEnumDatabasePermissions = @()
-                                            $mockEnumDatabasePermissions += New-Object Object |
+                                            $mockEnumDatabasePermissions += New-Object -TypeName Object |
                                                 Add-Member -MemberType NoteProperty -Name PermissionType -Value $mockSqlPermissionType01 -PassThru |
                                                 Add-Member -MemberType NoteProperty -Name PermissionState -Value $mockSqlPermissionState -PassThru |
                                                 Add-Member -MemberType NoteProperty -Name Grantee -Value $mockExpectedSqlServerLogin -PassThru |
                                                 Add-Member -MemberType NoteProperty -Name GrantorType -Value 'User' -PassThru |
                                                 Add-Member -MemberType NoteProperty -Name ObjectClass -Value 'Database' -PassThru |
                                                 Add-Member -MemberType NoteProperty -Name ObjectName -Value $mockSqlDatabaseName -PassThru
-                                            $mockEnumDatabasePermissions += New-Object Object |
+                                            $mockEnumDatabasePermissions += New-Object -TypeName Object |
                                                 Add-Member -MemberType NoteProperty -Name PermissionType -Value $mockSqlPermissionType02 -PassThru |
                                                 Add-Member -MemberType NoteProperty -Name PermissionState -Value $mockSqlPermissionState -PassThru |
                                                 Add-Member -MemberType NoteProperty -Name Grantee -Value $mockExpectedSqlServerLogin -PassThru |
@@ -187,11 +187,11 @@ try
                         Add-Member -MemberType ScriptProperty -Name Logins -Value {
                         return @{
                             $mockSqlServerLogin        = @((
-                                    New-Object Object |
+                                    New-Object -TypeName Object |
                                         Add-Member -MemberType NoteProperty -Name LoginType -Value $mockLoginType -PassThru
                                 ))
                             $mockSqlServerLoginUnknown = @((
-                                    New-Object Object |
+                                    New-Object -TypeName Object |
                                         Add-Member -MemberType NoteProperty -Name LoginType -Value $mockLoginType -PassThru
                                 ))
                         }
@@ -203,7 +203,7 @@ try
         $mockNewObjectUser = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlServerLoginUnknown -PassThru |
                         Add-Member -MemberType NoteProperty -Name Login -Value $mockSqlServerLoginUnknown -PassThru |
                         Add-Member -MemberType ScriptMethod -Name Create -Value {

--- a/Tests/Unit/MSFT_SqlDatabaseRecoveryModel.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabaseRecoveryModel.Tests.ps1
@@ -51,12 +51,12 @@ try
         $mockConnectSQL = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockInstanceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockServerName -PassThru |
                         Add-Member -MemberType ScriptProperty -Name Databases -Value {
                         return @{
-                            $mockSqlDatabaseName = ( New-Object Object |
+                            $mockSqlDatabaseName = ( New-Object -TypeName Object |
                                     Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlDatabaseName -PassThru |
                                     Add-Member -MemberType NoteProperty -Name RecoveryModel -Value $mockSqlDatabaseRecoveryModel -PassThru |
                                     Add-Member -MemberType ScriptMethod -Name Alter -Value {

--- a/Tests/Unit/MSFT_SqlDatabaseRole.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabaseRole.Tests.ps1
@@ -64,18 +64,18 @@ try
         $mockConnectSQL = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockInstanceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockServerName -PassThru |
                         Add-Member -MemberType ScriptProperty -Name Databases -Value {
                         return @{
                             $mockSqlDatabaseName = @((
-                                    New-Object Object |
+                                    New-Object -TypeName Object |
                                         Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlDatabaseName -PassThru |
                                         Add-Member -MemberType ScriptProperty -Name Users -Value {
                                         return @{
                                             $mockSqlServerLoginOne = @((
-                                                    New-Object Object |
+                                                    New-Object -TypeName Object |
                                                         Add-Member -MemberType ScriptMethod -Name IsMember -Value {
                                                         param(
                                                             [String]
@@ -92,7 +92,7 @@ try
                                                     } -PassThru
                                                 ))
                                             $mockSqlServerLoginTwo = @((
-                                                    New-Object Object |
+                                                    New-Object -TypeName Object |
                                                         Add-Member -MemberType ScriptMethod -Name IsMember -Value {
                                                         return $true
                                                     } -PassThru
@@ -102,7 +102,7 @@ try
                                         Add-Member -MemberType ScriptProperty -Name Roles -Value {
                                         return @{
                                             $mockSqlDatabaseRole       = @((
-                                                    New-Object Object |
+                                                    New-Object -TypeName Object |
                                                         Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlDatabaseRole -PassThru |
                                                         Add-Member -MemberType ScriptMethod -Name AddMember -Value {
                                                         param(
@@ -136,7 +136,7 @@ try
                                                     } -PassThru
                                                 ))
                                             $mockSqlDatabaseRoleSecond = @((
-                                                    New-Object Object |
+                                                    New-Object -TypeName Object |
                                                         Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlDatabaseRoleSecond -PassThru |
                                                         Add-Member -MemberType ScriptMethod -Name AddMember -Value {
                                                         param(
@@ -177,15 +177,15 @@ try
                         Add-Member -MemberType ScriptProperty -Name Logins -Value {
                         return @{
                             $mockSqlServerLoginOne = @((
-                                    New-Object Object |
+                                    New-Object -TypeName Object |
                                         Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru
                                 ))
                             $mockSqlServerLoginTwo = @((
-                                    New-Object Object |
+                                    New-Object -TypeName Object |
                                         Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru
                                 ))
                             $mockSqlServerLogin    = @((
-                                    New-Object Object |
+                                    New-Object -TypeName Object |
                                         Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru
                                 ))
                         }
@@ -198,7 +198,7 @@ try
         $mockNewObjectUser = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlServerLogin -PassThru |
                         Add-Member -MemberType NoteProperty -Name Login -Value $mockSqlServerLogin -PassThru |
                         Add-Member -MemberType ScriptMethod -Name Create -Value {

--- a/Tests/Unit/MSFT_SqlRS.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlRS.Tests.ps1
@@ -60,7 +60,7 @@ try
         $mockGetWmiObject_ConfigurationSetting_NamedInstance = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'DatabaseServerName' -Value "$mockReportingServicesDatabaseServerName\$mockReportingServicesDatabaseNamedInstanceName" -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'IsInitialized' -Value $mockDynamicIsInitialized -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'InstanceName' -Value $mockNamedInstanceName -PassThru |
@@ -108,7 +108,7 @@ try
                         Add-Member -MemberType ScriptMethod -Name ListReservedUrls {
                         $script:mockIsMethodCalled_ListReservedUrls = $true
 
-                        return New-Object Object |
+                        return New-Object -TypeName Object |
                             Add-Member -MemberType ScriptProperty -Name 'Application' {
                             return @(
                                 $mockDynamicReportServerApplicationName,
@@ -125,7 +125,7 @@ try
                 ),
                 (
                     # Array is a regression test for issue #819.
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'DatabaseServerName' -Value "$mockReportingServicesDatabaseServerName\$mockReportingServicesDatabaseNamedInstanceName" -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'IsInitialized' -Value $true -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'InstanceName' -Value 'DummyInstance' -PassThru -Force
@@ -134,7 +134,7 @@ try
         }
 
         $mockGetWmiObject_ConfigurationSetting_DefaultInstance = {
-            return New-Object Object |
+            return New-Object -TypeName Object |
                 Add-Member -MemberType NoteProperty -Name 'DatabaseServerName' -Value "$mockReportingServicesDatabaseServerName" -PassThru |
                 Add-Member -MemberType NoteProperty -Name 'IsInitialized' -Value $false -PassThru |
                 Add-Member -MemberType NoteProperty -Name 'InstanceName' -Value $mockDefaultInstanceName -PassThru |

--- a/Tests/Unit/MSFT_SqlRS.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlRS.Tests.ps1
@@ -66,56 +66,56 @@ try
                         Add-Member -MemberType NoteProperty -Name 'InstanceName' -Value $mockNamedInstanceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'VirtualDirectoryReportServer' -Value $mockVirtualDirectoryReportServerName -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'VirtualDirectoryReportManager' -Value $mockVirtualDirectoryReportManagerName -PassThru |
-                        Add-Member -MemberType ScriptMethod -Name SetVirtualDirectory {
+                        Add-Member -MemberType ScriptMethod -Name SetVirtualDirectory -Value {
                         $script:mockIsMethodCalled_SetVirtualDirectory = $true
 
                         return $null
                     } -PassThru |
-                        Add-Member -MemberType ScriptMethod -Name ReserveURL {
+                        Add-Member -MemberType ScriptMethod -Name ReserveURL -Value {
                         $script:mockIsMethodCalled_ReserveURL = $true
 
                         return $null
                     } -PassThru |
-                        Add-Member -MemberType ScriptMethod -Name GenerateDatabaseCreationScript {
+                        Add-Member -MemberType ScriptMethod -Name GenerateDatabaseCreationScript -Value {
                         $script:mockIsMethodCalled_GenerateDatabaseCreationScript = $true
 
                         return @{
                             Script = 'select * from something'
                         }
                     } -PassThru |
-                        Add-Member -MemberType ScriptMethod -Name GenerateDatabaseRightsScript {
+                        Add-Member -MemberType ScriptMethod -Name GenerateDatabaseRightsScript -Value {
                         $script:mockIsMethodCalled_GenerateDatabaseRightsScript = $true
 
                         return @{
                             Script = 'select * from something'
                         }
                     } -PassThru |
-                        Add-Member -MemberType ScriptMethod -Name SetDatabaseConnection {
+                        Add-Member -MemberType ScriptMethod -Name SetDatabaseConnection -Value {
                         $script:mockIsMethodCalled_SetDatabaseConnection = $true
 
                         return $null
                     } -PassThru |
-                        Add-Member -MemberType ScriptMethod -Name InitializeReportServer {
+                        Add-Member -MemberType ScriptMethod -Name InitializeReportServer -Value {
                         $script:mockIsMethodCalled_InitializeReportServer = $true
 
                         return $null
                     } -PassThru |
-                        Add-Member -MemberType ScriptMethod -Name RemoveURL {
+                        Add-Member -MemberType ScriptMethod -Name RemoveURL -Value {
                         $script:mockIsMethodCalled_RemoveURL = $true
 
                         return $null
                     } -PassThru |
-                        Add-Member -MemberType ScriptMethod -Name ListReservedUrls {
+                        Add-Member -MemberType ScriptMethod -Name ListReservedUrls -Value {
                         $script:mockIsMethodCalled_ListReservedUrls = $true
 
                         return New-Object -TypeName Object |
-                            Add-Member -MemberType ScriptProperty -Name 'Application' {
+                            Add-Member -MemberType ScriptProperty -Name 'Application' -Value {
                             return @(
                                 $mockDynamicReportServerApplicationName,
                                 $mockDynamicReportsApplicationName
                             )
                         } -PassThru |
-                            Add-Member -MemberType ScriptProperty -Name 'UrlString' {
+                            Add-Member -MemberType ScriptProperty -Name 'UrlString' -Value {
                             return @(
                                 $mockDynamicReportsApplicationUrlString,
                                 $mockDynamicReportServerApplicationUrlString
@@ -140,36 +140,36 @@ try
                 Add-Member -MemberType NoteProperty -Name 'InstanceName' -Value $mockDefaultInstanceName -PassThru |
                 Add-Member -MemberType NoteProperty -Name 'VirtualDirectoryReportServer' -Value '' -PassThru |
                 Add-Member -MemberType NoteProperty -Name 'VirtualDirectoryReportManager' -Value '' -PassThru |
-                Add-Member -MemberType ScriptMethod -Name SetVirtualDirectory {
+                Add-Member -MemberType ScriptMethod -Name SetVirtualDirectory -Value {
                 $script:mockIsMethodCalled_SetVirtualDirectory = $true
 
                 return $null
             } -PassThru |
-                Add-Member -MemberType ScriptMethod -Name ReserveURL {
+                Add-Member -MemberType ScriptMethod -Name ReserveURL -Value {
                 $script:mockIsMethodCalled_ReserveURL = $true
 
                 return $null
             } -PassThru |
-                Add-Member -MemberType ScriptMethod -Name GenerateDatabaseCreationScript {
+                Add-Member -MemberType ScriptMethod -Name GenerateDatabaseCreationScript -Value {
                 $script:mockIsMethodCalled_GenerateDatabaseCreationScript = $true
 
                 return @{
                     Script = 'select * from something'
                 }
             } -PassThru |
-                Add-Member -MemberType ScriptMethod -Name GenerateDatabaseRightsScript {
+                Add-Member -MemberType ScriptMethod -Name GenerateDatabaseRightsScript -Value {
                 $script:mockIsMethodCalled_GenerateDatabaseRightsScript = $true
 
                 return @{
                     Script = 'select * from something'
                 }
             } -PassThru |
-                Add-Member -MemberType ScriptMethod -Name SetDatabaseConnection {
+                Add-Member -MemberType ScriptMethod -Name SetDatabaseConnection -Value {
                 $script:mockIsMethodCalled_SetDatabaseConnection = $true
 
                 return $null
             } -PassThru |
-                Add-Member -MemberType ScriptMethod -Name InitializeReportServer {
+                Add-Member -MemberType ScriptMethod -Name InitializeReportServer -Value {
                 $script:mockIsMethodCalled_InitializeReportServer = $true
 
                 return $null

--- a/Tests/Unit/MSFT_SqlServerConfiguration.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerConfiguration.Tests.ps1
@@ -74,7 +74,7 @@ try
         Context 'The system is not in the desired state' {
 
             Mock -CommandName Connect-SQL -MockWith {
-                $mock = New-Object PSObject -Property @{
+                $mock = New-Object -TypeName PSObject -Property @{
                     Configuration = @{
                         Properties = @(
                             @{
@@ -111,7 +111,7 @@ try
         Context 'The system is in the desired state' {
 
             Mock -CommandName Connect-SQL -MockWith {
-                $mock = New-Object PSObject -Property @{
+                $mock = New-Object -TypeName PSObject -Property @{
                     Configuration = @{
                         Properties = @(
                             @{
@@ -148,7 +148,7 @@ try
         Context 'Invalid data is supplied' {
 
             Mock -CommandName Connect-SQL -MockWith {
-                $mock = New-Object PSObject -Property @{
+                $mock = New-Object -TypeName PSObject -Property @{
                     Configuration = @{
                         Properties = @(
                             @{
@@ -178,7 +178,7 @@ try
         Mock -CommandName New-VerboseMessage -MockWith {} -ModuleName $script:DSCResourceName
 
         Mock -CommandName Connect-SQL -MockWith {
-            $mock = New-Object PSObject -Property @{
+            $mock = New-Object -TypeName PSObject -Property @{
                 Configuration = @{
                     Properties = @(
                         @{
@@ -210,7 +210,7 @@ try
         Mock -CommandName New-TerminatingError -MockWith {} -ModuleName $script:DSCResourceName
 
         Mock -CommandName Connect-SQL -MockWith {
-            $mock = New-Object PSObject -Property @{
+            $mock = New-Object -TypeName PSObject -Property @{
                 Configuration = @{
                     Properties = @(
                         @{
@@ -229,7 +229,7 @@ try
         } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { $SQLServer -eq 'CLU01' }
 
         Mock -CommandName Connect-SQL -MockWith {
-            $mock = New-Object PSObject -Property @{
+            $mock = New-Object -TypeName PSObject -Property @{
                 Configuration = @{
                     Properties = @(
                         @{

--- a/Tests/Unit/MSFT_SqlServerEndpoint.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerEndpoint.Tests.ps1
@@ -61,22 +61,22 @@ try
 
         $mockEndpointObject = {
             # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
-            return New-Object Object |
+            return New-Object -TypeName Object |
                 Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDynamicEndpointName -PassThru |
                 Add-Member -MemberType NoteProperty -Name 'EndpointType' -Value $mockDynamicEndpointType -PassThru |
                 Add-Member -MemberType NoteProperty -Name 'ProtocolType' -Value $null -PassThru |
                 Add-Member -MemberType ScriptProperty -Name 'Protocol' {
-                    return New-Object Object |
+                    return New-Object -TypeName Object |
                         Add-Member -MemberType ScriptProperty -Name 'Tcp' {
-                            return New-Object Object |
+                            return New-Object -TypeName Object |
                                 Add-Member -MemberType NoteProperty -Name 'ListenerPort' -Value $mockDynamicEndpointListenerPort -PassThru |
                                 Add-Member -MemberType NoteProperty -Name 'ListenerIPAddress' -Value $mockDynamicEndpointListenerIpAddress -PassThru -Force
                         } -PassThru -Force
                 } -PassThru |
                 Add-Member -MemberType ScriptProperty -Name 'Payload' {
-                    return New-Object Object |
+                    return New-Object -TypeName Object |
                         Add-Member -MemberType ScriptProperty -Name 'DatabaseMirroring' {
-                            return New-Object Object |
+                            return New-Object -TypeName Object |
                                 Add-Member -MemberType NoteProperty -Name 'ServerMirroringRole' -Value $null -PassThru |
                                 Add-Member -MemberType NoteProperty -Name 'EndpointEncryption' -Value $null -PassThru |
                                 Add-Member -MemberType NoteProperty -Name 'EndpointEncryptionAlgorithm' -Value $null -PassThru -Force
@@ -115,7 +115,7 @@ try
         }
 
         $mockConnectSql = {
-            return New-Object Object |
+            return New-Object -TypeName Object |
                 Add-Member ScriptProperty Endpoints {
                     return @(
                         @{

--- a/Tests/Unit/MSFT_SqlServerEndpoint.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerEndpoint.Tests.ps1
@@ -65,24 +65,24 @@ try
                 Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDynamicEndpointName -PassThru |
                 Add-Member -MemberType NoteProperty -Name 'EndpointType' -Value $mockDynamicEndpointType -PassThru |
                 Add-Member -MemberType NoteProperty -Name 'ProtocolType' -Value $null -PassThru |
-                Add-Member -MemberType ScriptProperty -Name 'Protocol' {
+                Add-Member -MemberType ScriptProperty -Name 'Protocol' -Value {
                     return New-Object -TypeName Object |
-                        Add-Member -MemberType ScriptProperty -Name 'Tcp' {
+                        Add-Member -MemberType ScriptProperty -Name 'Tcp' -Value {
                             return New-Object -TypeName Object |
                                 Add-Member -MemberType NoteProperty -Name 'ListenerPort' -Value $mockDynamicEndpointListenerPort -PassThru |
                                 Add-Member -MemberType NoteProperty -Name 'ListenerIPAddress' -Value $mockDynamicEndpointListenerIpAddress -PassThru -Force
                         } -PassThru -Force
                 } -PassThru |
-                Add-Member -MemberType ScriptProperty -Name 'Payload' {
+                Add-Member -MemberType ScriptProperty -Name 'Payload' -Value {
                     return New-Object -TypeName Object |
-                        Add-Member -MemberType ScriptProperty -Name 'DatabaseMirroring' {
+                        Add-Member -MemberType ScriptProperty -Name 'DatabaseMirroring' -Value {
                             return New-Object -TypeName Object |
                                 Add-Member -MemberType NoteProperty -Name 'ServerMirroringRole' -Value $null -PassThru |
                                 Add-Member -MemberType NoteProperty -Name 'EndpointEncryption' -Value $null -PassThru |
                                 Add-Member -MemberType NoteProperty -Name 'EndpointEncryptionAlgorithm' -Value $null -PassThru -Force
                         } -PassThru -Force
                 } -PassThru |
-                Add-Member -MemberType ScriptMethod -Name 'Alter' {
+                Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
                     $script:mockMethodAlterRan = $true
 
                     if ( $this.Name -ne $mockExpectedNameWhenCallingMethod )
@@ -91,7 +91,7 @@ try
                                 -f $mockExpectedNameWhenCallingMethod, $this.Name
                     }
                 } -PassThru |
-                Add-Member -MemberType ScriptMethod -Name 'Drop' {
+                Add-Member -MemberType ScriptMethod -Name 'Drop' -Value {
                     $script:mockMethodDropRan = $true
 
                     if ( $this.Name -ne $mockExpectedNameWhenCallingMethod )
@@ -100,10 +100,10 @@ try
                                 -f $mockExpectedNameWhenCallingMethod, $this.Name
                     }
                 } -PassThru |
-                Add-Member -MemberType ScriptMethod -Name 'Start' {
+                Add-Member -MemberType ScriptMethod -Name 'Start' -Value {
                     $script:mockMethodStartRan = $true
                 } -PassThru |
-                Add-Member -MemberType ScriptMethod -Name 'Create' {
+                Add-Member -MemberType ScriptMethod -Name 'Create' -Value {
                     $script:mockMethodCreateRan = $true
 
                     if ( $this.Name -ne $mockExpectedNameWhenCallingMethod )
@@ -116,7 +116,7 @@ try
 
         $mockConnectSql = {
             return New-Object -TypeName Object |
-                Add-Member ScriptProperty Endpoints {
+                Add-Member -MemberType ScriptProperty -Name Endpoints -Value {
                     return @(
                         @{
                             # This executes the script block $mockEndpointObject and returns a mocked Microsoft.SqlServer.Management.Smo.Endpoint

--- a/Tests/Unit/MSFT_SqlServerEndpointPermission.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerEndpointPermission.Tests.ps1
@@ -49,17 +49,17 @@ try
         $script:mockMethodRevokeRan = $false
 
         $mockConnectSql = {
-            return New-Object Object |
+            return New-Object -TypeName Object |
                 Add-Member -MemberType ScriptProperty -Name 'Endpoints' {
                 return @(
                     @{
                         # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
-                        $mockDynamicEndpointName = New-Object Object |
+                        $mockDynamicEndpointName = New-Object -TypeName Object |
                             Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockEndpointName -PassThru |
                             Add-Member -MemberType ScriptMethod -Name 'EnumObjectPermissions' {
                             param($permissionSet)
                             return @(
-                                (New-Object Object |
+                                (New-Object -TypeName Object |
                                         Add-Member -MemberType NoteProperty Grantee $mockDynamicPrincipal -PassThru |
                                         Add-Member -MemberType NoteProperty PermissionState 'Grant' -PassThru
                                 )

--- a/Tests/Unit/MSFT_SqlServerEndpointPermission.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerEndpointPermission.Tests.ps1
@@ -50,13 +50,13 @@ try
 
         $mockConnectSql = {
             return New-Object -TypeName Object |
-                Add-Member -MemberType ScriptProperty -Name 'Endpoints' {
+                Add-Member -MemberType ScriptProperty -Name 'Endpoints' -Value {
                 return @(
                     @{
                         # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                         $mockDynamicEndpointName = New-Object -TypeName Object |
                             Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockEndpointName -PassThru |
-                            Add-Member -MemberType ScriptMethod -Name 'EnumObjectPermissions' {
+                            Add-Member -MemberType ScriptMethod -Name 'EnumObjectPermissions' -Value {
                             param($permissionSet)
                             return @(
                                 (New-Object -TypeName Object |
@@ -65,7 +65,7 @@ try
                                 )
                             )
                         } -PassThru |
-                            Add-Member -MemberType ScriptMethod -Name 'Grant' {
+                            Add-Member -MemberType ScriptMethod -Name 'Grant' -Value {
                             param(
                                 $permissionSet,
                                 $mockPrincipal
@@ -73,7 +73,7 @@ try
 
                             $script:mockMethodGrantRan = $true
                         } -PassThru |
-                            Add-Member -MemberType ScriptMethod -Name 'Revoke' {
+                            Add-Member -MemberType ScriptMethod -Name 'Revoke' -Value {
                             param(
                                 $permissionSet,
                                 $mockPrincipal

--- a/Tests/Unit/MSFT_SqlServerEndpointState.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerEndpointState.Tests.ps1
@@ -50,7 +50,7 @@ try
 
         $mockConnectSql = {
             return New-Object -TypeName Object |
-                Add-Member -MemberType ScriptProperty -Name 'Endpoints' {
+                Add-Member -MemberType ScriptProperty -Name 'Endpoints' -Value {
                 return @(
                     @{
                         # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint

--- a/Tests/Unit/MSFT_SqlServerEndpointState.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerEndpointState.Tests.ps1
@@ -49,12 +49,12 @@ try
         $mockDynamicEndpointState = $mockEndpointStateStarted
 
         $mockConnectSql = {
-            return New-Object Object |
+            return New-Object -TypeName Object |
                 Add-Member -MemberType ScriptProperty -Name 'Endpoints' {
                 return @(
                     @{
                         # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
-                        $mockDynamicEndpointName = New-Object Object |
+                        $mockDynamicEndpointName = New-Object -TypeName Object |
                             Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDynamicEndpointName -PassThru |
                             Add-Member -MemberType NoteProperty -Name 'EndpointState' -Value $mockDynamicEndpointState -PassThru -Force
                     }

--- a/Tests/Unit/MSFT_SqlServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerLogin.Tests.ps1
@@ -173,7 +173,7 @@ try
         $mockConnectSql = {
             $windowsUser = New-Object Microsoft.SqlServer.Management.Smo.Login( 'Server', 'Windows\User1' )
             $windowsUser.LoginType = 'WindowsUser'
-            $windowsUser = $windowsUser | Add-Member -Name 'Disable' -MemberType ScriptMethod {
+            $windowsUser = $windowsUser | Add-Member -Name 'Disable' -MemberType ScriptMethod -Value {
                 $script:mockWasLoginClassMethodDisabledCalled = $true
             } -PassThru -Force
 
@@ -189,7 +189,7 @@ try
             $sqlLoginDisabled = New-Object Microsoft.SqlServer.Management.Smo.Login( 'Server', 'Windows\UserDisabled' )
             $sqlLoginDisabled.LoginType = 'WindowsUser'
             $sqlLoginDisabled.IsDisabled = $true
-            $sqlLoginDisabled = $sqlLoginDisabled | Add-Member -Name 'Enable' -MemberType ScriptMethod {
+            $sqlLoginDisabled = $sqlLoginDisabled | Add-Member -Name 'Enable' -MemberType ScriptMethod -Value {
                 $script:mockWasLoginClassMethodEnableCalled = $true
             } -PassThru -Force
 
@@ -678,7 +678,7 @@ try
 
                     Mock -CommandName New-Object -MockWith {
                         $windowsUser = New-Object Microsoft.SqlServer.Management.Smo.Login( 'Server', 'Windows\User1' )
-                        $windowsUser = $windowsUser | Add-Member -Name 'Disable' -MemberType ScriptMethod {
+                        $windowsUser = $windowsUser | Add-Member -Name 'Disable' -MemberType ScriptMethod -Value {
                             $script:mockWasLoginClassMethodDisabledCalled = $true
                         } -PassThru -Force
 
@@ -863,7 +863,7 @@ try
                 It 'Should throw the correct error when creating a SQL Login if the LoginMode is not Mixed' {
                     $mockConnectSQL_LoginModeNormal = {
                         return New-Object -TypeName Object |
-                            Add-Member ScriptProperty Logins {
+                            Add-Member -MemberType ScriptProperty -Name Logins -Value {
                             return @{
                                 'Windows\User1' = ( New-Object -TypeName Object |
                                         Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Windows\User1' -PassThru |

--- a/Tests/Unit/MSFT_SqlServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerLogin.Tests.ps1
@@ -193,7 +193,7 @@ try
                 $script:mockWasLoginClassMethodEnableCalled = $true
             } -PassThru -Force
 
-            $mock = New-Object PSObject -Property @{
+            $mock = New-Object -TypeName PSObject -Property @{
                 LoginMode = 'Mixed'
                 Logins = @{
                     $windowsUser.Name = $windowsUser
@@ -862,16 +862,16 @@ try
 
                 It 'Should throw the correct error when creating a SQL Login if the LoginMode is not Mixed' {
                     $mockConnectSQL_LoginModeNormal = {
-                        return New-Object Object |
+                        return New-Object -TypeName Object |
                             Add-Member ScriptProperty Logins {
                             return @{
-                                'Windows\User1' = ( New-Object Object |
+                                'Windows\User1' = ( New-Object -TypeName Object |
                                         Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Windows\User1' -PassThru |
                                         Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'WindowsUser' -PassThru |
                                         Add-Member -MemberType ScriptMethod -Name Alter -Value {} -PassThru |
                                         Add-Member -MemberType ScriptMethod -Name Drop -Value {} -PassThru -Force
                                 )
-                                'SqlLogin1' = ( New-Object Object |
+                                'SqlLogin1' = ( New-Object -TypeName Object |
                                         Add-Member -MemberType NoteProperty -Name 'Name' -Value 'SqlLogin1' -PassThru |
                                         Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'SqlLogin' -PassThru |
                                         Add-Member -MemberType NoteProperty -Name 'MustChangePassword' -Value $false -PassThru |
@@ -880,7 +880,7 @@ try
                                         Add-Member -MemberType ScriptMethod -Name Alter -Value {} -PassThru |
                                         Add-Member -MemberType ScriptMethod -Name Drop -Value {} -PassThru -Force
                                 )
-                                'Windows\Group1' = ( New-Object Object |
+                                'Windows\Group1' = ( New-Object -TypeName Object |
                                         Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Windows\Group1' -PassThru |
                                         Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'WindowsGroup' -PassThru |
                                         Add-Member -MemberType ScriptMethod -Name Alter -Value {} -PassThru |

--- a/Tests/Unit/MSFT_SqlServerMaxDop.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerMaxDop.Tests.ps1
@@ -58,13 +58,13 @@ try
         $mockConnectSQL = {
             return @(
                 (
-                    New-Object Object -TypeName Microsoft.SqlServer.Management.Smo.Server |
+                    New-Object -TypeName Object -TypeName Microsoft.SqlServer.Management.Smo.Server |
                         Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockInstanceName -PassThru -Force |
                         Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockServerName -PassThru -Force |
                         Add-Member -MemberType ScriptProperty -Name Configuration -Value {
-                        return @( ( New-Object Object |
+                        return @( ( New-Object -TypeName Object |
                                     Add-Member -MemberType ScriptProperty -Name MaxDegreeOfParallelism -Value {
-                                    return @( ( New-Object Object |
+                                    return @( ( New-Object -TypeName Object |
                                                 Add-Member -MemberType NoteProperty -Name DisplayName -Value 'max degree of parallelism' -PassThru |
                                                 Add-Member -MemberType NoteProperty -Name Description -Value 'maximum degree of parallelism' -PassThru |
                                                 Add-Member -MemberType NoteProperty -Name RunValue -Value $mockMaxDegreeOfParallelism -PassThru |
@@ -91,7 +91,7 @@ try
         $mockCimInstance_Win32Processor = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name NumberOfLogicalProcessors -Value $mockNumberOfLogicalProcessors -PassThru |
                         Add-Member -MemberType NoteProperty -Name NumberOfCores -Value $mockNumberOfCores -PassThru -Force
                 )

--- a/Tests/Unit/MSFT_SqlServerMaxDop.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerMaxDop.Tests.ps1
@@ -58,7 +58,7 @@ try
         $mockConnectSQL = {
             return @(
                 (
-                    New-Object -TypeName Object -TypeName Microsoft.SqlServer.Management.Smo.Server |
+                    New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server |
                         Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockInstanceName -PassThru -Force |
                         Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockServerName -PassThru -Force |
                         Add-Member -MemberType ScriptProperty -Name Configuration -Value {

--- a/Tests/Unit/MSFT_SqlServerMemory.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerMemory.Tests.ps1
@@ -58,14 +58,14 @@ try
         $mockConnectSQL = {
             return @(
                 (
-                    # New-Object Object |
+                    # New-Object -TypeName Object |
                     New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server |
                         Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockInstanceName -PassThru -Force |
                         Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockServerName -PassThru -Force |
                         Add-Member -MemberType ScriptProperty -Name Configuration -Value {
-                        return @( ( New-Object Object |
+                        return @( ( New-Object -TypeName Object |
                                     Add-Member -MemberType ScriptProperty -Name MinServerMemory -Value {
-                                    return @( ( New-Object Object |
+                                    return @( ( New-Object -TypeName Object |
                                                 Add-Member -MemberType NoteProperty -Name DisplayName -Value 'min server memory (MB)' -PassThru |
                                                 Add-Member -MemberType NoteProperty -Name Description -Value 'Minimum size of server memory (MB)' -PassThru |
                                                 Add-Member -MemberType NoteProperty -Name RunValue -Value $mockMinServerMemory -PassThru |
@@ -73,7 +73,7 @@ try
                                         ) )
                                 } -PassThru |
                                     Add-Member -MemberType ScriptProperty -Name MaxServerMemory -Value {
-                                    return @( ( New-Object Object |
+                                    return @( ( New-Object -TypeName Object |
                                                 Add-Member -MemberType NoteProperty -Name DisplayName -Value 'max server memory (MB)' -PassThru |
                                                 Add-Member -MemberType NoteProperty -Name Description -Value 'Maximum size of server memory (MB)' -PassThru |
                                                 Add-Member -MemberType NoteProperty -Name RunValue -Value $mockMaxServerMemory -PassThru |

--- a/Tests/Unit/MSFT_SqlServerNetwork.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerNetwork.Tests.ps1
@@ -42,17 +42,17 @@ try
 
         $mockFunction_NewObject_ManagedComputer = {
                 return New-Object -TypeName Object |
-                    Add-Member -MemberType ScriptProperty -Name 'ServerInstances' {
+                    Add-Member -MemberType ScriptProperty -Name 'ServerInstances' -Value {
                         return @{
                             $mockInstanceName = New-Object -TypeName Object |
-                                Add-Member -MemberType ScriptProperty -Name 'ServerProtocols' {
+                                Add-Member -MemberType ScriptProperty -Name 'ServerProtocols' -Value {
                                     return @{
                                         $mockDynamicValue_TcpProtocolName = New-Object -TypeName Object |
                                             Add-Member -MemberType NoteProperty -Name 'IsEnabled' -Value $mockDynamicValue_IsEnabled -PassThru |
-                                            Add-Member -MemberType ScriptProperty -Name 'IPAddresses' {
+                                            Add-Member -MemberType ScriptProperty -Name 'IPAddresses' -Value {
                                                 return @{
                                                     'IPAll' = New-Object -TypeName Object |
-                                                        Add-Member -MemberType ScriptProperty -Name 'IPAddressProperties' {
+                                                        Add-Member -MemberType ScriptProperty -Name 'IPAddressProperties' -Value {
                                                             return @{
                                                                 'TcpDynamicPorts' = New-Object -TypeName Object |
                                                                     Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockDynamicValue_TcpDynamicPort -PassThru -Force
@@ -62,7 +62,7 @@ try
                                                         } -PassThru -Force
                                                 }
                                             } -PassThru |
-                                            Add-Member -MemberType ScriptMethod -Name 'Alter' {
+                                            Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
                                                 <#
                                                     It is not possible to verify that the correct value was set here for TcpDynamicPorts and
                                                     TcpPort with the current implementation.

--- a/Tests/Unit/MSFT_SqlServerRole.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerRole.Tests.ps1
@@ -57,12 +57,12 @@ try
         $mockConnectSQL = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockInstanceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockServerName -PassThru |
                         Add-Member -MemberType ScriptProperty -Name Roles -Value {
                         return @{
-                            $mockSqlServerRole = ( New-Object Object |
+                            $mockSqlServerRole = ( New-Object -TypeName Object |
                                     Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlServerRole -PassThru |
                                     Add-Member -MemberType ScriptMethod -Name EnumMemberNames -Value {
                                     if ($mockInvalidOperationForEnumMethod)
@@ -116,19 +116,19 @@ try
                         Add-Member -MemberType ScriptProperty -Name Logins -Value {
                         return @{
                             $mockSqlServerLoginOne  = @((
-                                    New-Object Object |
+                                    New-Object -TypeName Object |
                                         Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru
                                 ))
                             $mockSqlServerLoginTwo  = @((
-                                    New-Object Object |
+                                    New-Object -TypeName Object |
                                         Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru
                                 ))
                             $mockSqlServerLoginTree = @((
-                                    New-Object Object |
+                                    New-Object -TypeName Object |
                                         Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru
                                 ))
                             $mockSqlServerLoginFour = @((
-                                    New-Object Object |
+                                    New-Object -TypeName Object |
                                         Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru
                                 ))
                         }
@@ -140,7 +140,7 @@ try
         $mockNewObjectServerRole = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlServerRoleAdd -PassThru |
                         Add-Member -MemberType ScriptMethod -Name Create -Value {
                         if ($mockInvalidOperationForCreateMethod)

--- a/Tests/Unit/MSFT_SqlSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlSetup.Tests.ps1
@@ -585,10 +585,10 @@ try
                         Add-Member -MemberType NoteProperty -Name 'SQLTempDBLogDir' -Value $mockDynamicSqlTempDatabaseLogPath -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'DefaultFile' -Value $mockSqlDefaultDatabaseFilePath -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'DefaultLog' -Value $mockSqlDefaultDatabaseLogPath -PassThru |
-                        Add-Member ScriptProperty Logins {
+                        Add-Member -MemberType ScriptProperty -Name Logins -Value {
                             return @( ( New-Object -TypeName Object |
                                     Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockSqlSystemAdministrator -PassThru |
-                                    Add-Member ScriptMethod ListMembers {
+                                    Add-Member -MemberType ScriptMethod -Name ListMembers -Value {
                                         return @('sysadmin')
                                     } -PassThru -Force
                                 ) )
@@ -610,10 +610,10 @@ try
                         Add-Member -MemberType NoteProperty -Name 'DefaultFile' -Value $mockSqlDefaultDatabaseFilePath -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'DefaultLog' -Value $mockSqlDefaultDatabaseLogPath -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'IsClustered' -Value $true -PassThru |
-                        Add-Member ScriptProperty Logins {
+                        Add-Member -MemberType ScriptProperty -Name Logins -Value {
                             return @( ( New-Object -TypeName Object |
                                     Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockSqlSystemAdministrator -PassThru |
-                                    Add-Member ScriptMethod ListMembers {
+                                    Add-Member -MemberType ScriptMethod -Name ListMembers -Value {
                                         return @('sysadmin')
                                     } -PassThru -Force
                                 ) )
@@ -626,7 +626,7 @@ try
             return @(
                 (
                     New-Object -TypeName Object |
-                        Add-Member -MemberType ScriptProperty ServerProperties  {
+                        Add-Member -MemberType ScriptProperty -Name ServerProperties -Value {
                             return @{
                                 'CollationName' = @( New-Object -TypeName Object | Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockSqlAnalysisCollation -PassThru -Force )
                                 'DataDir' = @( New-Object -TypeName Object | Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockSqlAnalysisDataDirectory -PassThru -Force )
@@ -635,12 +635,12 @@ try
                                 'BackupDir' = @( New-Object -TypeName Object | Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockSqlAnalysisBackupDirectory -PassThru -Force )
                             }
                         } -PassThru |
-                        Add-Member -MemberType ScriptProperty Roles  {
+                        Add-Member -MemberType ScriptProperty -Name Roles -Value {
                             return @{
                                 'Administrators' = @( New-Object -TypeName Object |
-                                    Add-Member ScriptProperty Members {
+                                    Add-Member -MemberType ScriptProperty -Name Members -Value {
                                         return New-Object -TypeName Object |
-                                            Add-Member -MemberType ScriptProperty Name {
+                                            Add-Member -MemberType ScriptProperty -Name Name -Value {
                                                 return $mockDynamicSqlAnalysisAdmins
                                             } -PassThru -Force
                                     } -PassThru -Force
@@ -667,7 +667,7 @@ try
                 (
                     New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockRobocopyExecutableName -PassThru |
-                        Add-Member ScriptProperty FileVersionInfo {
+                        Add-Member -MemberType ScriptProperty -Name FileVersionInfo -Value {
                             return @( ( New-Object -TypeName Object |
                                     Add-Member -MemberType NoteProperty -Name 'ProductVersion' -Value $mockRobocopyExecutableVersion -PassThru -Force
                                 ) )

--- a/Tests/Unit/MSFT_SqlSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlSetup.Tests.ps1
@@ -272,7 +272,7 @@ try
         $mockGetCimInstance_DefaultInstance_DatabaseService = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_DatabaseServiceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 )
@@ -282,7 +282,7 @@ try
         $mockGetCimInstance_DefaultInstance_AgentService = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AgentServiceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
                 )
@@ -292,7 +292,7 @@ try
         $mockGetCimInstance_DefaultInstance_FullTextService = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_FullTextServiceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 )
@@ -302,7 +302,7 @@ try
         $mockGetCimInstance_DefaultInstance_ReportingService = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_ReportingServiceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 )
@@ -312,7 +312,7 @@ try
         $mockGetCimInstance_DefaultInstance_IntegrationService = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 )
@@ -322,7 +322,7 @@ try
         $mockGetCimInstance_DefaultInstance_AnalysisService = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AnalysisServiceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 )
@@ -332,32 +332,32 @@ try
         $mockGetService_DefaultInstance = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_DatabaseServiceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 ),
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AgentServiceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
                 ),
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_FullTextServiceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 ),
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_ReportingServiceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 ),
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 ),
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AnalysisServiceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 )
@@ -367,7 +367,7 @@ try
         $mockGetCimInstance_NamedInstance_DatabaseService = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_DatabaseServiceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 )
@@ -377,7 +377,7 @@ try
         $mockGetCimInstance_NamedInstance_AgentService = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AgentServiceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
                 )
@@ -387,7 +387,7 @@ try
         $mockGetCimInstance_NamedInstance_FullTextService = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_FullTextServiceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 )
@@ -397,7 +397,7 @@ try
         $mockGetCimInstance_NamedInstance_ReportingService = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_ReportingServiceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 )
@@ -407,7 +407,7 @@ try
         $mockGetCimInstance_NamedInstance_IntegrationService = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 )
@@ -417,7 +417,7 @@ try
         $mockGetCimInstance_NamedInstance_AnalysisService = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AnalysisServiceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 )
@@ -427,32 +427,32 @@ try
         $mockGetService_NamedInstance = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_DatabaseServiceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 ),
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AgentServiceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
                 ),
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_FullTextServiceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 ),
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_ReportingServiceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 ),
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 ),
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AnalysisServiceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 )
@@ -462,7 +462,7 @@ try
         $mockGetItemProperty_InstanceId_ConfigurationState = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'SQL_Replication_Core_Inst' -Value 1 -PassThru -Force
                 )
             )
@@ -471,7 +471,7 @@ try
         $mockGetItemProperty_DQFeature = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                     Add-Member -MemberType NoteProperty -Name 'DQ_Components' -Value 1 -PassThru -Force
                 )
             )
@@ -480,7 +480,7 @@ try
         $mockGetItemProperty_SqlVersion_ConfigurationState = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                     Add-Member -MemberType NoteProperty -Name 'SQL_BOL_Components' -Value 1 -PassThru |
                     Add-Member -MemberType NoteProperty -Name 'SQL_DQ_CLIENT_Full' -Value 1 -PassThru |
                     Add-Member -MemberType NoteProperty -Name 'MDSCoreFeature' -Value 1 -PassThru -Force
@@ -491,7 +491,7 @@ try
         $mockGetItemProperty_ClientComponentsFull_FeatureList = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'FeatureList' -Value 'Connectivity_Full=3 SQL_SSMS_Full=3 Tools_Legacy_Full=3 Connectivity_FNS=3 SQL_Tools_Standard_FNS=3 Tools_Legacy_FNS=3 SDK_Full=3 SDK_FNS=3' -PassThru -Force
                 )
             )
@@ -500,7 +500,7 @@ try
         $mockGetItemProperty_ClientComponentsFull_EmptyFeatureList = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'FeatureList' -Value '' -PassThru -Force
                 )
             )
@@ -509,11 +509,11 @@ try
         $mockGetItemProperty_SQL = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name $mockDefaultInstance_InstanceName -Value $mockDefaultInstance_InstanceId -PassThru -Force
                 ),
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name $mockNamedInstance_InstanceName -Value $mockNamedInstance_InstanceId -PassThru -Force
                 )
             )
@@ -522,7 +522,7 @@ try
         $mockGetItemProperty_SharedDirectory = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name '28A1158CDF9ED6B41B2B7358982D4BA8' -Value $mockSqlSharedDirectory -PassThru -Force
                 )
             )
@@ -531,7 +531,7 @@ try
         $mockGetItem_SharedDirectory = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Property' -Value '28A1158CDF9ED6B41B2B7358982D4BA8' -PassThru -Force
                 )
             )
@@ -540,7 +540,7 @@ try
         $mockGetItemProperty_SharedWowDirectory = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name '28A1158CDF9ED6B41B2B7358982D4BA8' -Value $mockSqlSharedWowDirectory -PassThru -Force
                 )
             )
@@ -549,7 +549,7 @@ try
         $mockGetItem_SharedWowDirectory = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Property' -Value '28A1158CDF9ED6B41B2B7358982D4BA8' -PassThru -Force
                 )
             )
@@ -558,7 +558,7 @@ try
         $mockGetItemProperty_Setup = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'SqlProgramDir' -Value $mockSqlProgramDirectory -PassThru -Force
                 )
             )
@@ -567,7 +567,7 @@ try
         $mockGetItemProperty_ServicesAnalysis = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'ImagePath' -Value ('"C:\Program Files\Microsoft SQL Server\OLAP\bin\msmdsrv.exe" -s "{0}"' -f $mockSqlAnalysisConfigDirectory) -PassThru -Force
                 )
             )
@@ -576,7 +576,7 @@ try
         $mockConnectSQL = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'LoginMode' -Value $mockSqlLoginMode -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'Collation' -Value $mockSqlCollation -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'InstallDataDirectory' -Value $mockSqlInstallPath -PassThru |
@@ -586,7 +586,7 @@ try
                         Add-Member -MemberType NoteProperty -Name 'DefaultFile' -Value $mockSqlDefaultDatabaseFilePath -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'DefaultLog' -Value $mockSqlDefaultDatabaseLogPath -PassThru |
                         Add-Member ScriptProperty Logins {
-                            return @( ( New-Object Object |
+                            return @( ( New-Object -TypeName Object |
                                     Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockSqlSystemAdministrator -PassThru |
                                     Add-Member ScriptMethod ListMembers {
                                         return @('sysadmin')
@@ -600,7 +600,7 @@ try
         $mockConnectSQLCluster = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'LoginMode' -Value $mockSqlLoginMode -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'Collation' -Value $mockSqlCollation -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'InstallDataDirectory' -Value $mockSqlInstallPath -PassThru |
@@ -611,7 +611,7 @@ try
                         Add-Member -MemberType NoteProperty -Name 'DefaultLog' -Value $mockSqlDefaultDatabaseLogPath -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'IsClustered' -Value $true -PassThru |
                         Add-Member ScriptProperty Logins {
-                            return @( ( New-Object Object |
+                            return @( ( New-Object -TypeName Object |
                                     Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockSqlSystemAdministrator -PassThru |
                                     Add-Member ScriptMethod ListMembers {
                                         return @('sysadmin')
@@ -625,21 +625,21 @@ try
         $mockConnectSQLAnalysis = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType ScriptProperty ServerProperties  {
                             return @{
-                                'CollationName' = @( New-Object Object | Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockSqlAnalysisCollation -PassThru -Force )
-                                'DataDir' = @( New-Object Object | Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockSqlAnalysisDataDirectory -PassThru -Force )
-                                'TempDir' = @( New-Object Object | Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockSqlAnalysisTempDirectory -PassThru -Force )
-                                'LogDir' = @( New-Object Object | Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockSqlAnalysisLogDirectory -PassThru -Force )
-                                'BackupDir' = @( New-Object Object | Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockSqlAnalysisBackupDirectory -PassThru -Force )
+                                'CollationName' = @( New-Object -TypeName Object | Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockSqlAnalysisCollation -PassThru -Force )
+                                'DataDir' = @( New-Object -TypeName Object | Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockSqlAnalysisDataDirectory -PassThru -Force )
+                                'TempDir' = @( New-Object -TypeName Object | Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockSqlAnalysisTempDirectory -PassThru -Force )
+                                'LogDir' = @( New-Object -TypeName Object | Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockSqlAnalysisLogDirectory -PassThru -Force )
+                                'BackupDir' = @( New-Object -TypeName Object | Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockSqlAnalysisBackupDirectory -PassThru -Force )
                             }
                         } -PassThru |
                         Add-Member -MemberType ScriptProperty Roles  {
                             return @{
-                                'Administrators' = @( New-Object Object |
+                                'Administrators' = @( New-Object -TypeName Object |
                                     Add-Member ScriptProperty Members {
-                                        return New-Object Object |
+                                        return New-Object -TypeName Object |
                                             Add-Member -MemberType ScriptProperty Name {
                                                 return $mockDynamicSqlAnalysisAdmins
                                             } -PassThru -Force
@@ -665,10 +665,10 @@ try
         $mockGetCommand = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockRobocopyExecutableName -PassThru |
                         Add-Member ScriptProperty FileVersionInfo {
-                            return @( ( New-Object Object |
+                            return @( ( New-Object -TypeName Object |
                                     Add-Member -MemberType NoteProperty -Name 'ProductVersion' -Value $mockRobocopyExecutableVersion -PassThru -Force
                                 ) )
                         } -PassThru -Force
@@ -685,19 +685,19 @@ try
                 throw "Expected arguments was not the same as the arguments in the function call.`nExpected: '$mockStartSqlSetupProcessExpectedArgument' `n But was: '$ArgumentList'"
             }
 
-            return New-Object Object |
+            return New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'ExitCode' -Value 0 -PassThru -Force
         }
 
         $mockStartSqlSetupProcess_Robocopy_WithExitCode = {
-            return New-Object Object |
+            return New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'ExitCode' -Value $mockStartSqlSetupProcessExitCode -PassThru -Force
         }
 
         $mockSourcePathUNCWithoutLeaf = '\\server\share'
         $mockSourcePathGuid = 'cc719562-0f46-4a16-8605-9f8a47c70402'
         $mockNewGuid = {
-            return New-Object Object |
+            return New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Guid' -Value $mockSourcePathGuid -PassThru -Force
         }
 
@@ -758,33 +758,33 @@ try
             return @(
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['SysData'].Path}) -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['SysData'].Name}) -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['SysData'].Path}) -PassThru -Force |
+                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['SysData'].Name}) -PassThru -Force
                 ),
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['UserData'].Path}) -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['UserData'].Name}) -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['UserData'].Path}) -PassThru -Force |
+                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['UserData'].Name}) -PassThru -Force
                 ),
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['UserLogs'].Path}) -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['UserLogs'].Name}) -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['UserLogs'].Path}) -PassThru -Force |
+                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['UserLogs'].Name}) -PassThru -Force
                 ),
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBData'].Path}) -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBData'].Name}) -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBData'].Path}) -PassThru -Force |
+                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBData'].Name}) -PassThru -Force
                 ),
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBLogs'].Path}) -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBLogs'].Name}) -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBLogs'].Path}) -PassThru -Force |
+                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBLogs'].Name}) -PassThru -Force
                 ),
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['Backup'].Path}) -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['Backup'].Name}) -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['Backup'].Path}) -PassThru -Force |
+                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['Backup'].Name}) -PassThru -Force
                 )
             )
         }

--- a/Tests/Unit/MSFT_SqlWindowsFirewall.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlWindowsFirewall.Tests.ps1
@@ -105,27 +105,27 @@ try
         $mockGetService_DefaultInstance = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_DatabaseServiceName -PassThru -Force
                 ),
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AgentServiceName -PassThru -Force
                 ),
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_FullTextServiceName -PassThru -Force
                 ),
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_ReportingServiceName -PassThru -Force
                 ),
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockDefaultInstance_IntegrationServiceName -f $mockCurrentSqlMajorVersion) -PassThru -Force
                 ),
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AnalysisServiceName -PassThru -Force
                 )
             )
@@ -135,27 +135,27 @@ try
         $mockGetService_NamedInstance = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_DatabaseServiceName -PassThru -Force
                 ),
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AgentServiceName -PassThru -Force
                 ),
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_FullTextServiceName -PassThru -Force
                 ),
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_ReportingServiceName -PassThru -Force
                 ),
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockNamedInstance_IntegrationServiceName -f $mockCurrentSqlMajorVersion) -PassThru -Force
                 ),
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AnalysisServiceName -PassThru -Force
                 )
             )
@@ -170,7 +170,7 @@ try
         $mockGetItemProperty_SqlInstanceId = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name $mockCurrentInstanceName -Value $mockCurrentDatabaseEngineInstanceId -PassThru -Force
                 )
             )
@@ -184,7 +184,7 @@ try
         $mockGetItemProperty_AnalysisServicesInstanceId = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name $mockCurrentInstanceName -Value $mockCurrentAnalysisServiceInstanceId -PassThru -Force
                 )
             )
@@ -198,7 +198,7 @@ try
         $mockGetItemProperty_DatabaseEngineSqlBinRoot = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'SQLBinRoot' -Value $mockCurrentDatabaseEngineSqlBinDirectory -PassThru -Force
                 )
             )
@@ -212,7 +212,7 @@ try
         $mockGetItemProperty_AnalysisServicesSqlBinRoot = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'SQLBinRoot' -Value $mockCurrentAnalysisServicesSqlBinDirectory -PassThru -Force
                 )
             )
@@ -226,7 +226,7 @@ try
         $mockGetItemProperty_IntegrationsServicesSqlPath = {
             return @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'SQLPath' -Value $mockCurrentIntegrationServicesSqlPathDirectory -PassThru -Force
                 )
             )
@@ -255,7 +255,7 @@ try
             {
                 return @(
                     (
-                        New-Object Object |
+                        New-Object -TypeName Object |
                             Add-Member -MemberType NoteProperty -Name 'Program' -Value (Join-Path $mockCurrentDatabaseEngineSqlBinDirectory -ChildPath $mockDatabaseEngineExecutableName) -PassThru -Force
                     )
                 )
@@ -264,7 +264,7 @@ try
             {
                 return @(
                     (
-                        New-Object Object |
+                        New-Object -TypeName Object |
                             Add-Member -MemberType NoteProperty -Name 'Program' -Value (Join-Path -Path (Join-Path $mockCurrentIntegrationServicesSqlPathDirectory -ChildPath 'Binn') -ChildPath $mockIntegrationServicesExecutableName) -PassThru -Force
                     )
                 )
@@ -281,7 +281,7 @@ try
             {
                 return @(
                     (
-                        New-Object Object |
+                        New-Object -TypeName Object |
                             Add-Member -MemberType NoteProperty -Name 'Service' -Value $mockCurrentSqlAnalysisServiceName -PassThru -Force
                     )
                 )
@@ -290,7 +290,7 @@ try
             {
                 return @(
                     (
-                        New-Object Object |
+                        New-Object -TypeName Object |
                             Add-Member -MemberType NoteProperty -Name 'Service' -Value $mockSQLBrowserServiceName -PassThru -Force
                     )
                 )
@@ -306,7 +306,7 @@ try
             {
                 return @(
                     (
-                        New-Object Object |
+                        New-Object -TypeName Object |
                             Add-Member -MemberType NoteProperty -Name 'Protocol' -Value $mockFirewallRulePort_ReportingServicesNoSslProtocol -PassThru |
                             Add-Member -MemberType NoteProperty -Name 'LocalPort' -Value $mockFirewallRulePort_ReportingServicesNoSslLocalPort -PassThru -Force
                     )
@@ -316,7 +316,7 @@ try
             {
                 return @(
                     (
-                        New-Object Object |
+                        New-Object -TypeName Object |
                             Add-Member -MemberType NoteProperty -Name 'Protocol' -Value $mockFirewallRulePort_ReportingServicesSslProtocol -PassThru |
                             Add-Member -MemberType NoteProperty -Name 'LocalPort' -Value $mockFirewallRulePort_ReportingServicesSslLocalPort -PassThru -Force
                     )
@@ -326,7 +326,7 @@ try
             {
                 return @(
                     (
-                        New-Object Object |
+                        New-Object -TypeName Object |
                             Add-Member -MemberType NoteProperty -Name 'Protocol' -Value $mockFirewallRulePort_IntegrationServicesProtocol -PassThru |
                             Add-Member -MemberType NoteProperty -Name 'LocalPort' -Value $mockFirewallRulePort_IntegrationServicesLocalPort -PassThru -Force
                     )
@@ -385,9 +385,9 @@ try
         }
 
         $mockGetItem_SqlMajorVersion = {
-            return New-Object Object |
+            return New-Object -TypeName Object |
                         Add-Member ScriptProperty VersionInfo {
-                            return New-Object Object |
+                            return New-Object -TypeName Object |
                                         Add-Member -MemberType NoteProperty -Name 'ProductVersion' -Value ('{0}.0.0000.00000' -f $mockCurrentSqlMajorVersion) -PassThru -Force
                         } -PassThru -Force
         }

--- a/Tests/Unit/MSFT_SqlWindowsFirewall.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlWindowsFirewall.Tests.ps1
@@ -386,7 +386,7 @@ try
 
         $mockGetItem_SqlMajorVersion = {
             return New-Object -TypeName Object |
-                        Add-Member ScriptProperty VersionInfo {
+                        Add-Member -MemberType ScriptProperty -Name VersionInfo -Value {
                             return New-Object -TypeName Object |
                                         Add-Member -MemberType NoteProperty -Name 'ProductVersion' -Value ('{0}.0.0000.00000' -f $mockCurrentSqlMajorVersion) -PassThru -Force
                         } -PassThru -Force

--- a/Tests/Unit/SqlServerDSCHelper.Tests.ps1
+++ b/Tests/Unit/SqlServerDSCHelper.Tests.ps1
@@ -23,7 +23,7 @@ Add-Type -Path ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stub
 InModuleScope $script:moduleName {
     $mockNewObject_MicrosoftAnalysisServicesServer = {
         return New-Object -TypeName Object |
-                    Add-Member -MemberType ScriptMethod -Name Connect {
+                    Add-Member -MemberType ScriptMethod -Name Connect -Value {
                         param(
                             [Parameter(Mandatory = $true)]
                             [ValidateNotNullOrEmpty()]
@@ -84,7 +84,7 @@ InModuleScope $script:moduleName {
                     Add-Member -MemberType NoteProperty -Name ConnectAsUser -Value $false -PassThru |
                     Add-Member -MemberType NoteProperty -Name ConnectAsUserPassword -Value '' -PassThru |
                     Add-Member -MemberType NoteProperty -Name ConnectAsUserName -Value '' -PassThru |
-                    Add-Member -MemberType ScriptMethod -Name Connect {
+                    Add-Member -MemberType ScriptMethod -Name Connect -Value {
                         if ($mockExpectedDatabaseEngineInstance -eq 'MSSQLSERVER')
                         {
                             $mockExpectedServiceInstance = $mockExpectedDatabaseEngineServer

--- a/Tests/Unit/SqlServerDSCHelper.Tests.ps1
+++ b/Tests/Unit/SqlServerDSCHelper.Tests.ps1
@@ -22,7 +22,7 @@ Add-Type -Path ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stub
 # Begin Testing
 InModuleScope $script:moduleName {
     $mockNewObject_MicrosoftAnalysisServicesServer = {
-        return New-Object Object |
+        return New-Object -TypeName Object |
                     Add-Member -MemberType ScriptMethod -Name Connect {
                         param(
                             [Parameter(Mandatory = $true)]
@@ -58,7 +58,7 @@ InModuleScope $script:moduleName {
             $serverInstance = $ArgumentList[0]
         }
 
-        return New-Object Object |
+        return New-Object -TypeName Object |
             Add-Member -MemberType ScriptProperty -Name Status -Value {
                 if ($mockExpectedDatabaseEngineInstance -eq 'MSSQLSERVER')
                 {
@@ -79,7 +79,7 @@ InModuleScope $script:moduleName {
                 }
             } -PassThru |
             Add-Member -MemberType NoteProperty -Name ConnectionContext -Value (
-                New-Object Object |
+                New-Object -TypeName Object |
                     Add-Member -MemberType NoteProperty -Name ServerInstance -Value $serverInstance -PassThru |
                     Add-Member -MemberType NoteProperty -Name ConnectAsUser -Value $false -PassThru |
                     Add-Member -MemberType NoteProperty -Name ConnectAsUserPassword -Value '' -PassThru |
@@ -535,7 +535,7 @@ InModuleScope $script:moduleName {
         $mockInvokeQueryClusterServicePermissionsSet = @() # Will be set dynamically in the check
 
         $mockInvokeQueryClusterServicePermissionsResult = {
-            return New-Object PSObject -Property @{
+            return New-Object -TypeName PSObject -Property @{
                 Tables = @{
                     Rows = @{
                         permission_name = $mockInvokeQueryClusterServicePermissionsSet
@@ -597,7 +597,7 @@ InModuleScope $script:moduleName {
     }
 
     $mockGetModule = {
-        return New-Object PSObject -Property @{
+        return New-Object -TypeName PSObject -Property @{
             Name = $mockModuleNameToImport
         }
     }
@@ -713,7 +713,7 @@ InModuleScope $script:moduleName {
     $mockGetItemProperty_MicrosoftSQLServer_InstanceNames_SQL = {
         return @(
             (
-                New-Object Object |
+                New-Object -TypeName Object |
                     Add-Member -MemberType NoteProperty -Name $mockInstanceName -Value $mockInstance_InstanceId -PassThru -Force
             )
         )
@@ -722,7 +722,7 @@ InModuleScope $script:moduleName {
     $mockGetItemProperty_MicrosoftSQLServer_FullInstanceId_Setup = {
         return @(
             (
-                New-Object Object |
+                New-Object -TypeName Object |
                     Add-Member -MemberType NoteProperty -Name 'Version' -Value "$($mockSqlMajorVersion).0.4001.0" -PassThru -Force
             )
         )
@@ -769,7 +769,7 @@ InModuleScope $script:moduleName {
                 Mock -CommandName Get-ItemProperty `
                     -ParameterFilter $mockGetItemProperty_ParameterFilter_MicrosoftSQLServer_FullInstanceId_Setup `
                     -MockWith {
-                        return New-Object Object
+                        return New-Object -TypeName Object
                     } -Verifiable
 
                 $mockCorrectErrorMessage = ($script:localizedData.SqlServerVersionIsInvalid -f $mockInstanceName)
@@ -912,7 +912,7 @@ InModuleScope $script:moduleName {
 
             $mock = @(
                 (
-                    New-Object Object |
+                    New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'DomainInstanceName' -Value $SQLServer -PassThru
                 )
             )
@@ -979,7 +979,7 @@ InModuleScope $script:moduleName {
 
                 $mock = @(
                     (
-                        New-Object Object |
+                        New-Object -TypeName Object |
                             Add-Member -MemberType NoteProperty -Name 'Version' -Value $mockSqlVersion -PassThru
                     )
                 )


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to SqlServer
  - Updated so that named parameters are used for New-Object cmdlet. This was
    done to follow the style guideline.

**This Pull Request (PR) fixes the following issues:**
n/a

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/974)
<!-- Reviewable:end -->
