### PR TITLE
SqlServerDsc: Fix style of examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
   - Resources that did not have a description in the README.md now has one.
   - Resources that missed links to the examples in the README.md now has those
     links.
+  - Style changes in all examples, removing type [System.Management.Automation.Credential()]
+    from credential parameters ([issue #1003](https://github.com/PowerShell/SqlServerDsc/issues/1003)),
+    and renamed the credential parameter so it is not using abbreviation.
 - Changes to SqlAlias
   - Fixed issue where exception was thrown if reg keys did not exist
     ([issue #949](https://github.com/PowerShell/SqlServerDsc/issues/949)).

--- a/Examples/Resources/SqlAG/1-CreateAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAG/1-CreateAvailabilityGroup.ps1
@@ -32,7 +32,7 @@ Configuration Example
 {
     param(
         [Parameter(Mandatory = $true)]
-        [PSCredential]
+        [System.Management.Automation.PSCredential]
         $SqlAdministratorCredential
     )
 

--- a/Examples/Resources/SqlAG/1-CreateAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAG/1-CreateAvailabilityGroup.ps1
@@ -33,7 +33,7 @@ Configuration Example
     param(
         [Parameter(Mandatory = $true)]
         [PSCredential]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -47,7 +47,7 @@ Configuration Example
             LoginType            = 'WindowsUser'
             ServerName           = $Node.NodeName
             InstanceName         = $Node.InstanceName
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         # Add the required permissions to the cluster service login
@@ -59,7 +59,7 @@ Configuration Example
             InstanceName         = $Node.InstanceName
             Principal            = 'NT SERVICE\ClusSvc'
             Permission           = 'AlterAnyAvailabilityGroup', 'ViewServerState'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         # Create a DatabaseMirroring endpoint
@@ -70,7 +70,7 @@ Configuration Example
             Port                 = 5022
             ServerName           = $Node.NodeName
             InstanceName         = $Node.InstanceName
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         if ( $Node.Role -eq 'PrimaryReplica' )
@@ -83,7 +83,7 @@ Configuration Example
                 InstanceName         = $Node.InstanceName
                 ServerName           = $Node.NodeName
                 DependsOn            = '[SqlServerEndpoint]HADREndpoint', '[SqlServerPermission]AddNTServiceClusSvcPermissions'
-                PsDscRunAsCredential = $SysAdminAccount
+                PsDscRunAsCredential = $SqlAdministratorCredential
             }
         }
     }

--- a/Examples/Resources/SqlAG/2-RemoveAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAG/2-RemoveAvailabilityGroup.ps1
@@ -33,7 +33,7 @@ Configuration Example
     param(
         [Parameter(Mandatory = $true)]
         [PSCredential]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -48,7 +48,7 @@ Configuration Example
                 Name                 = 'TestAG'
                 InstanceName         = $Node.InstanceName
                 ServerName           = $Node.NodeName
-                PsDscRunAsCredential = $SysAdminAccount
+                PsDscRunAsCredential = $SqlAdministratorCredential
             }
         }
     }

--- a/Examples/Resources/SqlAG/2-RemoveAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAG/2-RemoveAvailabilityGroup.ps1
@@ -32,7 +32,7 @@ Configuration Example
 {
     param(
         [Parameter(Mandatory = $true)]
-        [PSCredential]
+        [System.Management.Automation.PSCredential]
         $SqlAdministratorCredential
     )
 

--- a/Examples/Resources/SqlAG/3-CreateAvailabilityGroupDetailed.ps1
+++ b/Examples/Resources/SqlAG/3-CreateAvailabilityGroupDetailed.ps1
@@ -50,7 +50,7 @@ Configuration Example
 {
     param(
         [Parameter(Mandatory = $true)]
-        [PSCredential]
+        [System.Management.Automation.PSCredential]
         $SqlAdministratorCredential
     )
 

--- a/Examples/Resources/SqlAG/3-CreateAvailabilityGroupDetailed.ps1
+++ b/Examples/Resources/SqlAG/3-CreateAvailabilityGroupDetailed.ps1
@@ -51,7 +51,7 @@ Configuration Example
     param(
         [Parameter(Mandatory = $true)]
         [PSCredential]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -65,7 +65,7 @@ Configuration Example
             LoginType            = 'WindowsUser'
             ServerName           = $Node.NodeName
             InstanceName         = $Node.InstanceName
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         # Add the required permissions to the cluster service login
@@ -77,7 +77,7 @@ Configuration Example
             InstanceName         = $Node.InstanceName
             Principal            = 'NT SERVICE\ClusSvc'
             Permission           = 'AlterAnyAvailabilityGroup', 'ViewServerState'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         # Create a DatabaseMirroring endpoint
@@ -88,7 +88,7 @@ Configuration Example
             Port                 = 5022
             ServerName           = $Node.NodeName
             InstanceName         = $Node.InstanceName
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         if ( $Node.Role -eq 'PrimaryReplica' )
@@ -116,7 +116,7 @@ Configuration Example
                 DtcSupportEnabled             = $Node.DtcSupportEnabled
 
                 DependsOn                     = '[SqlServerEndpoint]HADREndpoint', '[SqlServerPermission]AddNTServiceClusSvcPermissions'
-                PsDscRunAsCredential          = $SysAdminAccount
+                PsDscRunAsCredential          = $SqlAdministratorCredential
             }
         }
     }

--- a/Examples/Resources/SqlAGDatabase/1-AddDatabaseToAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAGDatabase/1-AddDatabaseToAvailabilityGroup.ps1
@@ -42,7 +42,7 @@ Configuration Example
 {
     param(
         [Parameter(Mandatory = $true)]
-        [PSCredential]
+        [System.Management.Automation.PSCredential]
         $SqlAdministratorCredential
     )
 

--- a/Examples/Resources/SqlAGDatabase/1-AddDatabaseToAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAGDatabase/1-AddDatabaseToAvailabilityGroup.ps1
@@ -43,7 +43,7 @@ Configuration Example
     param(
         [Parameter(Mandatory = $true)]
         [PSCredential]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -57,7 +57,7 @@ Configuration Example
             LoginType            = 'WindowsUser'
             ServerName           = $Node.NodeName
             InstanceName         = $Node.SQLInstanceName
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         # Add the required permissions to the cluster service login
@@ -69,7 +69,7 @@ Configuration Example
             InstanceName         = $Node.SqlInstanceName
             Principal            = 'NT SERVICE\ClusSvc'
             Permission           = 'AlterAnyAvailabilityGroup', 'ViewServerState'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         # Create a DatabaseMirroring endpoint
@@ -80,7 +80,7 @@ Configuration Example
             Port                 = 5022
             ServerName           = $Node.NodeName
             InstanceName         = $Node.SQLInstanceName
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         if ( $Node.Role -eq 'PrimaryReplica' )
@@ -93,7 +93,7 @@ Configuration Example
                 InstanceName         = $Node.SQLInstanceName
                 ServerName           = $Node.NodeName
                 DependsOn            = '[SqlServerEndpoint]HADREndpoint', '[SqlServerPermission]AddNTServiceClusSvcPermissions'
-                PsDscRunAsCredential = $SysAdminAccount
+                PsDscRunAsCredential = $SqlAdministratorCredential
             }
         }
 
@@ -123,7 +123,7 @@ Configuration Example
                 ServerName              = $Node.NodeName
                 Ensure                  = 'Present'
                 ProcessOnlyOnActiveNode = $true
-                PsDscRunAsCredential    = $SysAdminAccount
+                PsDscRunAsCredential    = $SqlAdministratorCredential
             }
         }
     }

