### PR TITLE
SqlServiceAccount: Added integration tests (plus other changes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@
     ([issue #930](https://github.com/PowerShell/SqlServerDsc/issues/930)).
   - Made the description of parameter RestartService more descriptive
     ([issue #960](https://github.com/PowerShell/SqlServerDsc/issues/960)).
-  - Added a read-only parameter ServiceAccountName so correctly returns the
-    service account name as a string ([issue #982](https://github.com/PowerShell/SqlServerDsc/issues/982)).
+  - Added a read-only parameter ServiceAccountName so that the service account
+    name is correctly returned as a string ([issue #982](https://github.com/PowerShell/SqlServerDsc/issues/982)).
   - Added integration tests ([issue #980](https://github.com/PowerShell/SqlServerDsc/issues/980)).
 - Changes to SqlSetup
   - Added parameter `ASServerMode` to support installing Analysis Services in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     ([issue #965](https://github.com/PowerShell/SqlServerDsc/issues/965)).
   - Added a README.md under Tests\Integration to help contributors to write
     integration tests.
+  - Added 'Integration tests' section in the CONTRIBUTING.md.
 - Changes to SqlAlias
   - Fixed issue where exception was thrown if reg keys did not exist
     ([issue #949](https://github.com/PowerShell/SqlServerDsc/issues/949)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
     ([issue #930](https://github.com/PowerShell/SqlServerDsc/issues/930)).
   - Made the description of parameter RestartService more descriptive
     ([issue #960](https://github.com/PowerShell/SqlServerDsc/issues/960)).
+  - Added integration tests ([issue #980](https://github.com/PowerShell/SqlServerDsc/issues/980)).
 - Changes to SqlSetup
   - Added parameter `ASServerMode` to support installing Analysis Services in
     Multidimensional mode, Tabular mode and PowerPivot mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
     done to follow the style guideline.
   - Updated manifest and license to reflect the new year
     ([issue #965](https://github.com/PowerShell/SqlServerDsc/issues/965)).
+  - Added a README.md under Tests\Integration to help contributors to write
+    integration tests.
 - Changes to SqlAlias
   - Fixed issue where exception was thrown if reg keys did not exist
     ([issue #949](https://github.com/PowerShell/SqlServerDsc/issues/949)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
     ([issue #930](https://github.com/PowerShell/SqlServerDsc/issues/930)).
   - Made the description of parameter RestartService more descriptive
     ([issue #960](https://github.com/PowerShell/SqlServerDsc/issues/960)).
+  - Added a read-only parameter ServiceAccountName so correctly returns the
+    service account name as a string ([issue #982](https://github.com/PowerShell/SqlServerDsc/issues/982)).
   - Added integration tests ([issue #980](https://github.com/PowerShell/SqlServerDsc/issues/980)).
 - Changes to SqlSetup
   - Added parameter `ASServerMode` to support installing Analysis Services in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
     ([issue #388](https://github.com/PowerShell/SqlServerDsc/issues/388)).
   - Added integration tests for testing Analysis Services Multidimensional mode
     and Tabular mode.
+  - Cleaned up integration tests.
+  - Added integration tests for installing a default instance of Database Engine.
 
 ## 10.0.0.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -372,7 +372,7 @@ one resource, then the functions can also be placed in the common
 [SqlServerDscHelper.psm1](https://github.com/PowerShell/SqlServerDsc/blob/dev/SqlServerDscHelper.psm1)
 module file.
 
-### Tests
+### Unit tests
 
 For a review of a Pull Request (PR) to start, all tests must pass without error.
 If you need help to figure why some test don't pass, just write a comment in the
@@ -386,7 +386,7 @@ cd '<path to cloned repository>\Tests'
 Invoke-Pester
 ```
 
-#### Tests for style check of Markdown files
+#### Unit tests for style check of Markdown files
 
 When sending in a Pull Request (PR) a style check will be performed on all Markdown
 files, and if the tests find any error the build will fail.
@@ -398,7 +398,7 @@ To have npm available you need to install [node.js](https://nodejs.org/en/downlo
 If 'npm' is not available, a warning text will print and the rest of the tests
 will continue run.
 
-#### Tests for examples files
+#### Unit tests for examples files
 
 When sending in a Pull Request (PR) all example files will be tested so they can
 be compiled to a .mof file. If the tests find any errors the build will fail.
@@ -407,6 +407,17 @@ Before the test runs in AppVeyor the module will be copied to the first path of
 To run this test locally, make sure you have the SqlServerDsc module
 deployed to a path where it can be used.
 See `$env:PSModulePath` to view the existing paths.
+
+### Integration tests
+
+Integration tests should be written for resources so they can be validated by
+the automated test framework which is run in AppVeyour when commits are pushed
+to a Pull Request (PR).
+Please see the [Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md)
+for common DSC Resource Kit testing guidelines.
+There is also configuration made by existing integration tests that can be reused
+to write integration tests for other resources. That is documented in
+[Integration tests for SqlServerDsc](https://github.com/PowerShell/SqlServerDsc/blob/dev/Tests/Integration/README.md).
 
 #### Using SMO stub classes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -411,12 +411,12 @@ See `$env:PSModulePath` to view the existing paths.
 ### Integration tests
 
 Integration tests should be written for resources so they can be validated by
-the automated test framework which is run in AppVeyour when commits are pushed
+the automated test framework which is run in AppVeyor when commits are pushed
 to a Pull Request (PR).
 Please see the [Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md)
 for common DSC Resource Kit testing guidelines.
-There is also configuration made by existing integration tests that can be reused
-to write integration tests for other resources. That is documented in
+There are also configuration made by existing integration tests that can be reused
+to write integration tests for other resources. This is documented in
 [Integration tests for SqlServerDsc](https://github.com/PowerShell/SqlServerDsc/blob/dev/Tests/Integration/README.md).
 
 #### Using SMO stub classes

--- a/DSCResources/MSFT_SqlServiceAccount/MSFT_SqlServiceAccount.psm1
+++ b/DSCResources/MSFT_SqlServiceAccount/MSFT_SqlServiceAccount.psm1
@@ -65,12 +65,12 @@ function Get-TargetResource
     # Replace a domain of '.' with the value for $ServerName
     $serviceAccountName = $serviceObject.ServiceAccount -ireplace '^([\.])\\(.*)$', "$ServerName\`$2"
 
-    # Return a hashtable with the service information
+    # Return a hash table with the service information
     return @{
-        ServerName     = $ServerName
-        InstanceName   = $InstanceName
-        ServiceType    = $serviceObject.Type
-        ServiceAccount = $serviceAccountName
+        ServerName         = $ServerName
+        InstanceName       = $InstanceName
+        ServiceType        = $serviceObject.Type
+        ServiceAccountName = $serviceAccountName
     }
 }
 
@@ -99,7 +99,7 @@ function Get-TargetResource
         Forces the service account to be updated.
 
     .EXAMPLE
-        Test-TargetResource -ServerName $env:COMPUTERNAME -SQLInstaneName MSSQLSERVER -ServiceType DatabaseEngine -ServiceAccount $account
+        Test-TargetResource -ServerName $env:COMPUTERNAME -InstanceName MSSQLSERVER -ServiceType DatabaseEngine -ServiceAccount $account
 
 #>
 function Test-TargetResource
@@ -172,7 +172,7 @@ function Test-TargetResource
         Forces the service account to be updated.
 
     .EXAMPLE
-        Set-TargetResource -ServerName $env:COMPUTERNAME -SQLInstaneName MSSQLSERVER -ServiceType DatabaseEngine -ServiceAccount $account
+        Set-TargetResource -ServerName $env:COMPUTERNAME -InstanceName MSSQLSERVER -ServiceType DatabaseEngine -ServiceAccount $account
 #>
 function Set-TargetResource
 {

--- a/DSCResources/MSFT_SqlServiceAccount/MSFT_SqlServiceAccount.psm1
+++ b/DSCResources/MSFT_SqlServiceAccount/MSFT_SqlServiceAccount.psm1
@@ -142,9 +142,9 @@ function Test-TargetResource
 
     # Get the current state
     $currentState = Get-TargetResource -ServerName $ServerName -InstanceName $InstanceName -ServiceType $ServiceType -ServiceAccount $ServiceAccount
-    New-VerboseMessage -Message ($script:localizedData.CurrentServiceAccount -f $currentState.ServiceAccount, $ServerName, $InstanceName)
+    New-VerboseMessage -Message ($script:localizedData.CurrentServiceAccount -f $currentState.ServiceAccountName, $ServerName, $InstanceName)
 
-    return ($currentState.ServiceAccount -ieq $ServiceAccount.UserName)
+    return ($currentState.ServiceAccountName -ieq $ServiceAccount.UserName)
 }
 
 <#

--- a/DSCResources/MSFT_SqlServiceAccount/MSFT_SqlServiceAccount.schema.mof
+++ b/DSCResources/MSFT_SqlServiceAccount/MSFT_SqlServiceAccount.schema.mof
@@ -7,4 +7,5 @@ class MSFT_SqlServiceAccount : OMI_BaseResource
     [Required, EmbeddedInstance("MSFT_Credential"), Description("The service account that should be used when running the service.")] String ServiceAccount;
     [Write, Description("Determines whether the service is automatically restarted when a change to the configuration was needed.")] Boolean RestartService;
     [Write, Description("Forces the service account to be updated. Useful for password changes.")] Boolean Force;
+    [Read, Description("Returns the service account username for the service.")] String ServiceAccountName;
 };

--- a/DSCResources/MSFT_SqlServiceAccount/en-US/MSFT_SqlServiceAccount.strings.psd1
+++ b/DSCResources/MSFT_SqlServiceAccount/en-US/MSFT_SqlServiceAccount.strings.psd1
@@ -2,7 +2,7 @@
 
 ConvertFrom-StringData @'
     ForceServiceAccountUpdate = Force specified, skipping tests. With this configuration, Test-TargetResource will always return 'False'.
-    CurrentServiceAccount = Current service account is '{0}' for {1}\{2}.
+    CurrentServiceAccount = Current service account is '{0}' for {1}\\{2}.
     ConnectingToWmi = Connecting to WMI on '{0}'.
     UpdatingServiceAccount = Setting service account to '{0}' for service {1}.
     RestartingService = Restarting '{0}' and any dependent services.

--- a/README.md
+++ b/README.md
@@ -1276,6 +1276,11 @@ Manage the service account for SQL Server services.
   Useful for password changes. This will cause `Set-TargetResource` to be run on
   each consecutive run.
 
+#### Read-Only Properties from Get-TargetResource
+
+* **`[String]` ServiceAccountName** _(Read)_: Returns the service account username
+  for the service.
+
 #### Examples
 
 * [Run service under a user account](/Examples/Resources/SqlServiceAccount/1-ConfigureServiceAccount-UserAccount.ps1)

--- a/Tests/Integration/MSFT_SqlServiceAccount.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlServiceAccount.Integration.Tests.ps1
@@ -1,0 +1,116 @@
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceFriendlyName = 'SqlServiceAccount'
+$script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
+
+if (-not $env:APPVEYOR -eq $true)
+{
+    Write-Warning -Message ('Integration test for {0} will be skipped unless $env:APPVEYOR equals $true' -f $script:DSCResourceName)
+    return
+}
+
+#region HEADER
+# Integration Test Template Version: 1.1.2
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))
+}
+
+Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Integration
+
+#endregion
+
+$mockSqlInstallAccountPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
+$mockSqlInstallAccountUserName = "$env:COMPUTERNAME\SqlInstall"
+$mockSqlInstallCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlInstallAccountUserName, $mockSqlInstallAccountPassword
+
+$mockSqlServicePrimaryAccountPassword = ConvertTo-SecureString -String 'yig-C^Equ3' -AsPlainText -Force
+$mockSqlServicePrimaryAccountUserName = "$env:COMPUTERNAME\svc-SqlPrimary"
+$mockSqlServicePrimaryCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlServicePrimaryAccountUserName, $mockSqlServicePrimaryAccountPassword
+
+$mockSqlAgentServicePrimaryAccountPassword = ConvertTo-SecureString -String 'yig-C^Equ3' -AsPlainText -Force
+$mockSqlAgentServicePrimaryAccountUserName = "$env:COMPUTERNAME\svc-SqlAgentPri"
+$mockSqlAgentServicePrimaryCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlAgentServicePrimaryAccountUserName, $mockSqlAgentServicePrimaryAccountPassword
+
+$mockSqlServiceSecondaryAccountPassword = ConvertTo-SecureString -String 'yig-C^Equ3' -AsPlainText -Force
+$mockSqlServiceSecondaryAccountUserName = "$env:COMPUTERNAME\svc-SqlSecondary"
+$mockSqlServiceSecondaryCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlServiceSecondaryAccountUserName, $mockSqlServiceSecondaryAccountPassword
+
+$mockSqlAgentServiceSecondaryAccountPassword = ConvertTo-SecureString -String 'yig-C^Equ3' -AsPlainText -Force
+$mockSqlAgentServiceSecondaryAccountUserName = "$env:COMPUTERNAME\svc-SqlAgentSec"
+$mockSqlAgentServiceSecondaryCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlAgentServiceSecondaryAccountUserName, $mockSqlAgentServiceSecondaryAccountPassword
+
+$moc
+try
+{
+    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
+    . $configFile
+
+    $mockServiceTypeDatabaseEngine = $ConfigurationData.AllNodes.ServiceTypeDatabaseEngine
+    $mockServiceTypeSqlServerAgent = $ConfigurationData.AllNodes.ServiceTypeSqlServerAgent
+
+    Describe "$($script:DSCResourceName)_Integration" {
+        BeforeAll {
+            $resourceId = "[$($script:DSCResourceFriendlyName)]Integration_Test"
+        }
+
+        $configurationName = "$($script:DSCResourceName)_DatabaseEngine_DefaultInstance_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        SqlInstallCredential               = $mockSqlInstallCredential
+                        SqlServiceSecondaryCredential      = $mockSqlServiceSecondaryCredential
+                        OutputPath           = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData    = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $currentConfiguration = Get-DscConfiguration
+
+                $resourceCurrentState = $currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName
+                } | Where-Object -FilterScript {
+                    $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.ServiceType    | Should -Be $mockServiceTypeDatabaseEngine
+                $resourceCurrentState.ServiceAccount | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $mockSqlAgentServiceSecondaryAccountUserName -Leaf))
+            }
+        }
+    }
+}
+finally
+{
+    #region FOOTER
+
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+
+    #endregion
+}

--- a/Tests/Integration/MSFT_SqlServiceAccount.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlServiceAccount.Integration.Tests.ps1
@@ -53,10 +53,12 @@ try
 
     <#
         This should have used $ConfigurationData.AllNodes.ServiceTypeDatabaseEngine
-        but due to a bug (see issue #981) we have to set this to 'SqlServer'.
+        and $ConfigurationData.AllNodes.ServiceTypeSqlServerAgent, but due to a
+        bug (see issue #981) we have to set this to 'SqlServer' and 'SqlAgent'
+        respectively.
     #>
     $mockServiceTypeDatabaseEngine = 'SqlServer'
-    $mockServiceTypeSqlServerAgent = $ConfigurationData.AllNodes.ServiceTypeSqlServerAgent
+    $mockServiceTypeSqlServerAgent = 'SqlAgent'
 
     Describe "$($script:DSCResourceName)_Integration" {
         BeforeAll {
@@ -69,11 +71,11 @@ try
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlInstallCredential               = $mockSqlInstallCredential
-                        SqlServiceSecondaryCredential      = $mockSqlServiceSecondaryCredential
-                        OutputPath           = $TestDrive
+                        SqlInstallCredential          = $mockSqlInstallCredential
+                        SqlServiceSecondaryCredential = $mockSqlServiceSecondaryCredential
+                        OutputPath                    = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
-                        ConfigurationData    = $ConfigurationData
+                        ConfigurationData             = $ConfigurationData
                     }
 
                     & $configurationName @configurationParameters
@@ -105,8 +107,329 @@ try
                 }
 
                 $resourceCurrentState.ServiceType | Should -Be $mockServiceTypeDatabaseEngine
-                $resourceCurrentState.ServiceAccount.UserName | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $mockSqlServiceSecondaryAccountUserName -Leaf))
-                $resourceCurrentState.ServiceAccount | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $mockSqlServiceSecondaryAccountUserName -Leaf))
+                $resourceCurrentState.ServiceAccountName | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $mockSqlServiceSecondaryAccountUserName -Leaf))
+            }
+        }
+
+        $configurationName = "$($script:DSCResourceName)_SqlServerAgent_DefaultInstance_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        SqlInstallCredential               = $mockSqlInstallCredential
+                        SqlAgentServiceSecondaryCredential = $mockSqlAgentServiceSecondaryCredential
+                        OutputPath                         = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData                  = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $currentConfiguration = Get-DscConfiguration
+
+                $resourceCurrentState = $currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName
+                } | Where-Object -FilterScript {
+                    $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.ServiceType | Should -Be $mockServiceTypeSqlServerAgent
+                $resourceCurrentState.ServiceAccountName | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $mockSqlAgentServiceSecondaryAccountUserName -Leaf))
+            }
+        }
+
+        $configurationName = "$($script:DSCResourceName)_DatabaseEngine_DefaultInstance_Restore_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        SqlInstallCredential          = $mockSqlInstallCredential
+                        SqlServicePrimaryCredential = $mockSqlServicePrimaryCredential
+                        OutputPath                    = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData             = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $currentConfiguration = Get-DscConfiguration
+
+                $resourceCurrentState = $currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName
+                } | Where-Object -FilterScript {
+                    $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.ServiceType | Should -Be $mockServiceTypeDatabaseEngine
+                $resourceCurrentState.ServiceAccountName | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $mockSqlServicePrimaryAccountUserName -Leaf))
+            }
+        }
+
+        $configurationName = "$($script:DSCResourceName)_SqlServerAgent_DefaultInstance_Restore_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        SqlInstallCredential             = $mockSqlInstallCredential
+                        SqlAgentServicePrimaryCredential = $mockSqlAgentServicePrimaryCredential
+                        OutputPath                       = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData                = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $currentConfiguration = Get-DscConfiguration
+
+                $resourceCurrentState = $currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName
+                } | Where-Object -FilterScript {
+                    $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.ServiceType | Should -Be $mockServiceTypeSqlServerAgent
+                $resourceCurrentState.ServiceAccountName | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $mockSqlAgentServicePrimaryAccountUserName -Leaf))
+            }
+        }
+
+        $configurationName = "$($script:DSCResourceName)_DatabaseEngine_NamedInstance_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        SqlInstallCredential          = $mockSqlInstallCredential
+                        SqlServiceSecondaryCredential = $mockSqlServiceSecondaryCredential
+                        OutputPath                    = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData             = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $currentConfiguration = Get-DscConfiguration
+
+                $resourceCurrentState = $currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName
+                } | Where-Object -FilterScript {
+                    $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.ServiceType | Should -Be $mockServiceTypeDatabaseEngine
+                $resourceCurrentState.ServiceAccountName | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $mockSqlServiceSecondaryAccountUserName -Leaf))
+            }
+        }
+
+        $configurationName = "$($script:DSCResourceName)_SqlServerAgent_NamedInstance_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        SqlInstallCredential               = $mockSqlInstallCredential
+                        SqlAgentServiceSecondaryCredential = $mockSqlAgentServiceSecondaryCredential
+                        OutputPath                         = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData                  = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $currentConfiguration = Get-DscConfiguration
+
+                $resourceCurrentState = $currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName
+                } | Where-Object -FilterScript {
+                    $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.ServiceType | Should -Be $mockServiceTypeSqlServerAgent
+                $resourceCurrentState.ServiceAccountName | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $mockSqlAgentServiceSecondaryAccountUserName -Leaf))
+            }
+        }
+
+        $configurationName = "$($script:DSCResourceName)_DatabaseEngine_NamedInstance_Restore_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        SqlInstallCredential          = $mockSqlInstallCredential
+                        SqlServicePrimaryCredential = $mockSqlServicePrimaryCredential
+                        OutputPath                    = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData             = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $currentConfiguration = Get-DscConfiguration
+
+                $resourceCurrentState = $currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName
+                } | Where-Object -FilterScript {
+                    $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.ServiceType | Should -Be $mockServiceTypeDatabaseEngine
+                $resourceCurrentState.ServiceAccountName | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $mockSqlServicePrimaryAccountUserName -Leaf))
+            }
+        }
+
+        $configurationName = "$($script:DSCResourceName)_SqlServerAgent_NamedInstance_Restore_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        SqlInstallCredential             = $mockSqlInstallCredential
+                        SqlAgentServicePrimaryCredential = $mockSqlAgentServicePrimaryCredential
+                        OutputPath                       = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData                = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $currentConfiguration = Get-DscConfiguration
+
+                $resourceCurrentState = $currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName
+                } | Where-Object -FilterScript {
+                    $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.ServiceType | Should -Be $mockServiceTypeSqlServerAgent
+                $resourceCurrentState.ServiceAccountName | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $mockSqlAgentServicePrimaryAccountUserName -Leaf))
             }
         }
     }

--- a/Tests/Integration/MSFT_SqlServiceAccount.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlServiceAccount.Integration.Tests.ps1
@@ -71,7 +71,6 @@ try
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlInstallCredential          = $mockSqlInstallCredential
                         SqlServiceSecondaryCredential = $mockSqlServiceSecondaryCredential
                         OutputPath                    = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
@@ -163,7 +162,6 @@ try
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlInstallCredential          = $mockSqlInstallCredential
                         SqlServicePrimaryCredential = $mockSqlServicePrimaryCredential
                         OutputPath                    = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
@@ -255,7 +253,6 @@ try
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlInstallCredential          = $mockSqlInstallCredential
                         SqlServiceSecondaryCredential = $mockSqlServiceSecondaryCredential
                         OutputPath                    = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
@@ -347,7 +344,6 @@ try
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlInstallCredential          = $mockSqlInstallCredential
                         SqlServicePrimaryCredential = $mockSqlServicePrimaryCredential
                         OutputPath                    = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.

--- a/Tests/Integration/MSFT_SqlServiceAccount.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlServiceAccount.Integration.Tests.ps1
@@ -51,7 +51,11 @@ try
     $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
     . $configFile
 
-    $mockServiceTypeDatabaseEngine = $ConfigurationData.AllNodes.ServiceTypeDatabaseEngine
+    <#
+        This should have used $ConfigurationData.AllNodes.ServiceTypeDatabaseEngine
+        but due to a bug (see issue #981) we have to set this to 'SqlServer'.
+    #>
+    $mockServiceTypeDatabaseEngine = 'SqlServer'
     $mockServiceTypeSqlServerAgent = $ConfigurationData.AllNodes.ServiceTypeSqlServerAgent
 
     Describe "$($script:DSCResourceName)_Integration" {
@@ -100,8 +104,9 @@ try
                     $_.ResourceId -eq $resourceId
                 }
 
-                $resourceCurrentState.ServiceType    | Should -Be $mockServiceTypeDatabaseEngine
-                $resourceCurrentState.ServiceAccount | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $mockSqlAgentServiceSecondaryAccountUserName -Leaf))
+                $resourceCurrentState.ServiceType | Should -Be $mockServiceTypeDatabaseEngine
+                $resourceCurrentState.ServiceAccount.UserName | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $mockSqlServiceSecondaryAccountUserName -Leaf))
+                $resourceCurrentState.ServiceAccount | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $mockSqlServiceSecondaryAccountUserName -Leaf))
             }
         }
     }

--- a/Tests/Integration/MSFT_SqlServiceAccount.config.ps1
+++ b/Tests/Integration/MSFT_SqlServiceAccount.config.ps1
@@ -18,15 +18,18 @@ $ConfigurationData = @{
     )
 }
 
+<#
+    .SYNOPSIS
+        Changes the SQL Server service account of the default instance to a
+        different account that was initially used during installation.
+
+    .NOTES
+        This test was intentionally meant to run as SYSTEM.
+#>
 Configuration MSFT_SqlServiceAccount_DatabaseEngine_DefaultInstance_Config
 {
     param
     (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $SqlInstallCredential,
-
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSCredential]
@@ -36,9 +39,6 @@ Configuration MSFT_SqlServiceAccount_DatabaseEngine_DefaultInstance_Config
     Import-DscResource -ModuleName 'SqlServerDsc'
 
     node localhost {
-        <#
-            Run this test as SYSTEM.
-        #>
         SqlServiceAccount Integration_Test
         {
             ServerName     = $Node.ServerName
@@ -50,6 +50,15 @@ Configuration MSFT_SqlServiceAccount_DatabaseEngine_DefaultInstance_Config
     }
 }
 
+<#
+    .SYNOPSIS
+        Changes the SQL Server Agent service account of the default instance to
+        a different account that was initially used during installation.
+
+    .NOTES
+        This test is intentionally meant to run using the credentials in
+        $SqlInstallCredential.
+#>
 Configuration MSFT_SqlServiceAccount_SqlServerAgent_DefaultInstance_Config
 {
     param
@@ -68,9 +77,6 @@ Configuration MSFT_SqlServiceAccount_SqlServerAgent_DefaultInstance_Config
     Import-DscResource -ModuleName 'SqlServerDsc'
 
     node localhost {
-        <#
-            Run this test as $SqlInstallCredential.
-        #>
         SqlServiceAccount Integration_Test
         {
             ServerName           = $Node.ServerName
@@ -84,15 +90,18 @@ Configuration MSFT_SqlServiceAccount_SqlServerAgent_DefaultInstance_Config
     }
 }
 
+<#
+    .SYNOPSIS
+        Reverts the SQL Server service account of the default instance to the
+        original account that was initially used during installation.
+
+    .NOTES
+        This test was intentionally meant to run as SYSTEM.
+#>
 Configuration MSFT_SqlServiceAccount_DatabaseEngine_DefaultInstance_Restore_Config
 {
     param
     (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $SqlInstallCredential,
-
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSCredential]
@@ -102,9 +111,6 @@ Configuration MSFT_SqlServiceAccount_DatabaseEngine_DefaultInstance_Restore_Conf
     Import-DscResource -ModuleName 'SqlServerDsc'
 
     node localhost {
-        <#
-            Run this test as SYSTEM.
-        #>
         SqlServiceAccount Integration_Test
         {
             ServerName     = $Node.ServerName
@@ -116,6 +122,15 @@ Configuration MSFT_SqlServiceAccount_DatabaseEngine_DefaultInstance_Restore_Conf
     }
 }
 
+<#
+    .SYNOPSIS
+        Reverts the SQL Server Agent service account of the default instance to
+        the original account that was initially used during installation.
+
+    .NOTES
+        This test is intentionally meant to run using the credentials in
+        $SqlInstallCredential.
+#>
 Configuration MSFT_SqlServiceAccount_SqlServerAgent_DefaultInstance_Restore_Config
 {
     param
@@ -134,9 +149,6 @@ Configuration MSFT_SqlServiceAccount_SqlServerAgent_DefaultInstance_Restore_Conf
     Import-DscResource -ModuleName 'SqlServerDsc'
 
     node localhost {
-        <#
-            Run this test as $SqlInstallCredential.
-        #>
         SqlServiceAccount Integration_Test
         {
             ServerName           = $Node.ServerName
@@ -150,15 +162,18 @@ Configuration MSFT_SqlServiceAccount_SqlServerAgent_DefaultInstance_Restore_Conf
     }
 }
 
+<#
+    .SYNOPSIS
+        Changes the SQL Server service account of the named instance to a
+        different account that was initially used during installation.
+
+    .NOTES
+        This test was intentionally meant to run as SYSTEM.
+#>
 Configuration MSFT_SqlServiceAccount_DatabaseEngine_NamedInstance_Config
 {
     param
     (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $SqlInstallCredential,
-
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSCredential]
@@ -168,9 +183,6 @@ Configuration MSFT_SqlServiceAccount_DatabaseEngine_NamedInstance_Config
     Import-DscResource -ModuleName 'SqlServerDsc'
 
     node localhost {
-        <#
-            Run this test as SYSTEM.
-        #>
         SqlServiceAccount Integration_Test
         {
             ServerName     = $Node.ServerName
@@ -182,6 +194,15 @@ Configuration MSFT_SqlServiceAccount_DatabaseEngine_NamedInstance_Config
     }
 }
 
+<#
+    .SYNOPSIS
+        Changes the SQL Server Agent service account of the named instance to
+        a different account that was initially used during installation.
+
+    .NOTES
+        This test is intentionally meant to run using the credentials in
+        $SqlInstallCredential.
+#>
 Configuration MSFT_SqlServiceAccount_SqlServerAgent_NamedInstance_Config
 {
     param
@@ -200,9 +221,6 @@ Configuration MSFT_SqlServiceAccount_SqlServerAgent_NamedInstance_Config
     Import-DscResource -ModuleName 'SqlServerDsc'
 
     node localhost {
-        <#
-            Run this test as $SqlInstallCredential.
-        #>
         SqlServiceAccount Integration_Test
         {
             ServerName           = $Node.ServerName
@@ -216,15 +234,18 @@ Configuration MSFT_SqlServiceAccount_SqlServerAgent_NamedInstance_Config
     }
 }
 
+<#
+    .SYNOPSIS
+        Reverts the SQL Server service account of the named instance to the
+        original account that was initially used during installation.
+
+    .NOTES
+        This test was intentionally meant to run as SYSTEM.
+#>
 Configuration MSFT_SqlServiceAccount_DatabaseEngine_NamedInstance_Restore_Config
 {
     param
     (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $SqlInstallCredential,
-
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSCredential]
@@ -234,9 +255,6 @@ Configuration MSFT_SqlServiceAccount_DatabaseEngine_NamedInstance_Restore_Config
     Import-DscResource -ModuleName 'SqlServerDsc'
 
     node localhost {
-        <#
-            Run this test as SYSTEM.
-        #>
         SqlServiceAccount Integration_Test
         {
             ServerName     = $Node.ServerName
@@ -248,6 +266,15 @@ Configuration MSFT_SqlServiceAccount_DatabaseEngine_NamedInstance_Restore_Config
     }
 }
 
+<#
+    .SYNOPSIS
+        Reverts the SQL Server Agent service account of the named instance to
+        the original account that was initially used during installation.
+
+    .NOTES
+        This test is intentionally meant to run using the credentials in
+        $SqlInstallCredential.
+#>
 Configuration MSFT_SqlServiceAccount_SqlServerAgent_NamedInstance_Restore_Config
 {
     param
@@ -266,9 +293,6 @@ Configuration MSFT_SqlServiceAccount_SqlServerAgent_NamedInstance_Restore_Config
     Import-DscResource -ModuleName 'SqlServerDsc'
 
     node localhost {
-        <#
-            Run this test as $SqlInstallCredential.
-        #>
         SqlServiceAccount Integration_Test
         {
             ServerName           = $Node.ServerName

--- a/Tests/Integration/MSFT_SqlServiceAccount.config.ps1
+++ b/Tests/Integration/MSFT_SqlServiceAccount.config.ps1
@@ -1,0 +1,151 @@
+# This is used to make sure the integration test run in the correct order.
+[Microsoft.DscResourceKit.IntegrationTest(OrderNumber = 2)]
+param()
+
+$ConfigurationData = @{
+    AllNodes = @(
+        @{
+            NodeName                    = 'localhost'
+            ServerName                  = $env:COMPUTERNAME
+            DefaultInstanceName         = 'MSSQLSERVER'
+            NamedInstanceName           = 'DSCSQL2016'
+
+            ServiceTypeDatabaseEngine   = 'DatabaseEngine'
+            ServiceTypeSqlServerAgent   = 'SQLServerAgent'
+
+            PSDscAllowPlainTextPassword = $true
+        }
+    )
+}
+
+Configuration MSFT_SqlServiceAccount_DatabaseEngine_DefaultInstance_Config
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SqlInstallCredential,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SqlServiceSecondaryCredential
+    )
+
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node localhost {
+        <#
+            Run this test as SYSTEM.
+        #>
+        SqlServiceAccount Integration_Test
+        {
+            ServerName     = $Node.ServerName
+            InstanceName   = $Node.DefaultInstanceName
+            ServiceType    = $Node.ServiceTypeDatabaseEngine
+            ServiceAccount = $ServiceAccountCredential
+            RestartService = $true
+        }
+    }
+}
+
+Configuration MSFT_SqlServiceAccount_SqlServerAgent_DefaultInstance_Config
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SqlInstallCredential,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SqlAgentServiceSecondaryCredential
+    )
+
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node localhost {
+        <#
+            Run this test as $SqlInstallCredential.
+        #>
+        SqlServiceAccount Integration_Test
+        {
+            ServerName           = $Node.ServerName
+            InstanceName         = $Node.DefaultInstanceName
+            ServiceType          = $Node.ServiceTypeSQLServerAgent
+            ServiceAccount       = $SqlAgentServiceSecondaryCredential
+            RestartService       = $true
+
+            PsDscRunAsCredential = $SqlInstallCredential
+        }
+    }
+}
+
+Configuration MSFT_SqlServiceAccount_DatabaseEngine_DefaultInstance_Restore_Config
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SqlInstallCredential,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SqlServicePrimaryCredential
+    )
+
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node localhost {
+        <#
+            Run this test as SYSTEM.
+        #>
+        SqlServiceAccount Integration_Test
+        {
+            ServerName     = $Node.ServerName
+            InstanceName   = $Node.DefaultInstanceName
+            ServiceType    = $Node.ServiceTypeDatabaseEngine
+            ServiceAccount = $SqlServicePrimaryCredential
+            RestartService = $true
+        }
+    }
+}
+
+Configuration MSFT_SqlServiceAccount_SqlServerAgent_DefaultInstance_Restore_Config
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SqlInstallCredential,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SqlAgentServicePrimaryCredential
+    )
+
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node localhost {
+        <#
+            Run this test as $SqlInstallCredential.
+        #>
+        SqlServiceAccount Integration_Test
+        {
+            ServerName           = $Node.ServerName
+            InstanceName         = $Node.DefaultInstanceName
+            ServiceType          = $Node.ServiceTypeSQLServerAgent
+            ServiceAccount       = $SqlAgentServicePrimaryCredential
+            RestartService       = $true
+
+            PsDscRunAsCredential = $SqlInstallCredential
+        }
+    }
+}

--- a/Tests/Integration/MSFT_SqlServiceAccount.config.ps1
+++ b/Tests/Integration/MSFT_SqlServiceAccount.config.ps1
@@ -11,7 +11,7 @@ $ConfigurationData = @{
             NamedInstanceName           = 'DSCSQL2016'
 
             ServiceTypeDatabaseEngine   = 'DatabaseEngine'
-            ServiceTypeSqlServerAgent   = 'SQLServerAgent'
+            ServiceTypeSqlServerAgent   = 'SqlServerAgent'
 
             PSDscAllowPlainTextPassword = $true
         }
@@ -141,6 +141,138 @@ Configuration MSFT_SqlServiceAccount_SqlServerAgent_DefaultInstance_Restore_Conf
         {
             ServerName           = $Node.ServerName
             InstanceName         = $Node.DefaultInstanceName
+            ServiceType          = $Node.ServiceTypeSQLServerAgent
+            ServiceAccount       = $SqlAgentServicePrimaryCredential
+            RestartService       = $true
+
+            PsDscRunAsCredential = $SqlInstallCredential
+        }
+    }
+}
+
+Configuration MSFT_SqlServiceAccount_DatabaseEngine_NamedInstance_Config
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SqlInstallCredential,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SqlServiceSecondaryCredential
+    )
+
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node localhost {
+        <#
+            Run this test as SYSTEM.
+        #>
+        SqlServiceAccount Integration_Test
+        {
+            ServerName     = $Node.ServerName
+            InstanceName   = $Node.NamedInstanceName
+            ServiceType    = $Node.ServiceTypeDatabaseEngine
+            ServiceAccount = $SqlServiceSecondaryCredential
+            RestartService = $true
+        }
+    }
+}
+
+Configuration MSFT_SqlServiceAccount_SqlServerAgent_NamedInstance_Config
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SqlInstallCredential,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SqlAgentServiceSecondaryCredential
+    )
+
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node localhost {
+        <#
+            Run this test as $SqlInstallCredential.
+        #>
+        SqlServiceAccount Integration_Test
+        {
+            ServerName           = $Node.ServerName
+            InstanceName         = $Node.NamedInstanceName
+            ServiceType          = $Node.ServiceTypeSQLServerAgent
+            ServiceAccount       = $SqlAgentServiceSecondaryCredential
+            RestartService       = $true
+
+            PsDscRunAsCredential = $SqlInstallCredential
+        }
+    }
+}
+
+Configuration MSFT_SqlServiceAccount_DatabaseEngine_NamedInstance_Restore_Config
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SqlInstallCredential,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SqlServicePrimaryCredential
+    )
+
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node localhost {
+        <#
+            Run this test as SYSTEM.
+        #>
+        SqlServiceAccount Integration_Test
+        {
+            ServerName     = $Node.ServerName
+            InstanceName   = $Node.NamedInstanceName
+            ServiceType    = $Node.ServiceTypeDatabaseEngine
+            ServiceAccount = $SqlServicePrimaryCredential
+            RestartService = $true
+        }
+    }
+}
+
+Configuration MSFT_SqlServiceAccount_SqlServerAgent_NamedInstance_Restore_Config
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SqlInstallCredential,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SqlAgentServicePrimaryCredential
+    )
+
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node localhost {
+        <#
+            Run this test as $SqlInstallCredential.
+        #>
+        SqlServiceAccount Integration_Test
+        {
+            ServerName           = $Node.ServerName
+            InstanceName         = $Node.NamedInstanceName
             ServiceType          = $Node.ServiceTypeSQLServerAgent
             ServiceAccount       = $SqlAgentServicePrimaryCredential
             RestartService       = $true

--- a/Tests/Integration/MSFT_SqlServiceAccount.config.ps1
+++ b/Tests/Integration/MSFT_SqlServiceAccount.config.ps1
@@ -44,7 +44,7 @@ Configuration MSFT_SqlServiceAccount_DatabaseEngine_DefaultInstance_Config
             ServerName     = $Node.ServerName
             InstanceName   = $Node.DefaultInstanceName
             ServiceType    = $Node.ServiceTypeDatabaseEngine
-            ServiceAccount = $ServiceAccountCredential
+            ServiceAccount = $SqlServiceSecondaryCredential
             RestartService = $true
         }
     }

--- a/Tests/Integration/README.md
+++ b/Tests/Integration/README.md
@@ -37,12 +37,16 @@ All instances have a SQL Server Agent that is started.
 The following local users are created on the AppVeyor build worker and can
 be used by other integration tests.
 
+> Note: User account names was kept to a maximum of 15 characters.
+
 User | Password | Permission | Description
 --- | --- | --- | ---
-.\SqlInstall | P@ssw0rd1 | Local administrator. Administrator on Database Engine instance DSCSQL2016*. | Runs Setup for the default instance
-.\SqlAdmin | P@ssw0rd1 | Administrator on all SQL Server instances |
-.\svc-Sql | yig-C^Equ3 | Local user | Runs the SQL Server service.
-.\svc-SqlAgent | yig-C^Equ3 | Local user | Runs the SQL Server Agent service.
+.\SqlInstall | P@ssw0rd1 | Local administrator. Administrator of Database Engine instance DSCSQL2016\*. | Runs Setup for the default instance.
+.\SqlAdmin | P@ssw0rd1 | Administrator of all SQL Server instances. |
+.\svc-SqlPrimary | yig-C^Equ3 | Local user. | Runs the SQL Server Agent service.
+.\svc-SqlAgentPri | yig-C^Equ3 | Local user. | Runs the SQL Server Agent service.
+.\svc-SqlSecondary | yig-C^Equ3 | Local user. | Used by other tests, but created here.
+.\svc-SqlAgentSec | yig-C^Equ3 | Local user. | Used by other tests.
 
 *\* This is due to that the integration tests runs the resource SqlAlwaysOnService
 with this user and that means that this user must have permission to access the
@@ -57,7 +61,7 @@ AppVeyor build worker for other integration tests to use.
 
 Instance | Feature | Description
 --- | --- | ---
-DSCRS2016 | RS | The Reporting Services is left initialized, and in working state.
+DSCRS2016 | RS | The Reporting Services is left initialized, and in a working state.
 
 ### Properties for the instance
 
@@ -72,7 +76,7 @@ DSCRS2016 | RS | The Reporting Services is left initialized, and in working stat
 **Run order:** 2
 
 The integration test will change the data, log and backup path of instance
-DSCSQL2016 to the following.
+**DSCSQL2016** to the following.
 
 Data | Log | Backup
 --- | --- | ---

--- a/Tests/Integration/README.md
+++ b/Tests/Integration/README.md
@@ -3,11 +3,11 @@
 For it to be easier to write integration tests for a resource that depends on
 other resources, this will list the run order of the integration tests that keep
 their configuration on the AppVeyor build worker. For example, the integration
-tests for SqlAlwaysOnService enables and then disables the AlwaysOn functionality,
-so that integration test is not listed here.
+test for SqlAlwaysOnService enables and then disables the AlwaysOn functionality,
+so that integration test are not listed.
 
-If a integration test should use one or more of these previous integration test
-configurations then the run order for the new integration test should be set to
+If an integration test should use one or more of these previous integration test
+configurations then the run order for the new integration tests should be set to
 a higher run order number than the highest run order of the dependent integration
 tests.
 

--- a/Tests/Integration/README.md
+++ b/Tests/Integration/README.md
@@ -24,6 +24,8 @@ DSCSQL2016 | SQLENGINE,AS,CONN,BC,SDK | MULTIDIMENSIONAL
 DSCTABULAR | AS,CONN,BC,SDK | TABULAR
 MSSQLSERVER | SQLENGINE,CONN,BC,SDK | -
 
+All instances have a SQL Server Agent that is started.
+
 ### Properties for all instances
 
 - **Collation:** Finnish\_Swedish\_CI\_AS
@@ -37,10 +39,14 @@ be used by other integration tests.
 
 User | Password | Permission | Description
 --- | --- | --- | ---
-.\SqlInstall | P@ssw0rd1 | Local administrator | Runs Setup for the default instance
+.\SqlInstall | P@ssw0rd1 | Local administrator. Administrator on Database Engine instance DSCSQL2016*. | Runs Setup for the default instance
 .\SqlAdmin | P@ssw0rd1 | Administrator on all SQL Server instances |
 .\svc-Sql | yig-C^Equ3 | Local user | Runs the SQL Server service.
 .\svc-SqlAgent | yig-C^Equ3 | Local user | Runs the SQL Server Agent service.
+
+*\* This is due to that the integration tests runs the resource SqlAlwaysOnService
+with this user and that means that this user must have permission to access the
+properties `IsClustered` and `IsHadrEnable`.*
 
 ## SqlRS
 

--- a/Tests/Integration/README.md
+++ b/Tests/Integration/README.md
@@ -1,0 +1,73 @@
+# Integration tests for SqlServerDsc
+
+For it to be easier to write integration tests for a resource that depends on
+other resources, this will list the run order of the integration tests that keep
+their configuration on the AppVeyor build worker. For example, the integration
+tests for SqlAlwaysOnService enables and then disables the AlwaysOn functionality,
+so that integration test is not listed here.
+
+If a integration test should use one or more of these previous integration test
+configurations then the run order for the new integration test should be set to
+a higher run order number than the highest run order of the dependent integration
+tests.
+
+## SqlSetup
+
+**Run order:** 1
+
+The integration tests will install the following instances and leave them on the
+AppVeyor build worker for other integration tests to use.
+
+Instance | Feature | AS server mode
+--- | --- | ---
+DSCSQL2016 | SQLENGINE,AS,CONN,BC,SDK | MULTIDIMENSIONAL
+DSCTABULAR | AS,CONN,BC,SDK | TABULAR
+MSSQLSERVER | SQLENGINE,CONN,BC,SDK | -
+
+### Properties for all instances
+
+- **Collation:** Finnish\_Swedish\_CI\_AS
+- **InstallSharedDir:** C:\Program Files\Microsoft SQL Server
+- **InstallSharedWOWDir:** C:\Program Files (x86)\Microsoft SQL Server
+
+### Users
+
+The following local users are created on the AppVeyor build worker and can
+be used by other integration tests.
+
+User | Password | Permission | Description
+--- | --- | --- | ---
+.\SqlInstall | P@ssw0rd1 | Local administrator | Runs Setup for the default instance
+.\SqlAdmin | P@ssw0rd1 | Administrator on all SQL Server instances |
+.\svc-Sql | yig-C^Equ3 | Local user | Runs the SQL Server service.
+.\svc-SqlAgent | yig-C^Equ3 | Local user | Runs the SQL Server Agent service.
+
+## SqlRS
+
+**Run order:** 2
+
+The integration tests will install the following instances and leave it on the
+AppVeyor build worker for other integration tests to use.
+
+Instance | Feature | Description
+--- | --- | ---
+DSCRS2016 | RS | The Reporting Services is left initialized, and in working state.
+
+### Properties for the instance
+
+- **Collation:** Finnish\_Swedish\_CI\_AS
+- **InstallSharedDir:** C:\Program Files\Microsoft SQL Server
+- **InstallSharedWOWDir:** C:\Program Files (x86)\Microsoft SQL Server
+- **DatabaseServerName:** `$env:COMPUTERNAME`
+- **DatabaseInstanceName:** DSCSQL2016
+
+## SqlDatabaseDefaultLocation
+
+**Run order:** 2
+
+The integration test will change the data, log and backup path of instance
+DSCSQL2016 to the following.
+
+Data | Log | Backup
+--- | --- | ---
+C:\SQLData | C:\SQLLog | C:\Backups

--- a/Tests/Unit/MSFT_SqlServiceAccount.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServiceAccount.Tests.ps1
@@ -668,7 +668,7 @@ try
                     $testServiceInformation.ServerName | Should -Be $mockSqlServer
                     $testServiceInformation.InstanceName | Should -Be $mockNamedInstance
                     $testServiceInformation.ServiceType | Should -Be 'SqlServer'
-                    $testServiceInformation.ServiceAccount | Should -Be $mockDesiredServiceAccountName
+                    $testServiceInformation.ServiceAccountName | Should -Be $mockDesiredServiceAccountName
 
                     # Ensure mocks were properly used
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Exactly -Times 1
@@ -705,7 +705,7 @@ try
                     $currentState = Get-TargetResource @defaultGetTargetResourceParameters
 
                     # Validate the service account
-                    $currentState.ServiceAccount | Should -Be $mockLocalServiceAccountName
+                    $currentState.ServiceAccountName | Should -Be $mockLocalServiceAccountName
 
                     # Ensure mocks were properly used
                     Assert-MockCalled -CommandName New-Object -ParameterFilter $mockNewObject_ParameterFilter -Scope It -Exactly -Times 1
@@ -900,10 +900,10 @@ try
                 }
 
                 It 'Should throw the correct exception if SetServiceAccount call fails' {
-                    $newObjectParms = $mockNewObjectParameters_DefaultInstance.Clone()
-                    $newObjectParms.MockWith = $mockNewObject_ManagedComputer_DefaultInstance_SetServiceAccountException
+                    $newObjectParameters = $mockNewObjectParameters_DefaultInstance.Clone()
+                    $newObjectParameters.MockWith = $mockNewObject_ManagedComputer_DefaultInstance_SetServiceAccountException
 
-                    Mock @newObjectParms
+                    Mock @newObjectParameters
 
                     $setTargetResourceParameters = $defaultSetTargetResourceParameters.Clone()
 
@@ -984,10 +984,10 @@ try
                 }
 
                 It 'Should throw the correct exception if SetServiceAccount call fails' {
-                    $newObjectParms = $mockNewObjectParameters_NamedInstance.Clone()
-                    $newObjectParms.MockWith = $mockNewObject_ManagedComputer_NamedInstance_SetServiceAccountException
+                    $newObjectParameters = $mockNewObjectParameters_NamedInstance.Clone()
+                    $newObjectParameters.MockWith = $mockNewObject_ManagedComputer_NamedInstance_SetServiceAccountException
 
-                    Mock @newObjectParms
+                    Mock @newObjectParameters
 
                     $setTargetResourceParameters = $defaultSetTargetResourceParameters.Clone()
 

--- a/Tests/Unit/MSFT_SqlServiceAccount.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServiceAccount.Tests.ps1
@@ -629,7 +629,7 @@ try
                     $testServiceInformation.ServerName | Should -Be $mockSqlServer
                     $testServiceInformation.InstanceName | Should -Be $mockDefaultInstanceName
                     $testServiceInformation.ServiceType | Should -Be 'SqlServer'
-                    $testServiceInformation.ServiceAccount | Should -Be $mockDefaultServiceAccountName
+                    $testServiceInformation.ServiceAccountName | Should -Be $mockDefaultServiceAccountName
 
                     # Ensure mocks were properly used
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Exactly -Times 1


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to SqlServerDsc
  - Added a README.md under Tests\Integration to help contributors to write
   integration tests.
  - Added 'Integration tests' section in the CONTRIBUTING.md.
- Changes to SqlServiceAccount
  - Added a read-only parameter ServiceAccountName so that the service account
    name is correctly returned as a string (issue #982).
  - Added integration tests (issue #980).
- Changes to SqlSetup
  - Cleaned up integration tests.
  - Added integration tests for installing a default instance of Database Engine.

**This Pull Request (PR) fixes the following issues:**
Fixes #980 
Fixes #982 

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/987)
<!-- Reviewable:end -->

  