### PR TITLE
SqlServerDsc: Fixes the timing issue with SqlServiceAccount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@
   - Updated the security token for AppVeyor status badge in README.md. When we
     renamed the repository the security token was changed
     ([issue #1012](https://github.com/PowerShell/SqlServerDsc/issues/1012)).
+  - Now the helper function Restart-SqlService, after restarting the SQL Server
+    service, does not return until it can connect to the SQL Server instance, and
+    the instance returns status 'Online' ([issue #1008](https://github.com/PowerShell/SqlServerDsc/issues/1008)).
+    If it fails to connect within the timeout period (defaults to 120 seconds) it
+    throws an error.
   - Fixed typo in comment-base help for helper function Test-AvailabilityReplicaSeedingModeAutomatic.
   - Style cleanup in helper function tests.
 - Changes to SqlAG
@@ -123,6 +128,11 @@
     name is correctly returned as a string ([issue #982](https://github.com/PowerShell/SqlServerDsc/issues/982)).
   - Added integration tests ([issue #980](https://github.com/PowerShell/SqlServerDsc/issues/980)).
   - Minor code style cleanup.
+  - The timing issue that the resource returned before SQL Server service was
+    actually restarted has been solved by a change in the helper function
+    Restart-SqlService ([issue #1008](https://github.com/PowerShell/SqlServerDsc/issues/1008)).
+    Now Restart-SqlService waits for the instance to return status 'Online' or
+    throws an error saying it failed to connect within the timeout period.
 - Changes to SqlSetup
   - Added parameter `ASServerMode` to support installing Analysis Services in
     Multidimensional mode, Tabular mode and PowerPivot mode

--- a/Tests/Unit/SqlServerDSCHelper.Tests.ps1
+++ b/Tests/Unit/SqlServerDSCHelper.Tests.ps1
@@ -236,6 +236,7 @@ InModuleScope $script:moduleName {
                 Assert-MockCalled -CommandName Start-Job -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName Wait-Job -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName Receive-Job -Scope It -Exactly -Times 0
+                Assert-MockCalled -CommandName Remove-Job -Scope It -Exactly -Times 1
             }
 
             It 'Should restart SQL Service and not try to restart missing SQL Agent service' {
@@ -245,9 +246,6 @@ InModuleScope $script:moduleName {
                 Assert-MockCalled -CommandName Get-Service -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName Restart-Service -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName Start-Service -Scope It -Exactly -Times 0
-                Assert-MockCalled -CommandName Start-Job -Scope It -Exactly -Times 1
-                Assert-MockCalled -CommandName Wait-Job -Scope It -Exactly -Times 1
-                Assert-MockCalled -CommandName Receive-Job -Scope It -Exactly -Times 0
             }
 
             It 'Should restart SQL Service and not try to restart stopped SQL Agent service' {
@@ -257,9 +255,6 @@ InModuleScope $script:moduleName {
                 Assert-MockCalled -CommandName Get-Service -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName Restart-Service -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName Start-Service -Scope It -Exactly -Times 0
-                Assert-MockCalled -CommandName Start-Job -Scope It -Exactly -Times 1
-                Assert-MockCalled -CommandName Wait-Job -Scope It -Exactly -Times 1
-                Assert-MockCalled -CommandName Receive-Job -Scope It -Exactly -Times 0
             }
 
             Context 'When it fails to connect to the instance within the timeout period' {
@@ -277,6 +272,7 @@ InModuleScope $script:moduleName {
                         Assert-MockCalled -CommandName Start-Job -Scope It -Exactly -Times 1
                         Assert-MockCalled -CommandName Wait-Job -Scope It -Exactly -Times 1
                         Assert-MockCalled -CommandName Receive-Job -Scope It -Exactly -Times 1
+                        Assert-MockCalled -CommandName Remove-Job -Scope It -Exactly -Times 1
                     } | Should -Throw $errorMessage
                 }
             }
@@ -354,6 +350,7 @@ InModuleScope $script:moduleName {
                 Assert-MockCalled -CommandName Start-Job -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName Wait-Job -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName Receive-Job -Scope It -Exactly -Times 0
+                Assert-MockCalled -CommandName Remove-Job -Scope It -Exactly -Times 1
             }
 
             It 'Should restart SQL Server and SQL Agent resources for a clustered named instance' {
@@ -364,9 +361,6 @@ InModuleScope $script:moduleName {
                 Assert-MockCalled -CommandName Get-CimAssociatedInstance -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName Invoke-CimMethod -ParameterFilter { $MethodName -eq 'TakeOffline' } -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName Invoke-CimMethod -ParameterFilter { $MethodName -eq 'BringOnline' } -Scope It -Exactly -Times 2
-                Assert-MockCalled -CommandName Start-Job -Scope It -Exactly -Times 1
-                Assert-MockCalled -CommandName Wait-Job -Scope It -Exactly -Times 1
-                Assert-MockCalled -CommandName Receive-Job -Scope It -Exactly -Times 0
             }
 
             It 'Should not try to restart a SQL Agent resource that is not online' {
@@ -377,9 +371,6 @@ InModuleScope $script:moduleName {
                 Assert-MockCalled -CommandName Get-CimAssociatedInstance -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName Invoke-CimMethod -ParameterFilter { $MethodName -eq 'TakeOffline' } -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName Invoke-CimMethod -ParameterFilter { $MethodName -eq 'BringOnline' } -Scope It -Exactly -Times 1
-                Assert-MockCalled -CommandName Start-Job -Scope It -Exactly -Times 1
-                Assert-MockCalled -CommandName Wait-Job -Scope It -Exactly -Times 1
-                Assert-MockCalled -CommandName Receive-Job -Scope It -Exactly -Times 0
             }
         }
     }

--- a/Tests/Unit/SqlServerDSCHelper.Tests.ps1
+++ b/Tests/Unit/SqlServerDSCHelper.Tests.ps1
@@ -234,6 +234,8 @@ InModuleScope $script:moduleName {
                 Assert-MockCalled -CommandName Restart-Service -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName Start-Service -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName Start-Job -Scope It -Exactly -Times 1
+                Assert-MockCalled -CommandName Wait-Job -Scope It -Exactly -Times 1
+                Assert-MockCalled -CommandName Receive-Job -Scope It -Exactly -Times 0
             }
 
             It 'Should restart SQL Service and not try to restart missing SQL Agent service' {
@@ -244,6 +246,8 @@ InModuleScope $script:moduleName {
                 Assert-MockCalled -CommandName Restart-Service -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName Start-Service -Scope It -Exactly -Times 0
                 Assert-MockCalled -CommandName Start-Job -Scope It -Exactly -Times 1
+                Assert-MockCalled -CommandName Wait-Job -Scope It -Exactly -Times 1
+                Assert-MockCalled -CommandName Receive-Job -Scope It -Exactly -Times 0
             }
 
             It 'Should restart SQL Service and not try to restart stopped SQL Agent service' {
@@ -254,6 +258,8 @@ InModuleScope $script:moduleName {
                 Assert-MockCalled -CommandName Restart-Service -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName Start-Service -Scope It -Exactly -Times 0
                 Assert-MockCalled -CommandName Start-Job -Scope It -Exactly -Times 1
+                Assert-MockCalled -CommandName Wait-Job -Scope It -Exactly -Times 1
+                Assert-MockCalled -CommandName Receive-Job -Scope It -Exactly -Times 0
             }
 
             Context 'When it fails to connect to the instance within the timeout period' {
@@ -268,11 +274,13 @@ InModuleScope $script:moduleName {
 
                     {
                         Restart-SqlService -SQLServer $env:ComputerName -SQLInstanceName 'MSSQLSERVER' -Timeout 1
+                        Assert-MockCalled -CommandName Start-Job -Scope It -Exactly -Times 1
+                        Assert-MockCalled -CommandName Wait-Job -Scope It -Exactly -Times 1
+                        Assert-MockCalled -CommandName Receive-Job -Scope It -Exactly -Times 1
                     } | Should -Throw $errorMessage
                 }
             }
         }
-
 
         Context 'Restart-SqlService clustered instance' {
             BeforeAll {
@@ -344,6 +352,8 @@ InModuleScope $script:moduleName {
                 Assert-MockCalled -CommandName Invoke-CimMethod -ParameterFilter { $MethodName -eq 'TakeOffline' } -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName Invoke-CimMethod -ParameterFilter { $MethodName -eq 'BringOnline' } -Scope It -Exactly -Times 2
                 Assert-MockCalled -CommandName Start-Job -Scope It -Exactly -Times 1
+                Assert-MockCalled -CommandName Wait-Job -Scope It -Exactly -Times 1
+                Assert-MockCalled -CommandName Receive-Job -Scope It -Exactly -Times 0
             }
 
             It 'Should restart SQL Server and SQL Agent resources for a clustered named instance' {
@@ -355,6 +365,8 @@ InModuleScope $script:moduleName {
                 Assert-MockCalled -CommandName Invoke-CimMethod -ParameterFilter { $MethodName -eq 'TakeOffline' } -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName Invoke-CimMethod -ParameterFilter { $MethodName -eq 'BringOnline' } -Scope It -Exactly -Times 2
                 Assert-MockCalled -CommandName Start-Job -Scope It -Exactly -Times 1
+                Assert-MockCalled -CommandName Wait-Job -Scope It -Exactly -Times 1
+                Assert-MockCalled -CommandName Receive-Job -Scope It -Exactly -Times 0
             }
 
             It 'Should not try to restart a SQL Agent resource that is not online' {
@@ -366,6 +378,8 @@ InModuleScope $script:moduleName {
                 Assert-MockCalled -CommandName Invoke-CimMethod -ParameterFilter { $MethodName -eq 'TakeOffline' } -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName Invoke-CimMethod -ParameterFilter { $MethodName -eq 'BringOnline' } -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName Start-Job -Scope It -Exactly -Times 1
+                Assert-MockCalled -CommandName Wait-Job -Scope It -Exactly -Times 1
+                Assert-MockCalled -CommandName Receive-Job -Scope It -Exactly -Times 0
             }
         }
     }

--- a/Tests/Unit/SqlServerDSCHelper.Tests.ps1
+++ b/Tests/Unit/SqlServerDSCHelper.Tests.ps1
@@ -136,11 +136,11 @@ InModuleScope $script:moduleName {
     #>
     $jobObjectCompleted = Start-Job -Name $mockStartJobName -ScriptBlock {
         Write-Verbose -Message 'Dummy script block for Start-Job mock'
-    }
+    } -ErrorAction Stop
 
     $jobObjectRunning = Start-Job -Name $mockStartJobName -ScriptBlock {
         Start-Sleep -Seconds 30
-    }
+    } -ErrorAction Stop
 
     Describe 'Testing Restart-SqlService' {
         BeforeAll {

--- a/en-US/SqlServerDscHelper.strings.psd1
+++ b/en-US/SqlServerDscHelper.strings.psd1
@@ -35,7 +35,6 @@ ConvertFrom-StringData @'
     RestartService = {0} service restarting.
     StartingDependentService = Starting service {0}
     WaitingInstanceTimeout = Waiting for instance {0}\\{1} to report status online, with a timeout value of {2} seconds.
-    FailedToValidateInstanceOnline = Failed to validate that instance is online after restart.
     FailedToConnectToInstanceTimeout = Failed to connect to the instance {0}\\{1} within the timeout period of {2} seconds.
     ExecuteQueryWithResultsFailed = Executing query with results failed on database '{0}'.
     ExecuteNonQueryFailed = Executing non-query failed on database '{0}'.

--- a/en-US/SqlServerDscHelper.strings.psd1
+++ b/en-US/SqlServerDscHelper.strings.psd1
@@ -35,6 +35,7 @@ ConvertFrom-StringData @'
     RestartService = {0} service restarting.
     StartingDependentService = Starting service {0}
     WaitingInstanceTimeout = Waiting for instance {0}\\{1} to report status online, with a timeout value of {2} seconds.
+    FailedToValidateInstanceOnline = Failed to validate that instance is online after restart.
     FailedToConnectToInstanceTimeout = Failed to connect to the instance {0}\\{1} within the timeout period of {2} seconds.
     ExecuteQueryWithResultsFailed = Executing query with results failed on database '{0}'.
     ExecuteNonQueryFailed = Executing non-query failed on database '{0}'.

--- a/en-US/SqlServerDscHelper.strings.psd1
+++ b/en-US/SqlServerDscHelper.strings.psd1
@@ -34,6 +34,8 @@ ConvertFrom-StringData @'
     GetServiceInformation = Getting {0} service information.
     RestartService = {0} service restarting.
     StartingDependentService = Starting service {0}
+    WaitingInstanceTimeout = Waiting for instance {0}\\{1} to report status online, with a timeout value of {2} seconds.
+    FailedToConnectToInstanceTimeout = Failed to connect to the instance {0}\\{1} within the timeout period of {2} seconds.
     ExecuteQueryWithResultsFailed = Executing query with results failed on database '{0}'.
     ExecuteNonQueryFailed = Executing non-query failed on database '{0}'.
     AlterAvailabilityGroupReplicaFailed = Failed to alter the availability group replica '{0}'.


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to SqlServerDsc
  - Now the helper function Restart-SqlService, after restarting the SQL Server
    service, does not return until it can connect to the SQL Server instance, and
    the instance returns status 'Online' (issue #1008).
    If it fails to connect within the timeout period (defaults to 120 seconds) it
    throws an error.
- Changes to SqlServiceAccount
  - The timing issue that the resource returned before SQL Server service was
    actually restarted has been solved by a change in the helper function
    Restart-SqlService ([issue #1008](https://github.com/PowerShell/SqlServerDsc/issues/1008)).
    Now Restart-SqlService waits for the instance to return status 'Online' or
    throws an error saying it failed to connect within the timeout period.

**This Pull Request (PR) fixes the following issues:**
Fixes #1008 

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/1019)
<!-- Reviewable:end -->