--- a/Examples/Resources/SqlAGDatabase/2-RemoveDatabaseFromAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAGDatabase/2-RemoveDatabaseFromAvailabilityGroup.ps1
@@ -39,7 +39,7 @@ Configuration Example
     param(
         [Parameter(Mandatory = $true)]
         [PSCredential]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -53,7 +53,7 @@ Configuration Example
             LoginType            = 'WindowsUser'
             ServerName           = $Node.NodeName
             InstanceName         = $Node.SQLInstanceName
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         # Add the required permissions to the cluster service login
@@ -65,7 +65,7 @@ Configuration Example
             InstanceName         = $Node.SqlInstanceName
             Principal            = 'NT SERVICE\ClusSvc'
             Permission           = 'AlterAnyAvailabilityGroup', 'ViewServerState'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         # Create a DatabaseMirroring endpoint
@@ -76,7 +76,7 @@ Configuration Example
             Port                 = 5022
             ServerName           = $Node.NodeName
             InstanceName         = $Node.SQLInstanceName
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         if ( $Node.Role -eq 'PrimaryReplica' )
@@ -89,7 +89,7 @@ Configuration Example
                 InstanceName         = $Node.SQLInstanceName
                 ServerName           = $Node.NodeName
                 DependsOn            = '[SqlServerEndpoint]HADREndpoint', '[SqlServerPermission]AddNTServiceClusSvcPermissions'
-                PsDscRunAsCredential = $SysAdminAccount
+                PsDscRunAsCredential = $SqlAdministratorCredential
             }
         }
 
@@ -118,7 +118,7 @@ Configuration Example
                 InstanceName          = $Node.SQLInstanceName
                 ServerName            = $Node.NodeName
                 Ensure                = 'Absent'
-                PsDscRunAsCredential  = $SysAdminAccount
+                PsDscRunAsCredential  = $SqlAdministratorCredential
             }
         }
     }

--- a/Examples/Resources/SqlAGDatabase/2-RemoveDatabaseFromAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAGDatabase/2-RemoveDatabaseFromAvailabilityGroup.ps1
@@ -38,7 +38,7 @@ Configuration Example
 {
     param(
         [Parameter(Mandatory = $true)]
-        [PSCredential]
+        [System.Management.Automation.PSCredential]
         $SqlAdministratorCredential
     )
 

--- a/Examples/Resources/SqlAGDatabase/3-MatchDefinedDatabaseInAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAGDatabase/3-MatchDefinedDatabaseInAvailabilityGroup.ps1
@@ -38,7 +38,7 @@ Configuration Example
 {
     param(
         [Parameter(Mandatory = $true)]
-        [PSCredential]
+        [System.Management.Automation.PSCredential]
         $SqlAdministratorCredential
     )
 

--- a/Examples/Resources/SqlAGDatabase/3-MatchDefinedDatabaseInAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAGDatabase/3-MatchDefinedDatabaseInAvailabilityGroup.ps1
@@ -39,7 +39,7 @@ Configuration Example
     param(
         [Parameter(Mandatory = $true)]
         [PSCredential]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -53,7 +53,7 @@ Configuration Example
             LoginType            = 'WindowsUser'
             ServerName           = $Node.NodeName
             InstanceName         = $Node.SQLInstanceName
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         # Add the required permissions to the cluster service login
@@ -65,7 +65,7 @@ Configuration Example
             InstanceName         = $Node.SqlInstanceName
             Principal            = 'NT SERVICE\ClusSvc'
             Permission           = 'AlterAnyAvailabilityGroup', 'ViewServerState'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         # Create a DatabaseMirroring endpoint
@@ -76,7 +76,7 @@ Configuration Example
             Port                 = 5022
             ServerName           = $Node.NodeName
             InstanceName         = $Node.SQLInstanceName
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         if ( $Node.Role -eq 'PrimaryReplica' )
@@ -89,7 +89,7 @@ Configuration Example
                 InstanceName         = $Node.SQLInstanceName
                 ServerName           = $Node.NodeName
                 DependsOn            = '[SqlServerEndpoint]HADREndpoint', '[SqlServerPermission]AddNTServiceClusSvcPermissions'
-                PsDscRunAsCredential = $SysAdminAccount
+                PsDscRunAsCredential = $SqlAdministratorCredential
             }
         }
 
@@ -119,7 +119,7 @@ Configuration Example
                 ServerName            = $Node.NodeName
                 Ensure                = 'Present'
                 Force                 = $true
-                PsDscRunAsCredential  = $SysAdminAccount
+                PsDscRunAsCredential  = $SqlAdministratorCredential
             }
         }
     }

