### PR TITLE
SqlRS: Fix Script Analyzer warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
     ([issue #949](https://github.com/PowerShell/SqlServerDsc/issues/949)).
 - Changes to SqlDatabase
   - Fix minor Script Analyzer warning.
+- Changes to SqlRS
+  - Replaced Get-WmiObject with Get-CimInstance to fix Script Analyzer warnings
+    ([issue #264](https://github.com/PowerShell/SqlServerDsc/issues/264)).
 - Changes to SqlServerNetwork
   - Added sysadmin account parameter usage to the examples.
 - Changes to SqlServerReplication

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Changes to SqlRS
   - Replaced Get-WmiObject with Get-CimInstance to fix Script Analyzer warnings
     ([issue #264](https://github.com/PowerShell/SqlServerDsc/issues/264)).
+  - Refactored the resource to use Invoke-CimMethod.
 - Changes to SqlServerNetwork
   - Added sysadmin account parameter usage to the examples.
 - Changes to SqlServerReplication

--- a/DSCResources/MSFT_SqlRS/MSFT_SqlRS.psm1
+++ b/DSCResources/MSFT_SqlRS/MSFT_SqlRS.psm1
@@ -353,7 +353,6 @@ function Set-TargetResource
                     UserName = $reportingServicesServiceAccountUserName
                     IsRemote = $false
                     IsWindowsUser = $true
-                    Lcid = $language
                 }
             }
 

--- a/DSCResources/MSFT_SqlRS/MSFT_SqlRS.psm1
+++ b/DSCResources/MSFT_SqlRS/MSFT_SqlRS.psm1
@@ -203,7 +203,7 @@ function Set-TargetResource
             $reportingServicesConnection = "$DatabaseServerName\$DatabaseInstanceName"
         }
 
-        $wmiOperatingSystem = Get-WMIObject -Class Win32_OperatingSystem -Namespace 'root/cimv2' -ErrorAction SilentlyContinue
+        $wmiOperatingSystem = Get-CimInstance -ClassName Win32_OperatingSystem -Namespace 'root/cimv2' -ErrorAction SilentlyContinue
         if ( $null -eq $wmiOperatingSystem )
         {
             throw 'Unable to find WMI object Win32_OperatingSystem.'
@@ -250,7 +250,7 @@ function Set-TargetResource
             $reportingServicesDatabaseScript = $reportingServicesData.Configuration.GenerateDatabaseCreationScript($reportingServicesDatabaseName, $language, $false)
 
             # Determine RS service account
-            $reportingServicesServiceAccountUserName = (Get-WmiObject -Class Win32_Service | Where-Object -FilterScript {
+            $reportingServicesServiceAccountUserName = (Get-CimInstance -ClassName Win32_Service | Where-Object -FilterScript {
                     $_.Name -eq $reportingServicesServiceName
                 }).StartName
             $reportingServicesDatabaseRightsScript = $reportingServicesData.Configuration.GenerateDatabaseRightsScript($reportingServicesServiceAccountUserName, $reportingServicesDatabaseName, $false, $true)
@@ -508,7 +508,7 @@ function Get-ReportingServicesData
     {
         $instanceId = (Get-ItemProperty -Path $instanceNamesRegistryKey -Name $InstanceName).$InstanceName
         $sqlVersion = [System.Int32]((Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$instanceId\Setup" -Name 'Version').Version).Split('.')[0]
-        $reportingServicesConfiguration = Get-WmiObject -Class MSReportServer_ConfigurationSetting -Namespace "root\Microsoft\SQLServer\ReportServer\RS_$InstanceName\v$sqlVersion\Admin"
+        $reportingServicesConfiguration = Get-CimInstance -ClassName MSReportServer_ConfigurationSetting -Namespace "root\Microsoft\SQLServer\ReportServer\RS_$InstanceName\v$sqlVersion\Admin"
         $reportingServicesConfiguration = $reportingServicesConfiguration | Where-Object -FilterScript {
             $_.InstanceName -eq $InstanceName
         }

--- a/DSCResources/MSFT_SqlRS/MSFT_SqlRS.psm1
+++ b/DSCResources/MSFT_SqlRS/MSFT_SqlRS.psm1
@@ -827,32 +827,6 @@ function Invoke-RsCimMethod
     #>
     if ($invokeCimMethodResult -and $invokeCimMethodResult.HRESULT -ne 0)
     {
-        <#
-            Errors that was found during development (and kept here for reference):
-
-            -------------------------------------------------------------------
-            Invoke-CimMethod
-            -------------------------------------------------------------------
-            Error: The parameter is incorrect.
-            Cause: Calling a method without one or more parameters.
-            -------------------------------------------------------------------
-
-            -------------------------------------------------------------------
-            ReserveUrl()
-            -------------------------------------------------------------------
-            Error: The parameter is incorrect. (HRESULT:-2147024809)
-            Cause: For example trying to URL with wrong format ( 'htp://+:80').
-
-            Error: The Url has already been reserved. (HRESULT:-2147220932)
-            Cause: When 'http://+:80' already exist.
-
-            Error: Cannot create a file when that file already exists.
-                   (HRESULT:-2147024713)
-            Cause: Trying to add 'http://+:443' (resulted in error since port 80
-                   is already using http).
-            -------------------------------------------------------------------
-        #>
-
         if ($invokeCimMethodResult | Get-Member -Name 'ExtendedErrors')
         {
             <#

--- a/README.md
+++ b/README.md
@@ -699,6 +699,23 @@ Initializes and configures SQL Reporting Services server.
 * [Default configuration](Examples/Resources/SqlRS/1-DefaultConfiguration.ps1)
 * [Custom virtual directories and reserved URLs](Examples/Resources/SqlRS/2-CustomConfiguration.ps1)
 
+#### Error messages
+
+##### Error: The parameter is incorrect (HRESULT:-2147024809)
+
+This is caused for example when trying to add an URL with the wrong format
+i.e. 'htp://+:80'.
+
+##### Error: The Url has already been reserved (HRESULT:-2147220932)
+
+This is caused when the URL is already reserved. For example 'http://+:80'
+already exist.
+
+##### Error: Cannot create a file when that file already exists (HRESULT:-2147024713)
+
+This is caused when trying to add another URL using the same protocol. For example
+trying to add 'http://+:443' when 'http://+:80' already exist.
+
 ### SqlRSSecureConnectionLevel
 
 No description.

--- a/README.md
+++ b/README.md
@@ -703,18 +703,18 @@ Initializes and configures SQL Reporting Services server.
 
 ##### Error: The parameter is incorrect (HRESULT:-2147024809)
 
-This is caused for example when trying to add an URL with the wrong format
+This is for example caused by trying to add an URL with the wrong format
 i.e. 'htp://+:80'.
 
 ##### Error: The Url has already been reserved (HRESULT:-2147220932)
 
-This is caused when the URL is already reserved. For example 'http://+:80'
+This is caused when the URL is already reserved. For example when 'http://+:80'
 already exist.
 
 ##### Error: Cannot create a file when that file already exists (HRESULT:-2147024713)
 
 This is caused when trying to add another URL using the same protocol. For example
-trying to add 'http://+:443' when 'http://+:80' already exist.
+when trying to add 'http://+:443' when 'http://+:80' already exist.
 
 ### SqlRSSecureConnectionLevel
 

--- a/Tests/Unit/MSFT_SqlRS.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlRS.Tests.ps1
@@ -50,6 +50,38 @@ try
         $mockVirtualDirectoryReportManagerName = 'Reports_SQL2016'
         $mockVirtualDirectoryReportServerName = 'ReportServer_SQL2016'
 
+        $mockInvokeCimMethod = {
+            throw 'Should not call Invoke-CimMethod directly, should call the wrapper Invoke-RsCimMethod.'
+        }
+
+        $mockInvokeRsCimMethod_ListReservedUrls = {
+            return New-Object -TypeName Object |
+                Add-Member -MemberType ScriptProperty -Name 'Application' -Value {
+                return @(
+                    $mockDynamicReportServerApplicationName,
+                    $mockDynamicReportsApplicationName
+                )
+            } -PassThru |
+                Add-Member -MemberType ScriptProperty -Name 'UrlString' -Value {
+                return @(
+                    $mockDynamicReportsApplicationUrlString,
+                    $mockDynamicReportServerApplicationUrlString
+                )
+            } -PassThru -Force
+        }
+
+        $mockInvokeRsCimMethod_GenerateDatabaseCreationScript = {
+            return @{
+                Script = 'select * from something'
+            }
+        }
+
+        $mockInvokeRsCimMethod_GenerateDatabaseRightsScript = {
+            return @{
+                Script = 'select * from something'
+            }
+        }
+
         $mockGetItemProperty = {
             return @{
                 InstanceName = $mockInstanceName
@@ -60,68 +92,14 @@ try
         $mockGetCimInstance_ConfigurationSetting_NamedInstance = {
             return @(
                 (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'DatabaseServerName' -Value "$mockReportingServicesDatabaseServerName\$mockReportingServicesDatabaseNamedInstanceName" -PassThru |
+                    New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance -ArgumentList @(
+                        'MSReportServer_ConfigurationSetting'
+                        'root/Microsoft/SQLServer/ReportServer/RS_SQL2016/v13/Admin'
+                    ) | Add-Member -MemberType NoteProperty -Name 'DatabaseServerName' -Value "$mockReportingServicesDatabaseServerName\$mockReportingServicesDatabaseNamedInstanceName" -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'IsInitialized' -Value $mockDynamicIsInitialized -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'InstanceName' -Value $mockNamedInstanceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'VirtualDirectoryReportServer' -Value $mockVirtualDirectoryReportServerName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'VirtualDirectoryReportManager' -Value $mockVirtualDirectoryReportManagerName -PassThru |
-                        Add-Member -MemberType ScriptMethod -Name SetVirtualDirectory -Value {
-                        $script:mockIsMethodCalled_SetVirtualDirectory = $true
-
-                        return $null
-                    } -PassThru |
-                        Add-Member -MemberType ScriptMethod -Name ReserveURL -Value {
-                        $script:mockIsMethodCalled_ReserveURL = $true
-
-                        return $null
-                    } -PassThru |
-                        Add-Member -MemberType ScriptMethod -Name GenerateDatabaseCreationScript -Value {
-                        $script:mockIsMethodCalled_GenerateDatabaseCreationScript = $true
-
-                        return @{
-                            Script = 'select * from something'
-                        }
-                    } -PassThru |
-                        Add-Member -MemberType ScriptMethod -Name GenerateDatabaseRightsScript -Value {
-                        $script:mockIsMethodCalled_GenerateDatabaseRightsScript = $true
-
-                        return @{
-                            Script = 'select * from something'
-                        }
-                    } -PassThru |
-                        Add-Member -MemberType ScriptMethod -Name SetDatabaseConnection -Value {
-                        $script:mockIsMethodCalled_SetDatabaseConnection = $true
-
-                        return $null
-                    } -PassThru |
-                        Add-Member -MemberType ScriptMethod -Name InitializeReportServer -Value {
-                        $script:mockIsMethodCalled_InitializeReportServer = $true
-
-                        return $null
-                    } -PassThru |
-                        Add-Member -MemberType ScriptMethod -Name RemoveURL -Value {
-                        $script:mockIsMethodCalled_RemoveURL = $true
-
-                        return $null
-                    } -PassThru |
-                        Add-Member -MemberType ScriptMethod -Name ListReservedUrls -Value {
-                        $script:mockIsMethodCalled_ListReservedUrls = $true
-
-                        return New-Object -TypeName Object |
-                            Add-Member -MemberType ScriptProperty -Name 'Application' -Value {
-                            return @(
-                                $mockDynamicReportServerApplicationName,
-                                $mockDynamicReportsApplicationName
-                            )
-                        } -PassThru |
-                            Add-Member -MemberType ScriptProperty -Name 'UrlString' -Value {
-                            return @(
-                                $mockDynamicReportsApplicationUrlString,
-                                $mockDynamicReportServerApplicationUrlString
-                            )
-                        } -PassThru -Force
-                    } -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'VirtualDirectoryReportManager' -Value $mockVirtualDirectoryReportManagerName -PassThru -Force
                 ),
                 (
                     # Array is a regression test for issue #819.
@@ -134,46 +112,14 @@ try
         }
 
         $mockGetCimInstance_ConfigurationSetting_DefaultInstance = {
-            return New-Object -TypeName Object |
-                Add-Member -MemberType NoteProperty -Name 'DatabaseServerName' -Value "$mockReportingServicesDatabaseServerName" -PassThru |
+            return New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance -ArgumentList @(
+                'MSReportServer_ConfigurationSetting'
+                'root/Microsoft/SQLServer/ReportServer/RS_SQL2016/v13/Admin'
+            ) | Add-Member -MemberType NoteProperty -Name 'DatabaseServerName' -Value "$mockReportingServicesDatabaseServerName" -PassThru |
                 Add-Member -MemberType NoteProperty -Name 'IsInitialized' -Value $false -PassThru |
                 Add-Member -MemberType NoteProperty -Name 'InstanceName' -Value $mockDefaultInstanceName -PassThru |
                 Add-Member -MemberType NoteProperty -Name 'VirtualDirectoryReportServer' -Value '' -PassThru |
-                Add-Member -MemberType NoteProperty -Name 'VirtualDirectoryReportManager' -Value '' -PassThru |
-                Add-Member -MemberType ScriptMethod -Name SetVirtualDirectory -Value {
-                $script:mockIsMethodCalled_SetVirtualDirectory = $true
-
-                return $null
-            } -PassThru |
-                Add-Member -MemberType ScriptMethod -Name ReserveURL -Value {
-                $script:mockIsMethodCalled_ReserveURL = $true
-
-                return $null
-            } -PassThru |
-                Add-Member -MemberType ScriptMethod -Name GenerateDatabaseCreationScript -Value {
-                $script:mockIsMethodCalled_GenerateDatabaseCreationScript = $true
-
-                return @{
-                    Script = 'select * from something'
-                }
-            } -PassThru |
-                Add-Member -MemberType ScriptMethod -Name GenerateDatabaseRightsScript -Value {
-                $script:mockIsMethodCalled_GenerateDatabaseRightsScript = $true
-
-                return @{
-                    Script = 'select * from something'
-                }
-            } -PassThru |
-                Add-Member -MemberType ScriptMethod -Name SetDatabaseConnection -Value {
-                $script:mockIsMethodCalled_SetDatabaseConnection = $true
-
-                return $null
-            } -PassThru |
-                Add-Member -MemberType ScriptMethod -Name InitializeReportServer -Value {
-                $script:mockIsMethodCalled_InitializeReportServer = $true
-
-                return $null
-            } -PassThru -Force
+                Add-Member -MemberType NoteProperty -Name 'VirtualDirectoryReportManager' -Value '' -PassThru -Force
         }
 
         $mockGetCimInstance_ConfigurationSetting_ParameterFilter = {
@@ -195,6 +141,15 @@ try
                 $mockDynamic_SqlBuildVersion = '13.0.4001.0'
 
                 Mock -CommandName Get-ItemProperty -MockWith $mockGetItemProperty -Verifiable
+                Mock -CommandName Invoke-RsCimMethod -MockWith $mockInvokeRsCimMethod_ListReservedUrls -ParameterFilter {
+                    $MethodName -eq 'ListReservedUrls'
+                } -Verifiable
+
+                <#
+                    This is mocked here so that no calls are made to it directly,
+                    or if any mock of Invoke-RsCimMethod are wrong.
+                #>
+                Mock -CommandName Invoke-CimMethod -MockWith $mockInvokeCimMethod
 
                 $defaultParameters = @{
                     InstanceName         = $mockNamedInstanceName
@@ -237,6 +192,10 @@ try
                     $resultGetTargetResource.ReportsVirtualDirectory | Should -Be $mockVirtualDirectoryReportManagerName
                     $resultGetTargetResource.ReportServerReservedUrl | Should -Be $mockReportServerApplicationUrl
                     $resultGetTargetResource.ReportsReservedUrl | Should -Be $mockReportsApplicationUrl
+
+                    Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                        $MethodName -eq 'ListReservedUrls'
+                    } -Exactly -Times 1 -Scope It
                 }
             }
 
@@ -272,6 +231,10 @@ try
                     $resultGetTargetResource.ReportsVirtualDirectory | Should -BeNullOrEmpty
                     $resultGetTargetResource.ReportServerReservedUrl | Should -BeNullOrEmpty
                     $resultGetTargetResource.ReportsReservedUrl | Should -BeNullOrEmpty
+
+                    Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                        $MethodName -eq 'ListReservedUrls'
+                    } -Exactly -Times 0 -Scope It
                 }
 
                 # Regression test for issue #822.
@@ -314,6 +277,25 @@ try
                 Mock -CommandName Invoke-Sqlcmd -Verifiable
                 Mock -CommandName Get-ItemProperty -MockWith $mockGetItemProperty -Verifiable
                 Mock -CommandName Restart-ReportingServicesService -Verifiable
+                Mock -CommandName Invoke-RsCimMethod -Verifiable
+                Mock -CommandName Invoke-RsCimMethod -MockWith $mockInvokeRsCimMethod_GenerateDatabaseCreationScript -ParameterFilter {
+                    $MethodName -eq 'GenerateDatabaseCreationScript'
+                }
+
+                Mock -CommandName Invoke-RsCimMethod -MockWith $mockInvokeRsCimMethod_GenerateDatabaseRightsScript -ParameterFilter {
+                    $MethodName -eq 'GenerateDatabaseRightsScript'
+                }
+
+                <#
+                    This is mocked here so that no calls are made to it directly,
+                    or if any mock of Invoke-RsCimMethod are wrong.
+                #>
+                Mock -CommandName Invoke-CimMethod -MockWith $mockInvokeCimMethod
+
+                $mockDynamicReportServerApplicationName = $mockReportServerApplicationName
+                $mockDynamicReportsApplicationName = $mockReportsApplicationName
+                $mockDynamicReportsApplicationUrlString = $mockReportsApplicationUrl
+                $mockDynamicReportServerApplicationUrlString = $mockReportServerApplicationUrl
             }
 
             Context 'When the system is not in the desired state' {
@@ -343,26 +325,46 @@ try
                             -MockWith $mockGetCimInstance_Language `
                             -ParameterFilter $mockGetCimInstance_OperatingSystem_ParameterFilter `
                             -Verifiable
-
-                        # Start each test with each method in correct state.
-                        $script:mockIsMethodCalled_GenerateDatabaseCreationScript = $false
-                        $script:mockIsMethodCalled_GenerateDatabaseRightsScript = $false
-                        $script:mockIsMethodCalled_SetVirtualDirectory = $false
-                        $script:mockIsMethodCalled_ReserveURL = $false
-                        $script:mockIsMethodCalled_SetDatabaseConnection = $false
-                        $script:mockIsMethodCalled_InitializeReportServer = $false
                     }
 
                     It 'Should configure Reporting Service without throwing an error' {
                         { Set-TargetResource @defaultParameters } | Should -Not -Throw
 
-                        # Test so each mock of methods was called.
-                        $script:mockIsMethodCalled_GenerateDatabaseRightsScript | Should -Be $true
-                        $script:mockIsMethodCalled_GenerateDatabaseCreationScript | Should -Be $true
-                        $script:mockIsMethodCalled_SetVirtualDirectory | Should -Be $true
-                        $script:mockIsMethodCalled_ReserveURL | Should -Be $true
-                        $script:mockIsMethodCalled_SetDatabaseConnection | Should -Be $true
-                        $script:mockIsMethodCalled_InitializeReportServer | Should -Be $true
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'RemoveURL'
+                        } -Exactly -Times 0 -Scope It
+
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'InitializeReportServer'
+                        } -Exactly -Times 1 -Scope It
+
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'SetDatabaseConnection'
+                        } -Exactly -Times 1 -Scope It
+
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'GenerateDatabaseRightsScript'
+                        } -Exactly -Times 1 -Scope It
+
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'GenerateDatabaseCreationScript'
+                        } -Exactly -Times 1 -Scope It
+
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'SetVirtualDirectory' -and $Arguments.Application -eq $mockReportServerApplicationName
+                        } -Exactly -Times 1 -Scope It
+
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'SetVirtualDirectory' -and $Arguments.Application -eq $mockReportsApplicationName
+                        } -Exactly -Times 1 -Scope It
+
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'ReserveUrl' -and $Arguments.Application -eq $mockReportServerApplicationName
+                        } -Exactly -Times 1 -Scope It
+
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'ReserveUrl' -and $Arguments.Application -eq $mockReportsApplicationName
+                        } -Exactly -Times 1 -Scope It
 
                         Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 2 -Scope It
                         Assert-MockCalled -CommandName Invoke-Sqlcmd -Exactly -Times 2 -Scope It
@@ -429,26 +431,50 @@ try
                             -MockWith $mockGetCimInstance_Language `
                             -ParameterFilter $mockGetCimInstance_OperatingSystem_ParameterFilter `
                             -Verifiable
-
-                        # Start each test with each method in correct state.
-                        $script:mockIsMethodCalled_GenerateDatabaseCreationScript = $false
-                        $script:mockIsMethodCalled_GenerateDatabaseRightsScript = $false
-                        $script:mockIsMethodCalled_SetVirtualDirectory = $false
-                        $script:mockIsMethodCalled_ReserveURL = $false
-                        $script:mockIsMethodCalled_SetDatabaseConnection = $false
-                        $script:mockIsMethodCalled_InitializeReportServer = $false
                     }
 
                     It 'Should configure Reporting Service without throwing an error' {
                         { Set-TargetResource @testParameters } | Should -Not -Throw
 
-                        # Test so each mock of methods was called.
-                        $script:mockIsMethodCalled_GenerateDatabaseRightsScript | Should -Be $false
-                        $script:mockIsMethodCalled_GenerateDatabaseCreationScript | Should -Be $false
-                        $script:mockIsMethodCalled_SetVirtualDirectory | Should -Be $true
-                        $script:mockIsMethodCalled_ReserveURL | Should -Be $true
-                        $script:mockIsMethodCalled_SetDatabaseConnection | Should -Be $false
-                        $script:mockIsMethodCalled_InitializeReportServer | Should -Be $false
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'RemoveURL' -and $Arguments.Application -eq $mockReportServerApplicationName
+                        } -Exactly -Times 2 -Scope It
+
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'RemoveURL' -and $Arguments.Application -eq $mockReportsApplicationName
+                        } -Exactly -Times 2 -Scope It
+
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'InitializeReportServer'
+                        } -Exactly -Times 0 -Scope It
+
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'SetDatabaseConnection'
+                        } -Exactly -Times 0 -Scope It
+
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'GenerateDatabaseRightsScript'
+                        } -Exactly -Times 0 -Scope It
+
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'GenerateDatabaseCreationScript'
+                        } -Exactly -Times 0 -Scope It
+
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'SetVirtualDirectory' -and $Arguments.Application -eq $mockReportServerApplicationName
+                        } -Exactly -Times 1 -Scope It
+
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'SetVirtualDirectory' -and $Arguments.Application -eq $mockReportsApplicationName
+                        } -Exactly -Times 1 -Scope It
+
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'ReserveUrl' -and $Arguments.Application -eq $mockReportServerApplicationName
+                        } -Exactly -Times 2 -Scope It
+
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'ReserveUrl' -and $Arguments.Application -eq $mockReportsApplicationName
+                        } -Exactly -Times 2 -Scope It
 
                         Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 2 -Scope It
                         Assert-MockCalled -CommandName Invoke-Sqlcmd -Exactly -Times 0 -Scope It