--- a/Examples/Resources/SqlAGListener/1-AddAvailabilityGroupListenerWithSameNameAsVCO.ps1
+++ b/Examples/Resources/SqlAGListener/1-AddAvailabilityGroupListenerWithSameNameAsVCO.ps1
@@ -8,8 +8,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -26,7 +25,7 @@ Configuration Example
             IpAddress            = '192.168.0.73/255.255.255.0'
             Port                 = 5301
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlAGListener/2-AddAvailabilityGroupListenerWithDifferentNameAsVCO.ps1
+++ b/Examples/Resources/SqlAGListener/2-AddAvailabilityGroupListenerWithDifferentNameAsVCO.ps1
@@ -8,8 +8,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -26,7 +25,7 @@ Configuration Example
             IpAddress            = '192.168.0.74/255.255.255.0'
             Port                 = 5302
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlAGListener/3-RemoveAvailabilityGroupListenerWithSameNameAsVCO.ps1
+++ b/Examples/Resources/SqlAGListener/3-RemoveAvailabilityGroupListenerWithSameNameAsVCO.ps1
@@ -8,8 +8,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -24,7 +23,7 @@ Configuration Example
             AvailabilityGroup    = 'AvailabilityGroup-01'
             Name                 = 'AG-01'
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlAGListener/4-RemoveAvailabilityGroupListenerWithDifferentNameAsVCO.ps1
+++ b/Examples/Resources/SqlAGListener/4-RemoveAvailabilityGroupListenerWithDifferentNameAsVCO.ps1
@@ -8,8 +8,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -24,7 +23,7 @@ Configuration Example
             AvailabilityGroup    = 'AG-01'
             Name                 = "AG-01"
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlAGListener/5-AddAvailabilityGroupListenerUsingDHCPWithDefaultServerSubnet.ps1
+++ b/Examples/Resources/SqlAGListener/5-AddAvailabilityGroupListenerUsingDHCPWithDefaultServerSubnet.ps1
@@ -8,8 +8,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -26,7 +25,7 @@ Configuration Example
             DHCP                 = $true    # Also not specifying parameter DHCP will default to using DHCP with the default server subnet.
             Port                 = 5301
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlAGListener/6-AddAvailabilityGroupListenerUsingDHCPWithSpecificSubnet.ps1
+++ b/Examples/Resources/SqlAGListener/6-AddAvailabilityGroupListenerUsingDHCPWithSpecificSubnet.ps1
@@ -8,8 +8,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -27,7 +26,7 @@ Configuration Example
             IpAddress            = '192.168.0.1/255.255.252.0'
             Port                 = 5301
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlAGReplica/1-CreateAvailabilityGroupReplica.ps1
+++ b/Examples/Resources/SqlAGReplica/1-CreateAvailabilityGroupReplica.ps1
@@ -45,7 +45,7 @@ Configuration Example
     param(
         [Parameter(Mandatory = $true)]
         [PSCredential]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -59,7 +59,7 @@ Configuration Example
             LoginType            = 'WindowsUser'
             ServerName           = $Node.NodeName
             InstanceName         = $Node.SQLInstanceName
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         # Add the required permissions to the cluster service login
@@ -71,7 +71,7 @@ Configuration Example
             InstanceName         = $Node.SqlInstanceName
             Principal            = 'NT SERVICE\ClusSvc'
             Permission           = 'AlterAnyAvailabilityGroup', 'ViewServerState'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         # Create a DatabaseMirroring endpoint
@@ -82,7 +82,7 @@ Configuration Example
             Port                 = 5022
             ServerName           = $Node.NodeName
             InstanceName         = $Node.SQLInstanceName
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         if ( $Node.Role -eq 'PrimaryReplica' )
@@ -95,7 +95,7 @@ Configuration Example
                 InstanceName         = $Node.SQLInstanceName
                 ServerName           = $Node.NodeName
                 DependsOn            = '[SqlServerEndpoint]HADREndpoint', '[SqlServerPermission]AddNTServiceClusSvcPermissions'
-                PsDscRunAsCredential = $SysAdminAccount
+                PsDscRunAsCredential = $SqlAdministratorCredential
             }
         }
 

--- a/Examples/Resources/SqlAGReplica/1-CreateAvailabilityGroupReplica.ps1
+++ b/Examples/Resources/SqlAGReplica/1-CreateAvailabilityGroupReplica.ps1
@@ -44,7 +44,7 @@ Configuration Example
 {
     param(
         [Parameter(Mandatory = $true)]
-        [PSCredential]
+        [System.Management.Automation.PSCredential]
         $SqlAdministratorCredential
     )
 

--- a/Examples/Resources/SqlAGReplica/2-RemoveAvailabilityGroupReplica.ps1
+++ b/Examples/Resources/SqlAGReplica/2-RemoveAvailabilityGroupReplica.ps1
@@ -39,7 +39,7 @@ Configuration Example
     param(
         [Parameter(Mandatory = $true)]
         [PSCredential]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -53,7 +53,7 @@ Configuration Example
             LoginType            = 'WindowsUser'
             ServerName           = $Node.NodeName
             InstanceName         = $Node.SQLInstanceName
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         # Add the required permissions to the cluster service login
@@ -65,7 +65,7 @@ Configuration Example
             InstanceName         = $Node.SqlInstanceName
             Principal            = 'NT SERVICE\ClusSvc'
             Permission           = 'AlterAnyAvailabilityGroup', 'ViewServerState'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         # Create a DatabaseMirroring endpoint
@@ -76,7 +76,7 @@ Configuration Example
             Port                 = 5022
             ServerName           = $Node.NodeName
             InstanceName         = $Node.SQLInstanceName
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         if ( $Node.Role -eq 'PrimaryReplica' )
@@ -89,7 +89,7 @@ Configuration Example
                 InstanceName         = $Node.SQLInstanceName
                 ServerName           = $Node.NodeName
                 DependsOn            = '[SqlServerEndpoint]HADREndpoint', '[SqlServerPermission]AddNTServiceClusSvcPermissions'
-                PsDscRunAsCredential = $SysAdminAccount
+                PsDscRunAsCredential = $SqlAdministratorCredential
             }
         }
 

--- a/Examples/Resources/SqlAGReplica/2-RemoveAvailabilityGroupReplica.ps1
+++ b/Examples/Resources/SqlAGReplica/2-RemoveAvailabilityGroupReplica.ps1
@@ -38,7 +38,7 @@ Configuration Example
 {
     param(
         [Parameter(Mandatory = $true)]
-        [PSCredential]
+        [System.Management.Automation.PSCredential]
         $SqlAdministratorCredential
     )
 

--- a/Examples/Resources/SqlAlias/1-AddSqlAlias.ps1
+++ b/Examples/Resources/SqlAlias/1-AddSqlAlias.ps1
@@ -8,7 +8,7 @@ Configuration Example
 {
     param(
         [Parameter(Mandatory = $true)]
-        [PSCredential]
+        [System.Management.Automation.PSCredential]
         $SqlAdministratorCredential
     )
 

--- a/Examples/Resources/SqlAlias/1-AddSqlAlias.ps1
+++ b/Examples/Resources/SqlAlias/1-AddSqlAlias.ps1
@@ -9,7 +9,7 @@ Configuration Example
     param(
         [Parameter(Mandatory = $true)]
         [PSCredential]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -22,7 +22,7 @@ Configuration Example
             ServerName           = 'sqltest.company.local\DSC'
             Protocol             = 'TCP'
             TcpPort              = 1777
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         SqlAlias Add_SqlAlias_TCPUseDynamicTcpPort
@@ -32,7 +32,7 @@ Configuration Example
             ServerName           = 'sqltest.company.local\DSC'
             Protocol             = 'TCP'
             UseDynamicTcpPort    = $true
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         SqlAlias Add_SqlAlias_NP
@@ -41,7 +41,7 @@ Configuration Example
             Name                 = 'SQLDSC-NP'
             ServerName           = '\\sqlnode\PIPE\sql\query'
             Protocol             = 'NP'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlAlias/2-RemoveSqlAlias.ps1
+++ b/Examples/Resources/SqlAlias/2-RemoveSqlAlias.ps1
@@ -8,7 +8,7 @@ Configuration Example
 {
     param(
         [Parameter(Mandatory = $true)]
-        [PSCredential]
+        [System.Management.Automation.PSCredential]
         $SqlAdministratorCredential
     )
 

--- a/Examples/Resources/SqlAlias/2-RemoveSqlAlias.ps1
+++ b/Examples/Resources/SqlAlias/2-RemoveSqlAlias.ps1
@@ -9,7 +9,7 @@ Configuration Example
     param(
         [Parameter(Mandatory = $true)]
         [PSCredential]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -22,7 +22,7 @@ Configuration Example
             ServerName           = 'sqltest.company.local\DSC'
             Protocol             = 'TCP'
             TcpPort              = 1777
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         SqlAlias Remove_SqlAlias_NP
@@ -31,7 +31,7 @@ Configuration Example
             Name                 = 'SQLDSC-NP'
             ServerName           = '\\sqlnode\PIPE\sql\query'
             Protocol             = 'NP'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlAlwaysOnService/1-EnableAlwaysOn.ps1
+++ b/Examples/Resources/SqlAlwaysOnService/1-EnableAlwaysOn.ps1
@@ -9,8 +9,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -24,7 +23,7 @@ Configuration Example
             InstanceName         = 'MSSQLSERVER'
             RestartTimeout       = 120
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlAlwaysOnService/2-DisableAlwaysOn.ps1
+++ b/Examples/Resources/SqlAlwaysOnService/2-DisableAlwaysOn.ps1
@@ -9,8 +9,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -24,7 +23,7 @@ Configuration Example
             InstanceName         = 'MSSQLSERVER'
             RestartTimeout       = 120
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlDatabase/1-CreateDatabase.ps1
+++ b/Examples/Resources/SqlDatabase/1-CreateDatabase.ps1
@@ -12,8 +12,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc

--- a/Examples/Resources/SqlDatabase/2-DeleteDatabase.ps1
+++ b/Examples/Resources/SqlDatabase/2-DeleteDatabase.ps1
@@ -9,8 +9,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc

--- a/Examples/Resources/SqlDatabaseDefaultLocation/1-SetDatabaseDefaultLocation.ps1
+++ b/Examples/Resources/SqlDatabaseDefaultLocation/1-SetDatabaseDefaultLocation.ps1
@@ -13,7 +13,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -27,7 +27,7 @@ Configuration Example
             ProcessOnlyOnActiveNode = $true
             Type                    = 'Data'
             Path                    = 'C:\Program Files\Microsoft SQL Server'
-            PsDscRunAsCredential    = $SysAdminAccount
+            PsDscRunAsCredential    = $SqlAdministratorCredential
         }
 
         SqlDatabaseDefaultLocation Set_SqlDatabaseDefaultDirectory_Log
@@ -37,7 +37,7 @@ Configuration Example
             ProcessOnlyOnActiveNode = $true
             Type                    = 'Log'
             Path                    = 'C:\Program Files\Microsoft SQL Server'
-            PsDscRunAsCredential    = $SysAdminAccount
+            PsDscRunAsCredential    = $SqlAdministratorCredential
         }
 
         SqlDatabaseDefaultLocation Set_SqlDatabaseDefaultDirectory_Backup
@@ -47,7 +47,7 @@ Configuration Example
             ProcessOnlyOnActiveNode = $true
             Type                    = 'Backup'
             Path                    = 'C:\Program Files\Microsoft SQL Server'
-            PsDscRunAsCredential    = $SysAdminAccount
+            PsDscRunAsCredential    = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlDatabaseOwner/1-SetDatabaseOwner.ps1
+++ b/Examples/Resources/SqlDatabaseOwner/1-SetDatabaseOwner.ps1
@@ -9,8 +9,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -24,7 +23,7 @@ Configuration Example
             LoginType            = 'WindowsUser'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         SqlDatabaseOwner Set_SqlDatabaseOwner_SQLAdmin
@@ -33,7 +32,7 @@ Configuration Example
             Database             = 'AdventureWorks'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlDatabasePermission/1-GrantDatabasePermissions.ps1
+++ b/Examples/Resources/SqlDatabasePermission/1-GrantDatabasePermissions.ps1
@@ -8,7 +8,7 @@ Configuration Example
 {
     param(
         [Parameter(Mandatory = $true)]
-        [PSCredential]
+        [System.Management.Automation.PSCredential]
         $SqlAdministratorCredential
     )
 

--- a/Examples/Resources/SqlDatabasePermission/1-GrantDatabasePermissions.ps1
+++ b/Examples/Resources/SqlDatabasePermission/1-GrantDatabasePermissions.ps1
@@ -9,7 +9,7 @@ Configuration Example
     param(
         [Parameter(Mandatory = $true)]
         [PSCredential]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -22,7 +22,7 @@ Configuration Example
             LoginType            = 'WindowsUser'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         SqlServerLogin Add_SqlServerLogin_SQLUser
@@ -32,7 +32,7 @@ Configuration Example
             LoginType            = 'WindowsUser'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         SqlDatabasePermission Grant_SqlDatabasePermissions_SQLAdmin_Db01
@@ -44,7 +44,7 @@ Configuration Example
             Permissions          = 'Connect', 'Update'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         SqlDatabasePermission Grant_SqlDatabasePermissions_SQLUser_Db01
@@ -56,7 +56,7 @@ Configuration Example
             Permissions          = 'Connect', 'Update'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         SqlDatabasePermission Grant_SqlDatabasePermissions_SQLAdmin_Db02
@@ -68,7 +68,7 @@ Configuration Example
             Permissions          = 'Connect', 'Update'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlDatabasePermission/2-RevokeDatabasePermissions.ps1
+++ b/Examples/Resources/SqlDatabasePermission/2-RevokeDatabasePermissions.ps1
@@ -9,7 +9,7 @@ Configuration Example
     param(
         [Parameter(Mandatory = $true)]
         [PSCredential]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -24,7 +24,7 @@ Configuration Example
             Permissions          = 'Connect', 'Update'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         SqlDatabasePermission RevokeDeny_SqlDatabasePermissions_SQLAdmin
@@ -36,7 +36,7 @@ Configuration Example
             Permissions          = 'Select', 'Create Table'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlDatabasePermission/2-RevokeDatabasePermissions.ps1
+++ b/Examples/Resources/SqlDatabasePermission/2-RevokeDatabasePermissions.ps1
@@ -8,7 +8,7 @@ Configuration Example
 {
     param(
         [Parameter(Mandatory = $true)]
-        [PSCredential]
+        [System.Management.Automation.PSCredential]
         $SqlAdministratorCredential
     )
 

--- a/Examples/Resources/SqlDatabasePermission/3-DenyDatabasePermissions.ps1
+++ b/Examples/Resources/SqlDatabasePermission/3-DenyDatabasePermissions.ps1
@@ -8,7 +8,7 @@ Configuration Example
 {
     param(
         [Parameter(Mandatory = $true)]
-        [PSCredential]
+        [System.Management.Automation.PSCredential]
         $SqlAdministratorCredential
     )
 

--- a/Examples/Resources/SqlDatabasePermission/3-DenyDatabasePermissions.ps1
+++ b/Examples/Resources/SqlDatabasePermission/3-DenyDatabasePermissions.ps1
@@ -9,7 +9,7 @@ Configuration Example
     param(
         [Parameter(Mandatory = $true)]
         [PSCredential]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -22,7 +22,7 @@ Configuration Example
             LoginType            = 'WindowsUser'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         SqlServerLogin Add_SqlServerLogin_SQLUser
@@ -32,7 +32,7 @@ Configuration Example
             LoginType            = 'WindowsUser'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         SqlDatabasePermission Deny_SqlDatabasePermissions_SQLAdmin_Db01
@@ -44,7 +44,7 @@ Configuration Example
             Permissions          = 'Select', 'Create Table'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         SqlDatabasePermission Deny_SqlDatabasePermissions_SQLUser_Db01
@@ -56,7 +56,7 @@ Configuration Example
             Permissions          = 'Select', 'Create Table'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         SqlDatabasePermission Deny_SqlDatabasePermissions_SQLAdmin_Db02
@@ -68,7 +68,7 @@ Configuration Example
             Permissions          = 'Select', 'Create Table'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlDatabaseRecoveryModel/1-SetDatabaseRecoveryModel.ps1
+++ b/Examples/Resources/SqlDatabaseRecoveryModel/1-SetDatabaseRecoveryModel.ps1
@@ -10,8 +10,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -24,7 +23,7 @@ Configuration Example
             Name                 = 'Adventureworks'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         SqlDatabase Add_SqlDatabaseAdventureWorks2012
@@ -33,7 +32,7 @@ Configuration Example
             Name                 = 'AdventureWorks2012'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         SqlDatabaseRecoveryModel Set_SqlDatabaseRecoveryModel_Adventureworks
@@ -42,7 +41,7 @@ Configuration Example
             RecoveryModel        = 'Full'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         SqlDatabaseRecoveryModel Set_SqlDatabaseRecoveryModel_AdventureWorks2012
@@ -51,7 +50,7 @@ Configuration Example
             RecoveryModel        = 'Simple'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlDatabaseRole/1-AddDatabaseRole.ps1
+++ b/Examples/Resources/SqlDatabaseRole/1-AddDatabaseRole.ps1
@@ -9,8 +9,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -25,7 +24,7 @@ Configuration Example
             Name                 = 'CONTOSO\SQLAdmin'
             Role                 = 'MyRole', 'MySecondRole'
             Database             = 'AdventureWorks'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlDatabaseRole/2-RemoveDatabaseRole.ps1
+++ b/Examples/Resources/SqlDatabaseRole/2-RemoveDatabaseRole.ps1
@@ -9,8 +9,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -25,7 +24,7 @@ Configuration Example
             Name                 = 'CONTOSO\SQLAdmin'
             Role                 = 'DeleteRole'
             Database             = 'AdventureWorks'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlScript/1-RunScriptUsingSQLAuthentication.ps1
+++ b/Examples/Resources/SqlScript/1-RunScriptUsingSQLAuthentication.ps1
@@ -7,7 +7,7 @@ Configuration Example
 {
     param(
         [Parameter(Mandatory = $true)]
-        [PSCredential]
+        [System.Management.Automation.PSCredential]
         $SqlCredential
     )
 

--- a/Examples/Resources/SqlScript/2-RunScriptUsingWindowsAuthentication.ps1
+++ b/Examples/Resources/SqlScript/2-RunScriptUsingWindowsAuthentication.ps1
@@ -8,7 +8,7 @@ Configuration Example
 {
     param(
         [Parameter(Mandatory = $true)]
-        [PSCredential]
+        [System.Management.Automation.PSCredential]
         $WindowsCredential
     )
 

--- a/Examples/Resources/SqlServerEndpoint/1-CreateEndpointWithDefaultValues.ps1
+++ b/Examples/Resources/SqlServerEndpoint/1-CreateEndpointWithDefaultValues.ps1
@@ -9,8 +9,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -22,7 +21,7 @@ Configuration Example
             EndpointName         = 'HADR'
             InstanceName         = 'INST1'
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         SqlServerEndpoint SQLConfigureEndpoint-Instances2
@@ -30,7 +29,7 @@ Configuration Example
             EndpointName         = 'HADR'
             InstanceName         = 'INST2'
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlServerEndpoint/2-CreateEndpointWithSpecificPortAndIPAddress.ps1
+++ b/Examples/Resources/SqlServerEndpoint/2-CreateEndpointWithSpecificPortAndIPAddress.ps1
@@ -8,8 +8,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -27,7 +26,7 @@ Configuration Example
             ServerName           = 'server1.company.local'
             InstanceName         = 'INST1'
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlServerEndpoint/3-RemoveEndpoint.ps1
+++ b/Examples/Resources/SqlServerEndpoint/3-RemoveEndpoint.ps1
@@ -9,8 +9,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -24,7 +23,7 @@ Configuration Example
             EndpointName         = 'HADR'
             InstanceName      = 'INST1'
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         SqlServerEndpoint SQLConfigureEndpoint-Instance2
@@ -34,7 +33,7 @@ Configuration Example
             EndpointName         = 'HADR'
             InstanceName      = 'INST2'
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlServerEndpointPermission/1-AddConnectPermission.ps1
+++ b/Examples/Resources/SqlServerEndpointPermission/1-AddConnectPermission.ps1
@@ -9,12 +9,10 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount,
+        $SqlAdministratorCredential,
 
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlServiceCredential
     )
 
@@ -31,7 +29,7 @@ Configuration Example
             Principal            = $SqlServiceCredential.UserName
             Permission           = 'CONNECT'
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlServerEndpointPermission/2-RemoveConnectPermission.ps1
+++ b/Examples/Resources/SqlServerEndpointPermission/2-RemoveConnectPermission.ps1
@@ -9,12 +9,10 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount,
+        $SqlAdministratorCredential,
 
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlServiceCredential
     )
 
@@ -31,7 +29,7 @@ Configuration Example
             Principal            = $SqlServiceCredential.UserName
             Permission           = 'CONNECT'
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlServerEndpointPermission/3-AddConnectPermissionToTwoReplicasEachWithDifferentServiceAccount.ps1
+++ b/Examples/Resources/SqlServerEndpointPermission/3-AddConnectPermissionToTwoReplicasEachWithDifferentServiceAccount.ps1
@@ -40,17 +40,14 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount,
+        $SqlAdministratorCredential,
 
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlServiceNode1Credential,
 
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlServiceNode2Credential
     )
 
@@ -67,7 +64,7 @@ Configuration Example
             Principal            = $SqlServiceNode1Credential.UserName
             Permission           = 'CONNECT'
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         SqlServerEndpointPermission SQLConfigureEndpointPermissionSecondary
@@ -79,7 +76,7 @@ Configuration Example
             Principal            = $SqlServiceNode2Credential.UserName
             Permission           = 'CONNECT'
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 
@@ -94,7 +91,7 @@ Configuration Example
             Principal            = $SqlServiceNode1Credential.UserName
             Permission           = 'CONNECT'
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         SqlServerEndpointPermission SQLConfigureEndpointPermissionSecondary
@@ -106,7 +103,7 @@ Configuration Example
             Principal            = $SqlServiceNode2Credential.UserName
             Permission           = 'CONNECT'
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlServerEndpointPermission/4-RemoveConnectPermissionForTwoReplicasEachWithDifferentServiceAccount.ps1
+++ b/Examples/Resources/SqlServerEndpointPermission/4-RemoveConnectPermissionForTwoReplicasEachWithDifferentServiceAccount.ps1
@@ -40,17 +40,14 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlAdministratorCredential,
 
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlServiceNode1Credential,
 
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlServiceNode2Credential
     )
 

--- a/Examples/Resources/SqlServerEndpointState/1-MakeSureEndpointIsStarted.ps1
+++ b/Examples/Resources/SqlServerEndpointState/1-MakeSureEndpointIsStarted.ps1
@@ -17,8 +17,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -33,7 +32,7 @@ Configuration Example
             Name                 = 'DefaultMirrorEndpoint'
             State                = 'Started'
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         # Start the HADR in the default instance
@@ -44,7 +43,7 @@ Configuration Example
             Name                 = 'HADR'
             State                = 'Started'
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         # Start the DefaultMirrorEndpoint in the named instance INSTANCE1
@@ -55,7 +54,7 @@ Configuration Example
             Name                 = 'DefaultMirrorEndpoint'
             State                = 'Started'
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlServerEndpointState/2-MakeSureEndpointIsStopped.ps1
+++ b/Examples/Resources/SqlServerEndpointState/2-MakeSureEndpointIsStopped.ps1
@@ -8,8 +8,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -23,7 +22,7 @@ Configuration Example
             Name                 = 'DefaultMirrorEndpoint'
             State                = 'Stopped'
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
 
         }
     }

--- a/Examples/Resources/SqlServerLogin/1-AddLogin.ps1
+++ b/Examples/Resources/SqlServerLogin/1-AddLogin.ps1
@@ -14,7 +14,7 @@ Configuration Example
     param(
         [Parameter(Mandatory = $true)]
         [PSCredential]
-        $SysAdminAccount,
+        $SqlAdministratorCredential,
 
         [Parameter(Mandatory = $true)]
         [PSCredential]
@@ -31,7 +31,7 @@ Configuration Example
             LoginType            = 'WindowsUser'
             ServerName           = 'TestServer.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         SqlServerLogin Add_DisabledWindowsUser
@@ -41,7 +41,7 @@ Configuration Example
             LoginType            = 'WindowsUser'
             ServerName           = 'TestServer.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
             Disabled             = $true
         }
 
@@ -52,7 +52,7 @@ Configuration Example
             LoginType            = 'WindowsGroup'
             ServerName           = 'TestServer.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         SqlServerLogin Add_SqlLogin
@@ -66,7 +66,7 @@ Configuration Example
             LoginMustChangePassword        = $false
             LoginPasswordExpirationEnabled = $true
             LoginPasswordPolicyEnforced    = $true
-            PsDscRunAsCredential           = $SysAdminAccount
+            PsDscRunAsCredential           = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlServerLogin/1-AddLogin.ps1
+++ b/Examples/Resources/SqlServerLogin/1-AddLogin.ps1
@@ -13,11 +13,11 @@ Configuration Example
 {
     param(
         [Parameter(Mandatory = $true)]
-        [PSCredential]
+        [System.Management.Automation.PSCredential]
         $SqlAdministratorCredential,
 
         [Parameter(Mandatory = $true)]
-        [PSCredential]
+        [System.Management.Automation.PSCredential]
         $LoginCredential
     )
 

--- a/Examples/Resources/SqlServerMaxDop/1-SetMaxDopToOne.ps1
+++ b/Examples/Resources/SqlServerMaxDop/1-SetMaxDopToOne.ps1
@@ -9,8 +9,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -24,7 +23,7 @@ Configuration Example
             MaxDop               = 1
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlServerMaxDop/2-SetMaxDopToAuto.ps1
+++ b/Examples/Resources/SqlServerMaxDop/2-SetMaxDopToAuto.ps1
@@ -14,8 +14,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -28,7 +27,7 @@ Configuration Example
             DynamicAlloc            = $true
             ServerName              = 'sqltest.company.local'
             InstanceName            = 'DSC'
-            PsDscRunAsCredential    = $SysAdminAccount
+            PsDscRunAsCredential    = $SqlAdministratorCredential
             ProcessOnlyOnActiveNode = $true
         }
     }

--- a/Examples/Resources/SqlServerMaxDop/3-SetMaxDopToDefault.ps1
+++ b/Examples/Resources/SqlServerMaxDop/3-SetMaxDopToDefault.ps1
@@ -9,8 +9,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -22,7 +21,7 @@ Configuration Example
             Ensure               = 'Absent'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlServerMemory/1-SetMaxMemoryTo12GB.ps1
+++ b/Examples/Resources/SqlServerMemory/1-SetMaxMemoryTo12GB.ps1
@@ -9,8 +9,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -25,7 +24,7 @@ Configuration Example
             MaxMemory            = 12288
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlServerMemory/2-SetMaxMemoryToAuto.ps1
+++ b/Examples/Resources/SqlServerMemory/2-SetMaxMemoryToAuto.ps1
@@ -14,8 +14,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -28,7 +27,7 @@ Configuration Example
             DynamicAlloc            = $true
             ServerName              = 'sqltest.company.local'
             InstanceName            = 'DSC'
-            PsDscRunAsCredential    = $SysAdminAccount
+            PsDscRunAsCredential    = $SqlAdministratorCredential
             ProcessOnlyOnActiveNode = $true
         }
     }

--- a/Examples/Resources/SqlServerMemory/3-SetMinMemoryToFixedValueAndMaxMemoryToAuto.ps1
+++ b/Examples/Resources/SqlServerMemory/3-SetMinMemoryToFixedValueAndMaxMemoryToAuto.ps1
@@ -9,8 +9,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -24,7 +23,7 @@ Configuration Example
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
             MinMemory            = 2048
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlServerMemory/4-SetMaxMemoryToDefault.ps1
+++ b/Examples/Resources/SqlServerMemory/4-SetMaxMemoryToDefault.ps1
@@ -9,8 +9,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -22,7 +21,7 @@ Configuration Example
             Ensure               = 'Absent'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlServerNetwork/1-EnableTcpIpWithStaticPort.ps1
+++ b/Examples/Resources/SqlServerNetwork/1-EnableTcpIpWithStaticPort.ps1
@@ -10,7 +10,6 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SystemAdministratorAccount
     )
 

--- a/Examples/Resources/SqlServerNetwork/2-EnableTcpIpWithDynamicPort.ps1
+++ b/Examples/Resources/SqlServerNetwork/2-EnableTcpIpWithDynamicPort.ps1
@@ -10,7 +10,6 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SystemAdministratorAccount
     )
 