@@ -486,13 +512,41 @@ try
                     It 'Should configure Reporting Service without throwing an error' {
                         { Set-TargetResource @defaultParameters } | Should -Not -Throw
 
-                        # Test so each mock of methods was called.
-                        $script:mockIsMethodCalled_GenerateDatabaseRightsScript | Should -Be $true
-                        $script:mockIsMethodCalled_GenerateDatabaseCreationScript | Should -Be $true
-                        $script:mockIsMethodCalled_SetVirtualDirectory | Should -Be $true
-                        $script:mockIsMethodCalled_ReserveURL | Should -Be $true
-                        $script:mockIsMethodCalled_SetDatabaseConnection | Should -Be $true
-                        $script:mockIsMethodCalled_InitializeReportServer | Should -Be $true
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'RemoveURL'
+                        } -Exactly -Times 0 -Scope It
+
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'InitializeReportServer'
+                        } -Exactly -Times 1 -Scope It
+
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'SetDatabaseConnection'
+                        } -Exactly -Times 1 -Scope It
+
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'GenerateDatabaseRightsScript'
+                        } -Exactly -Times 1 -Scope It
+
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'GenerateDatabaseCreationScript'
+                        } -Exactly -Times 1 -Scope It
+
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'SetVirtualDirectory' -and $Arguments.Application -eq $mockReportServerApplicationName
+                        } -Exactly -Times 1 -Scope It
+
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'SetVirtualDirectory' -and $Arguments.Application -eq $mockReportsApplicationNameLegacy
+                        } -Exactly -Times 1 -Scope It
+
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'ReserveUrl' -and $Arguments.Application -eq $mockReportServerApplicationName
+                        } -Exactly -Times 1 -Scope It
+
+                        Assert-MockCalled -CommandName Invoke-RsCimMethod -ParameterFilter {
+                            $MethodName -eq 'ReserveUrl' -and $Arguments.Application -eq $mockReportsApplicationNameLegacy
+                        } -Exactly -Times 1 -Scope It
 
                         Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 2 -Scope It
                         Assert-MockCalled -CommandName Invoke-Sqlcmd -Exactly -Times 2 -Scope It