--- a/Examples/Resources/SqlServerPermission/1-AddServerPermissionForLogin.ps1
+++ b/Examples/Resources/SqlServerPermission/1-AddServerPermissionForLogin.ps1
@@ -9,8 +9,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDSC
@@ -26,7 +25,7 @@ Configuration Example
             Principal            = 'NT AUTHORITY\SYSTEM'
             Permission           = 'AlterAnyAvailabilityGroup', 'ViewServerState'
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         SqlServerPermission 'SQLConfigureServerPermission-ClusSvc'
@@ -37,7 +36,7 @@ Configuration Example
             Principal            = 'NT SERVICE\ClusSvc'
             Permission           = 'AlterAnyAvailabilityGroup', 'ViewServerState'
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlServerPermission/2-RemoveServerPermissionForLogin.ps1
+++ b/Examples/Resources/SqlServerPermission/2-RemoveServerPermissionForLogin.ps1
@@ -9,8 +9,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDSC
@@ -26,7 +25,7 @@ Configuration Example
             Principal            = 'NT AUTHORITY\SYSTEM'
             Permission           = 'AlterAnyAvailabilityGroup', 'ViewServerState'
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlServerReplication/1-ConfigureInstanceAsDistributor.ps1
+++ b/Examples/Resources/SqlServerReplication/1-ConfigureInstanceAsDistributor.ps1
@@ -8,8 +8,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -20,11 +19,11 @@ Configuration Example
         {
             Ensure               = 'Present'
             InstanceName         = 'MSSQLSERVER'
-            AdminLinkCredentials = $SysAdminAccount
+            AdminLinkCredentials = $SqlAdministratorCredential
             DistributorMode      = 'Local'
             WorkingDirectory     = 'C:\Temp'
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlServerReplication/2-ConfigureInstanceAsPublisher.ps1
+++ b/Examples/Resources/SqlServerReplication/2-ConfigureInstanceAsPublisher.ps1
@@ -8,8 +8,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -20,12 +19,12 @@ Configuration Example
         {
             Ensure               = 'Present'
             InstanceName         = 'PUBLISHER'
-            AdminLinkCredentials = $SysAdminAccount
+            AdminLinkCredentials = $SqlAdministratorCredential
             DistributorMode      = 'Remote'
             RemoteDistributor    = 'distsqlsrv.company.local'
             WorkingDirectory     = 'C:\Temp'
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlServerRole/1-AddServerRole.ps1
+++ b/Examples/Resources/SqlServerRole/1-AddServerRole.ps1
@@ -8,7 +8,7 @@ Configuration Example
 {
     param(
         [Parameter(Mandatory = $true)]
-        [PSCredential]
+        [System.Management.Automation.PSCredential]
         $SysAdminAccount
     )
 

--- a/Examples/Resources/SqlServerRole/2-RemoveServerRole.ps1
+++ b/Examples/Resources/SqlServerRole/2-RemoveServerRole.ps1
@@ -9,7 +9,7 @@ Configuration Example
     param(
         [Parameter(Mandatory = $true)]
         [PSCredential]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -21,7 +21,7 @@ Configuration Example
             ServerRoleName       = 'serverRoleToDelete'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlServerRole/2-RemoveServerRole.ps1
+++ b/Examples/Resources/SqlServerRole/2-RemoveServerRole.ps1
@@ -8,7 +8,7 @@ Configuration Example
 {
     param(
         [Parameter(Mandatory = $true)]
-        [PSCredential]
+        [System.Management.Automation.PSCredential]
         $SqlAdministratorCredential
     )
 

--- a/Examples/Resources/SqlServerRole/3-AddMembersToServerRole.ps1
+++ b/Examples/Resources/SqlServerRole/3-AddMembersToServerRole.ps1
@@ -9,7 +9,7 @@ Configuration Example
 {
     param(
         [Parameter(Mandatory = $true)]
-        [PSCredential]
+        [System.Management.Automation.PSCredential]
         $SqlAdministratorCredential
     )
 

--- a/Examples/Resources/SqlServerRole/3-AddMembersToServerRole.ps1
+++ b/Examples/Resources/SqlServerRole/3-AddMembersToServerRole.ps1
@@ -10,7 +10,7 @@ Configuration Example
     param(
         [Parameter(Mandatory = $true)]
         [PSCredential]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -23,7 +23,7 @@ Configuration Example
             Members              = 'CONTOSO\SQLAdmin', 'CONTOSO\SQLAdminBI'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlServerRole/4-MembersToIncludeInServerRole.ps1
+++ b/Examples/Resources/SqlServerRole/4-MembersToIncludeInServerRole.ps1
@@ -9,7 +9,7 @@ Configuration Example
 {
     param(
         [Parameter(Mandatory = $true)]
-        [PSCredential]
+        [System.Management.Automation.PSCredential]
         $SqlAdministratorCredential
     )
 

--- a/Examples/Resources/SqlServerRole/4-MembersToIncludeInServerRole.ps1
+++ b/Examples/Resources/SqlServerRole/4-MembersToIncludeInServerRole.ps1
@@ -10,7 +10,7 @@ Configuration Example
     param(
         [Parameter(Mandatory = $true)]
         [PSCredential]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -23,7 +23,7 @@ Configuration Example
             MembersToInclude     = 'CONTOSO\John', 'CONTOSO\Kelly'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlServerRole/5-MembersToExcludeInServerRole.ps1
+++ b/Examples/Resources/SqlServerRole/5-MembersToExcludeInServerRole.ps1
@@ -9,7 +9,7 @@ Configuration Example
 {
     param(
         [Parameter(Mandatory = $true)]
-        [PSCredential]
+        [System.Management.Automation.PSCredential]
         $SqlAdministratorCredential
     )
 

--- a/Examples/Resources/SqlServerRole/5-MembersToExcludeInServerRole.ps1
+++ b/Examples/Resources/SqlServerRole/5-MembersToExcludeInServerRole.ps1
@@ -10,7 +10,7 @@ Configuration Example
     param(
         [Parameter(Mandatory = $true)]
         [PSCredential]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -23,7 +23,7 @@ Configuration Example
             MembersToExclude     = 'CONTOSO\Mark', 'CONTOSO\Lucy'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlServiceAccount/1-ConfigureServiceAccount-UserAccount.ps1
+++ b/Examples/Resources/SqlServiceAccount/1-ConfigureServiceAccount-UserAccount.ps1
@@ -8,7 +8,7 @@ Configuration Example
 {
     param(
         [Parameter(Mandatory = $true)]
-        [PSCredential]
+        [System.Management.Automation.PSCredential]
         $ServiceAccountCredential
     )
 

--- a/Examples/Resources/SqlServiceAccount/2-ConfigureServiceAccount-VirtualAccount.ps1
+++ b/Examples/Resources/SqlServiceAccount/2-ConfigureServiceAccount-VirtualAccount.ps1
@@ -11,7 +11,7 @@ Configuration Example
 {
     param(
         [Parameter(Mandatory = $true)]
-        [PSCredential]
+        [System.Management.Automation.PSCredential]
         $ServiceAccountCredential
     )
 

--- a/Examples/Resources/SqlSetup/1-InstallDefaultInstanceSingleServer.ps1
+++ b/Examples/Resources/SqlSetup/1-InstallDefaultInstanceSingleServer.ps1
@@ -14,25 +14,21 @@ Configuration Example
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlInstallCredential,
 
         [Parameter()]
         [ValidateNotNullorEmpty()]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlAdministratorCredential = $SqlInstallCredential,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlServiceCredential,
 
         [Parameter()]
         [ValidateNotNullorEmpty()]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlAgentServiceCredential = $SqlServiceCredential
     )
 

--- a/Examples/Resources/SqlSetup/2-InstallNamedInstanceSingleServer.ps1
+++ b/Examples/Resources/SqlSetup/2-InstallNamedInstanceSingleServer.ps1
@@ -13,25 +13,21 @@ Configuration Example
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlInstallCredential,
 
         [Parameter()]
         [ValidateNotNullorEmpty()]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlAdministratorCredential = $SqlInstallCredential,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlServiceCredential,
 
         [Parameter()]
         [ValidateNotNullorEmpty()]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlAgentServiceCredential = $SqlServiceCredential
     )
 

--- a/Examples/Resources/SqlSetup/3-InstallNamedInstanceSingleServerFromUncPathUsingSourceCredential.ps1
+++ b/Examples/Resources/SqlSetup/3-InstallNamedInstanceSingleServerFromUncPathUsingSourceCredential.ps1
@@ -17,25 +17,21 @@ Configuration Example
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlInstallCredential,
 
         [Parameter()]
         [ValidateNotNullorEmpty()]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlAdministratorCredential = $SqlInstallCredential,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlServiceCredential,
 
         [Parameter()]
         [ValidateNotNullorEmpty()]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlAgentServiceCredential = $SqlServiceCredential
     )
 

--- a/Examples/Resources/SqlSetup/4-InstallNamedInstanceInFailoverClusterFirstNode.ps1
+++ b/Examples/Resources/SqlSetup/4-InstallNamedInstanceInFailoverClusterFirstNode.ps1
@@ -37,25 +37,21 @@ Configuration Example
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlInstallCredential,
 
         [Parameter()]
         [ValidateNotNullorEmpty()]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlAdministratorCredential = $SqlInstallCredential,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlServiceCredential,
 
         [Parameter()]
         [ValidateNotNullorEmpty()]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlAgentServiceCredential = $SqlServiceCredential
     )
 

--- a/Examples/Resources/SqlSetup/5-InstallNamedInstanceInFailoverClusterSecondNode.ps1
+++ b/Examples/Resources/SqlSetup/5-InstallNamedInstanceInFailoverClusterSecondNode.ps1
@@ -33,25 +33,21 @@ Configuration Example
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlInstallCredential,
 
         [Parameter()]
         [ValidateNotNullorEmpty()]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlAdministratorCredential = $SqlInstallCredential,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlServiceCredential,
 
         [Parameter()]
         [ValidateNotNullorEmpty()]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
         $SqlAgentServiceCredential = $SqlServiceCredential
     )
 

--- a/Examples/Resources/SqlWaitForAG/1-WaitForASingleClusterGroup.ps1
+++ b/Examples/Resources/SqlWaitForAG/1-WaitForASingleClusterGroup.ps1
@@ -8,8 +8,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -22,7 +21,7 @@ Configuration Example
             RetryIntervalSec     = 20
             RetryCount           = 30
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlWaitForAG/2-WaitForMultipleClusterGroups.ps1
+++ b/Examples/Resources/SqlWaitForAG/2-WaitForMultipleClusterGroups.ps1
@@ -8,8 +8,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -22,7 +21,7 @@ Configuration Example
             RetryIntervalSec     = 20
             RetryCount           = 30
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         SqlWaitForAG SQLConfigureAG-WaitAGTest2
@@ -31,7 +30,7 @@ Configuration Example
             RetryIntervalSec     = 20
             RetryCount           = 30
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlWindowsFirewall/1-CreateInboundFirewallRules.ps1
+++ b/Examples/Resources/SqlWindowsFirewall/1-CreateInboundFirewallRules.ps1
@@ -8,8 +8,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -23,7 +22,7 @@ Configuration Example
             InstanceName         = 'SQL2012'
             SourcePath           = '\\files.company.local\images\SQL2012'
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         SqlWindowsFirewall Create_FirewallRules_For_SQL2016
@@ -33,7 +32,7 @@ Configuration Example
             InstanceName     = 'SQL2016'
             SourcePath       = '\\files.company.local\images\SQL2016'
 
-            SourceCredential = $SysAdminAccount
+            SourceCredential = $SqlAdministratorCredential
         }
     }
 }

--- a/Examples/Resources/SqlWindowsFirewall/2-RemoveInboundFirewallRules.ps1
+++ b/Examples/Resources/SqlWindowsFirewall/2-RemoveInboundFirewallRules.ps1
@@ -8,8 +8,7 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $SysAdminAccount
+        $SqlAdministratorCredential
     )
 
     Import-DscResource -ModuleName SqlServerDsc
@@ -23,7 +22,7 @@ Configuration Example
             InstanceName         = 'SQL2012'
             SourcePath           = '\\files.company.local\images\SQL2012'
 
-            PsDscRunAsCredential = $SysAdminAccount
+            PsDscRunAsCredential = $SqlAdministratorCredential
         }
 
         SqlWindowsFirewall Remove_FirewallRules_For_SQL2016
@@ -33,7 +32,7 @@ Configuration Example
             InstanceName     = 'SQL2016'
             SourcePath       = '\\files.company.local\images\SQL2016'
 
-            SourceCredential = $SysAdminAccount
+            SourceCredential = $SqlAdministratorCredential
         }
     }
 }


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to SqlServerDsc
  - Style changes in all examples, removing type [System.Management.Automation.Credential()]
    from credential parameters (issue #1003), and renamed the credential parameter so it is not
    using abbreviation.

**This Pull Request (PR) fixes the following issues:**
Fixes #1003 

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/1005)
<!-- Reviewable:end -->