@@ -642,6 +696,111 @@ try
                 It 'Should return state as in desired state' {
                     $resultTestTargetResource = Test-TargetResource @defaultParameters
                     $resultTestTargetResource | Should -Be $true
+                }
+            }
+
+            Assert-VerifiableMock
+        }
+
+        Describe "SqlRS\Invoke-RsCimMethod" -Tag 'Helper' {
+            BeforeAll {
+                $cimInstance = New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance -ArgumentList @(
+                    'MSReportServer_ConfigurationSetting'
+                    'root/Microsoft/SQLServer/ReportServer/RS_SQL2016/v13/Admin'
+                )
+            }
+
+            Context 'When calling a method that execute successfully' {
+                BeforeAll {
+                    Mock -CommandName Invoke-CimMethod -MockWith {
+                        return @{
+                            HRESULT = 0
+                        }
+                    } -Verifiable
+                }
+
+                Context 'When calling Invoke-CimMethod without arguments' {
+                    It 'Should call Invoke-CimMethod without throwing an error' {
+                        $invokeRsCimMethodParameters = @{
+                            CimInstance = $cimInstance
+                            MethodName  = 'AnyMethod'
+                        }
+
+                        $resultTestTargetResource = Invoke-RsCimMethod @invokeRsCimMethodParameters
+                        $resultTestTargetResource.HRESULT | Should -Be 0
+
+                        Assert-MockCalled -CommandName Invoke-CimMethod -ParameterFilter {
+                            $MethodName -eq 'AnyMethod' -and $Arguments -eq $null
+                        } -Exactly -Times 1
+                    }
+                }
+
+                Context 'When calling Invoke-CimMethod with arguments' {
+                    It 'Should call Invoke-CimMethod without throwing an error' {
+                        $invokeRsCimMethodParameters = @{
+                            CimInstance = $cimInstance
+                            MethodName  = 'AnyMethod'
+                            Arguments   = @{
+                                Argument1 = 'ArgumentValue1'
+                            }
+                        }
+
+                        $resultTestTargetResource = Invoke-RsCimMethod @invokeRsCimMethodParameters
+                        $resultTestTargetResource.HRESULT | Should -Be 0
+
+                        Assert-MockCalled -CommandName Invoke-CimMethod -ParameterFilter {
+                            $MethodName -eq 'AnyMethod' -and $Arguments.Argument1 -eq 'ArgumentValue1'
+                        } -Exactly -Times 1
+                    }
+                }
+            }
+
+            Context 'When calling a method that fails with an error' {
+                Context 'When Invoke-CimMethod fails and returns an object with a Error property' {
+                    BeforeAll {
+                        Mock -CommandName Invoke-CimMethod -MockWith {
+                            return @{
+                                HRESULT = 1
+                                Error   = 'Something went wrong'
+                            }
+                        } -Verifiable
+                    }
+
+                    It 'Should call Invoke-CimMethod and throw the correct error' {
+                        $invokeRsCimMethodParameters = @{
+                            CimInstance = $cimInstance
+                            MethodName  = 'AnyMethod'
+                        }
+
+                        { Invoke-RsCimMethod @invokeRsCimMethodParameters } | Should -Throw 'Method AnyMethod() failed with an error. Error: Something went wrong (HRESULT:1)'
+
+                        Assert-MockCalled -CommandName Invoke-CimMethod -ParameterFilter {
+                            $MethodName -eq 'AnyMethod'
+                        } -Exactly -Times 1
+                    }
+                }
+
+                Context 'When Invoke-CimMethod fails and returns an object with a ExtendedErrors property' {
+                    BeforeAll {
+                        Mock -CommandName Invoke-CimMethod -MockWith {
+                            return New-Object -TypeName Object |
+                                Add-Member -MemberType NoteProperty -Name 'HRESULT' -Value 1 -PassThru |
+                                Add-Member -MemberType NoteProperty -Name 'ExtendedErrors' -Value @('Something went wrong', 'Another thing went wrong') -PassThru -Force
+                        } -Verifiable
+                    }
+
+                    It 'Should call Invoke-CimMethod and throw the correct error' {
+                        $invokeRsCimMethodParameters = @{
+                            CimInstance = $cimInstance
+                            MethodName  = 'AnyMethod'
+                        }
+
+                        { Invoke-RsCimMethod @invokeRsCimMethodParameters } | Should -Throw 'Method AnyMethod() failed with an error. Error: Something went wrong;Another thing went wrong (HRESULT:1)'
+
+                        Assert-MockCalled -CommandName Invoke-CimMethod -ParameterFilter {
+                            $MethodName -eq 'AnyMethod'
+                        } -Exactly -Times 1
+                    }
                 }
             }
 

--- a/Tests/Unit/MSFT_SqlRS.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlRS.Tests.ps1
@@ -57,7 +57,7 @@ try
             }
         }
 
-        $mockGetWmiObject_ConfigurationSetting_NamedInstance = {
+        $mockGetCimInstance_ConfigurationSetting_NamedInstance = {
             return @(
                 (
                     New-Object -TypeName Object |
@@ -133,7 +133,7 @@ try
             )
         }
 
-        $mockGetWmiObject_ConfigurationSetting_DefaultInstance = {
+        $mockGetCimInstance_ConfigurationSetting_DefaultInstance = {
             return New-Object -TypeName Object |
                 Add-Member -MemberType NoteProperty -Name 'DatabaseServerName' -Value "$mockReportingServicesDatabaseServerName" -PassThru |
                 Add-Member -MemberType NoteProperty -Name 'IsInitialized' -Value $false -PassThru |
@@ -176,18 +176,18 @@ try
             } -PassThru -Force
         }
 
-        $mockGetWmiObject_ConfigurationSetting_ParameterFilter = {
-            $Class -eq 'MSReportServer_ConfigurationSetting'
+        $mockGetCimInstance_ConfigurationSetting_ParameterFilter = {
+            $ClassName -eq 'MSReportServer_ConfigurationSetting'
         }
 
-        $mockGetWmiObject_Language = {
+        $mockGetCimInstance_Language = {
             return @{
                 Language = '1033'
             }
         }
 
-        $mockGetWmiObject_OperatingSystem_ParameterFilter = {
-            $Class -eq 'Win32_OperatingSystem'
+        $mockGetCimInstance_OperatingSystem_ParameterFilter = {
+            $ClassName -eq 'Win32_OperatingSystem'
         }
 
         Describe "SqlRS\Get-TargetResource" -Tag 'Get' {
@@ -214,9 +214,9 @@ try
                 }
 
                 BeforeEach {
-                    Mock -CommandName Get-WmiObject `
-                        -MockWith $mockGetWmiObject_ConfigurationSetting_NamedInstance `
-                        -ParameterFilter $mockGetWmiObject_ConfigurationSetting_ParameterFilter `
+                    Mock -CommandName Get-CimInstance `
+                        -MockWith $mockGetCimInstance_ConfigurationSetting_NamedInstance `
+                        -ParameterFilter $mockGetCimInstance_ConfigurationSetting_ParameterFilter `
                         -Verifiable
                 }
 
@@ -246,9 +246,9 @@ try
                 }
 
                 BeforeEach {
-                    Mock -CommandName Get-WmiObject `
-                        -MockWith $mockGetWmiObject_ConfigurationSetting_DefaultInstance `
-                        -ParameterFilter $mockGetWmiObject_ConfigurationSetting_ParameterFilter `
+                    Mock -CommandName Get-CimInstance `
+                        -MockWith $mockGetCimInstance_ConfigurationSetting_DefaultInstance `
+                        -ParameterFilter $mockGetCimInstance_ConfigurationSetting_ParameterFilter `
                         -Verifiable
 
                     $testParameters = $defaultParameters.Clone()
@@ -334,14 +334,14 @@ try
                     }
 
                     BeforeEach {
-                        Mock -CommandName Get-WmiObject `
-                            -MockWith $mockGetWmiObject_ConfigurationSetting_NamedInstance `
-                            -ParameterFilter $mockGetWmiObject_ConfigurationSetting_ParameterFilter `
+                        Mock -CommandName Get-CimInstance `
+                            -MockWith $mockGetCimInstance_ConfigurationSetting_NamedInstance `
+                            -ParameterFilter $mockGetCimInstance_ConfigurationSetting_ParameterFilter `
                             -Verifiable
 
-                        Mock -CommandName Get-WmiObject `
-                            -MockWith $mockGetWmiObject_Language `
-                            -ParameterFilter $mockGetWmiObject_OperatingSystem_ParameterFilter `
+                        Mock -CommandName Get-CimInstance `
+                            -MockWith $mockGetCimInstance_Language `
+                            -ParameterFilter $mockGetCimInstance_OperatingSystem_ParameterFilter `
                             -Verifiable
 
                         # Start each test with each method in correct state.
@@ -364,7 +364,7 @@ try
                         $script:mockIsMethodCalled_SetDatabaseConnection | Should -Be $true
                         $script:mockIsMethodCalled_InitializeReportServer | Should -Be $true
 
-                        Assert-MockCalled -CommandName Get-WmiObject -Exactly -Times 2 -Scope It
+                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 2 -Scope It
                         Assert-MockCalled -CommandName Invoke-Sqlcmd -Exactly -Times 2 -Scope It
                         Assert-MockCalled -CommandName Restart-ReportingServicesService -Exactly -Times 1 -Scope It
                     }
@@ -382,9 +382,9 @@ try
 
                     Context 'When it is not possible to evaluate OSLanguage' {
                         BeforeEach {
-                            Mock -CommandName Get-WmiObject -MockWith {
+                            Mock -CommandName Get-CimInstance -MockWith {
                                 return $null
-                            } -ParameterFilter $mockGetWmiObject_OperatingSystem_ParameterFilter -Verifiable                        }
+                            } -ParameterFilter $mockGetCimInstance_OperatingSystem_ParameterFilter -Verifiable                        }
 
                         It 'Should throw the correct error message' {
                             { Set-TargetResource @defaultParameters } | Should -Throw 'Unable to find WMI object Win32_OperatingSystem.'
@@ -420,14 +420,14 @@ try
                     }
 
                     BeforeEach {
-                        Mock -CommandName Get-WmiObject `
-                            -MockWith $mockGetWmiObject_ConfigurationSetting_NamedInstance `
-                            -ParameterFilter $mockGetWmiObject_ConfigurationSetting_ParameterFilter `
+                        Mock -CommandName Get-CimInstance `
+                            -MockWith $mockGetCimInstance_ConfigurationSetting_NamedInstance `
+                            -ParameterFilter $mockGetCimInstance_ConfigurationSetting_ParameterFilter `
                             -Verifiable
 
-                        Mock -CommandName Get-WmiObject `
-                            -MockWith $mockGetWmiObject_Language `
-                            -ParameterFilter $mockGetWmiObject_OperatingSystem_ParameterFilter `
+                        Mock -CommandName Get-CimInstance `
+                            -MockWith $mockGetCimInstance_Language `
+                            -ParameterFilter $mockGetCimInstance_OperatingSystem_ParameterFilter `
                             -Verifiable
 
                         # Start each test with each method in correct state.
@@ -450,7 +450,7 @@ try
                         $script:mockIsMethodCalled_SetDatabaseConnection | Should -Be $false
                         $script:mockIsMethodCalled_InitializeReportServer | Should -Be $false
 
-                        Assert-MockCalled -CommandName Get-WmiObject -Exactly -Times 2 -Scope It
+                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 2 -Scope It
                         Assert-MockCalled -CommandName Invoke-Sqlcmd -Exactly -Times 0 -Scope It
                     }
                 }
@@ -472,14 +472,14 @@ try
                     }
 
                     BeforeEach {
-                        Mock -CommandName Get-WmiObject `
-                            -MockWith $mockGetWmiObject_ConfigurationSetting_DefaultInstance `
-                            -ParameterFilter $mockGetWmiObject_ConfigurationSetting_ParameterFilter `
+                        Mock -CommandName Get-CimInstance `
+                            -MockWith $mockGetCimInstance_ConfigurationSetting_DefaultInstance `
+                            -ParameterFilter $mockGetCimInstance_ConfigurationSetting_ParameterFilter `
                             -Verifiable
 
-                        Mock -CommandName Get-WmiObject `
-                            -MockWith $mockGetWmiObject_Language `
-                            -ParameterFilter $mockGetWmiObject_OperatingSystem_ParameterFilter `
+                        Mock -CommandName Get-CimInstance `
+                            -MockWith $mockGetCimInstance_Language `
+                            -ParameterFilter $mockGetCimInstance_OperatingSystem_ParameterFilter `
                             -Verifiable
                     }
 
@@ -494,7 +494,7 @@ try
                         $script:mockIsMethodCalled_SetDatabaseConnection | Should -Be $true
                         $script:mockIsMethodCalled_InitializeReportServer | Should -Be $true
 
-                        Assert-MockCalled -CommandName Get-WmiObject -Exactly -Times 2 -Scope It
+                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 2 -Scope It
                         Assert-MockCalled -CommandName Invoke-Sqlcmd -Exactly -Times 2 -Scope It
                         Assert-MockCalled -CommandName Restart-ReportingServicesService -Exactly -Times 1 -Scope It
                     }


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to SqlRS
  - Replaced Get-WmiObject with Get-CimInstance to fix Script Analyzer warnings (issue #264).
  - Refactored the resource to use Invoke-CimMethod.

**This Pull Request (PR) fixes the following issues:**
Fixes #264 

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/988)
<!-- Reviewable:end -->
