### PR TITLE
SqlServerConfiguration: Added localization and improved verbose messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@
   - Style cleanup in tests.
   - Now the verbose message say what option is changing and to what value
     ([issue #1014](https://github.com/PowerShell/SqlServerDsc/issues/1014)).
-  - Change the type of the parameter from SInt32 to UInt32.
+  - Changed the RestartTimeout parameter from type SInt32 to type UInt32.
   - Added localization ([issue #605](https://github.com/PowerShell/SqlServerDsc/issues/605)).
 - Changes to SqlServerEndpoint
   - Updated README.md with links to the examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,10 @@
 - Changes to SqlServerConfiguration
   - Fixed minor typos in comment-based help.
   - Style cleanup in tests.
+  - Now the verbose message say what option is changing and to what value
+    ([issue #1014](https://github.com/PowerShell/SqlServerDsc/issues/1014)).
+  - Change the type of the parameter from SInt32 to UInt32.
+  - Added localization ([issue #605](https://github.com/PowerShell/SqlServerDsc/issues/605)).
 - Changes to SqlServerEndpoint
   - Updated README.md with links to the examples
     ([issue #504](https://github.com/PowerShell/SqlServerDsc/issues/504)).

--- a/DSCResources/MSFT_SqlServerConfiguration/MSFT_SqlServerConfiguration.psm1
+++ b/DSCResources/MSFT_SqlServerConfiguration/MSFT_SqlServerConfiguration.psm1
@@ -9,29 +9,29 @@ $script:localizedData = Get-LocalizedData -ResourceName 'MSFT_SqlServerConfigura
 
 <#
     .SYNOPSIS
-    Gets the current value of a SQL configuration option
+        Gets the current value of a SQL configuration option
 
     .PARAMETER ServerName
-    Hostname of the SQL Server to be configured
+        Hostname of the SQL Server to be configured
 
     .PARAMETER InstanceName
-    Name of the SQL instance to be configured. Default is 'MSSQLSERVER'
+        Name of the SQL instance to be configured. Default is 'MSSQLSERVER'
 
     .PARAMETER OptionName
-    The name of the SQL configuration option to be checked
+        The name of the SQL configuration option to be checked
 
     .PARAMETER OptionValue
-    The desired value of the SQL configuration option
+        The desired value of the SQL configuration option
 
     .PARAMETER RestartService
-    *** Not used in this function ***
-    Determines whether the instance should be restarted after updating the
-    configuration option.
+        *** Not used in this function ***
+        Determines whether the instance should be restarted after updating the
+        configuration option.
 
     .PARAMETER RestartTimeout
-    *** Not used in this function ***
-    The length of time, in seconds, to wait for the service to restart. Default
-    is 120 seconds.
+        *** Not used in this function ***
+        The length of time, in seconds, to wait for the service to restart. Default
+        is 120 seconds.
 #>
 function Get-TargetResource
 {
@@ -65,7 +65,7 @@ function Get-TargetResource
 
     $sql = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
-    ## get the configuration option
+    # Get the current value of the configuration option.
     $option = $sql.Configuration.Properties | Where-Object { $_.DisplayName -eq $OptionName }
 
     if (-not $option)
@@ -91,27 +91,27 @@ function Get-TargetResource
 
 <#
     .SYNOPSIS
-    Sets the value of a SQL configuration option
+        Sets the value of a SQL configuration option
 
     .PARAMETER ServerName
-    Hostname of the SQL Server to be configured
+        Hostname of the SQL Server to be configured
 
     .PARAMETER InstanceName
-    Name of the SQL instance to be configured. Default is 'MSSQLSERVER'
+        Name of the SQL instance to be configured. Default is 'MSSQLSERVER'
 
     .PARAMETER OptionName
-    The name of the SQL configuration option to be set
+        The name of the SQL configuration option to be set
 
     .PARAMETER OptionValue
-    The desired value of the SQL configuration option
+        The desired value of the SQL configuration option
 
     .PARAMETER RestartService
-    Determines whether the instance should be restarted after updating the
-    configuration option
+        Determines whether the instance should be restarted after updating the
+        configuration option
 
     .PARAMETER RestartTimeout
-    The length of time, in seconds, to wait for the service to restart. Default
-    is 120 seconds.
+        The length of time, in seconds, to wait for the service to restart. Default
+        is 120 seconds.
 #>
 function Set-TargetResource
 {
@@ -144,7 +144,7 @@ function Set-TargetResource
 
     $sql = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
 
-    ## get the configuration option
+    # Get the current value of the configuration option.
     $option = $sql.Configuration.Properties | Where-Object { $_.DisplayName -eq $OptionName }
 
     if (-not $option)
@@ -156,12 +156,14 @@ function Set-TargetResource
     $option.ConfigValue = $OptionValue
     $sql.Configuration.Alter()
 
+    Write-Verbose -Message (
+        $script:localizedData.ConfigurationValueUpdated `
+            -f $OptionName, $OptionValue
+    )
+
     if ($option.IsDynamic -eq $true)
     {
-        Write-Verbose -Message (
-            $script:localizedData.ConfigurationValueUpdated `
-                -f $OptionName, $OptionValue
-        )
+        Write-Verbose -Message $script:localizedData.NoRestartNeeded
     }
     elseif (($option.IsDynamic -eq $false) -and ($RestartService -eq $true))
     {
@@ -183,29 +185,29 @@ function Set-TargetResource
 
 <#
     .SYNOPSIS
-    Determines whether a SQL configuration option value is properly set
+        Determines whether a SQL configuration option value is properly set
 
     .PARAMETER ServerName
-    Hostname of the SQL Server to be configured
+        Hostname of the SQL Server to be configured
 
     .PARAMETER InstanceName
-    Name of the SQL instance to be configured. Default is 'MSSQLSERVER'
+        Name of the SQL instance to be configured. Default is 'MSSQLSERVER'
 
     .PARAMETER OptionName
-    The name of the SQL configuration option to be tested
+        The name of the SQL configuration option to be tested
 
     .PARAMETER OptionValue
-    The desired value of the SQL configuration option
+        The desired value of the SQL configuration option
 
     .PARAMETER RestartService
-    *** Not used in this function ***
-    Determines whether the instance should be restarted after updating the
-    configuration option
+        *** Not used in this function ***
+        Determines whether the instance should be restarted after updating the
+        configuration option
 
     .PARAMETER RestartTimeout
-    *** Not used in this function ***
-    The length of time, in seconds, to wait for the service to restart. Default
-    is 120 seconds.
+        *** Not used in this function ***
+        The length of time, in seconds, to wait for the service to restart. Default
+        is 120 seconds.
 #>
 function Test-TargetResource
 {
@@ -237,7 +239,7 @@ function Test-TargetResource
         $RestartTimeout = 120
     )
 
-    ## Get the current state of the configuration item
+    # Get the current value of the configuration option.
     $getTargetResourceResult = Get-TargetResource @PSBoundParameters
 
     if ($getTargetResourceResult.OptionValue -eq $OptionValue)
@@ -259,7 +261,6 @@ function Test-TargetResource
         $result = $false
     }
 
-    ## return whether the value matches the desired state
     return $result
 }
 

--- a/DSCResources/MSFT_SqlServerConfiguration/MSFT_SqlServerConfiguration.schema.mof
+++ b/DSCResources/MSFT_SqlServerConfiguration/MSFT_SqlServerConfiguration.schema.mof
@@ -4,7 +4,7 @@ class MSFT_SqlServerConfiguration : OMI_BaseResource
     [Key, Description("The hostname of the SQL Server to be configured.")] String ServerName;
     [Key, Description("Name of the SQL instance to be configured.")] String InstanceName;
     [Key, Description("The name of the SQL configuration option to be checked.")] String OptionName;
-    [Required, Description("The desired value of the SQL configuration option.")] Sint32 OptionValue;
+    [Required, Description("The desired value of the SQL configuration option.")] SInt32 OptionValue;
     [Write, Description("Determines whether the instance should be restarted after updating the configuration option.")] Boolean RestartService;
-    [Write, Description("The length of time, in seconds, to wait for the service to restart. Default is 120 seconds.")] Sint32 RestartTimeout;
+    [Write, Description("The length of time, in seconds, to wait for the service to restart. Default is 120 seconds.")] UInt32 RestartTimeout;
 };

--- a/DSCResources/MSFT_SqlServerConfiguration/en-US/MSFT_SqlServerConfiguration.strings.psd1
+++ b/DSCResources/MSFT_SqlServerConfiguration/en-US/MSFT_SqlServerConfiguration.strings.psd1
@@ -1,0 +1,11 @@
+# Localized resources for SqlServerConfiguration
+
+ConvertFrom-StringData @'
+    CurrentOptionValue = Configuration option '{0}' has a current value of '{1}'.
+    ConfigurationValueUpdated = Configuration option '{0}' has been updated to value '{1}'.
+    AutomaticRestart = A restart of SQL Server is required for the change to take effect. Initiating automatic restart of the SQL Server instance {0}//{1}.
+    ConfigurationOptionNotFound = Specified option '{0}' could not be found.
+    ConfigurationRestartRequired = Configuration option '{0}' has been updated to value '{1}', but a manual restart of SQL Server instance {2}//{3} is required for it to take effect.
+    NotInDesiredState = Configuration option '{0}' is not in desired state. Expected '{1}', but was '{2}'.
+    InDesiredState = Configuration option '{0}' is in desired state.
+'@

--- a/DSCResources/MSFT_SqlServerConfiguration/en-US/MSFT_SqlServerConfiguration.strings.psd1
+++ b/DSCResources/MSFT_SqlServerConfiguration/en-US/MSFT_SqlServerConfiguration.strings.psd1
@@ -8,4 +8,5 @@ ConvertFrom-StringData @'
     ConfigurationRestartRequired = Configuration option '{0}' has been updated to value '{1}', but a manual restart of SQL Server instance {2}//{3} is required for it to take effect.
     NotInDesiredState = Configuration option '{0}' is not in desired state. Expected '{1}', but was '{2}'.
     InDesiredState = Configuration option '{0}' is in desired state.
+    NoRestartNeeded = The option was changed without the need to restart the SQL Server instance.
 '@

--- a/README.md
+++ b/README.md
@@ -870,11 +870,11 @@ on a SQL Server instance.
 * **`[String]` OptionName** _(Key)_: The name of the SQL configuration option to
   be checked. For all possible values reference [MSDN](https://msdn.microsoft.com/en-us/library/ms189631.aspx)
   or run sp_configure.
-* **`[Sint32]` OptionValue** _(Required)_: The desired value of the SQL configuration
+* **`[SInt32]` OptionValue** _(Required)_: The desired value of the SQL configuration
   option.
 * **`[Boolean]` RestartService** _(Write)_: Determines whether the instance should
   be restarted after updating the configuration option.
-* **`[Sint32]` RestartTimeout** _(Write)_: The length of time, in seconds, to wait
+* **`[UInt32]` RestartTimeout** _(Write)_: The length of time, in seconds, to wait
   for the service to restart. Default is 120 seconds.
 
 #### Examples

--- a/Tests/Unit/MSFT_SqlServerConfiguration.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerConfiguration.Tests.ps1
@@ -60,19 +60,10 @@ $invalidOption = @{
     RestartTimeout = 120
 }
 
-## compile the SMO stub
-#Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
-
 try
 {
     Describe "$($script:DSCResourceName)\Get-TargetResource" {
-
-        Mock -CommandName New-VerboseMessage -ModuleName $script:DSCResourceName
-
-        Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -ModuleName $script:DSCResourceName
-
         Context 'The system is not in the desired state' {
-
             Mock -CommandName Connect-SQL -MockWith {
                 $mock = New-Object -TypeName PSObject -Property @{
                     Configuration = @{
@@ -85,13 +76,13 @@ try
                     }
                 }
 
-                ## add the Alter method
+                # Add the Alter method.
                 $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
 
                 return $mock
             } -ModuleName $script:DSCResourceName -Verifiable
 
-            ## Get the current state
+            # Get the current state.
             $result = Get-TargetResource @desiredState
 
             It 'Should return the same values as passed' {
@@ -109,7 +100,6 @@ try
         }
 
         Context 'The system is in the desired state' {
-
             Mock -CommandName Connect-SQL -MockWith {
                 $mock = New-Object -TypeName PSObject -Property @{
                     Configuration = @{
@@ -122,13 +112,13 @@ try
                     }
                 }
 
-                ## add the Alter method
+                # Add the Alter method.
                 $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
 
                 return $mock
             } -ModuleName $script:DSCResourceName -Verifiable
 
-            ## Get the current state
+            # Get the current state.
             $result = Get-TargetResource @desiredState
 
             It 'Should return the same values as passed' {
@@ -145,8 +135,7 @@ try
             }
         }
 
-        Context 'Invalid data is supplied' {
-
+        Context 'Invalid option name is supplied' {
             Mock -CommandName Connect-SQL -MockWith {
                 $mock = New-Object -TypeName PSObject -Property @{
                     Configuration = @{
@@ -159,24 +148,20 @@ try
                     }
                 }
 
-                ## add the Alter method
+                # Add the Alter method.
                 $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
 
                 return $mock
             } -ModuleName $script:DSCResourceName -Verifiable
 
-            It 'Should call New-TerminatingError mock when a bad option name is specified' {
-                { Get-TargetResource @invalidOption } | Should -Throw 'ConfigurationOptionNotFound'
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-TerminatingError -Scope It -Times 1
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope Context -Times 1
+            It 'Should throw the correct error message' {
+                $errorMessage = ($script:localizedData.ConfigurationOptionNotFound -f $invalidOption.OptionName)
+                { Get-TargetResource @invalidOption } | Should -Throw $errorMessage
             }
         }
     }
 
     Describe "$($script:DSCResourceName)\Test-TargetResource" {
-
-        Mock -CommandName New-VerboseMessage -ModuleName $script:DSCResourceName
-
         Mock -CommandName Connect-SQL -MockWith {
             $mock = New-Object -TypeName PSObject -Property @{
                 Configuration = @{
@@ -189,7 +174,7 @@ try
                 }
             }
 
-            ## add the Alter method
+            # Add the Alter method.
             $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
 
             return $mock
@@ -205,10 +190,7 @@ try
     }
 
     Describe "$($script:DSCResourceName)\Set-TargetResource" {
-        Mock -CommandName New-VerboseMessage -ModuleName $script:DSCResourceName
-
         Mock -CommandName New-TerminatingError -ModuleName $script:DSCResourceName
-
         Mock -CommandName Connect-SQL -MockWith {
             $mock = New-Object -TypeName PSObject -Property @{
                 Configuration = @{
@@ -222,7 +204,7 @@ try
                 }
             }
 
-            ## add the Alter method
+            # Add the Alter method.
             $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
 
             return $mock
@@ -241,15 +223,14 @@ try
                 }
             }
 
-            ## add the Alter method
+            # Add the Alter method.
             $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
 
             return $mock
         } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { $SQLServer -eq 'CLU02' }
 
         Mock -CommandName Restart-SqlService -ModuleName $script:DSCResourceName -Verifiable
-
-        Mock -CommandName New-WarningMessage -ModuleName $script:DSCResourceName -Verifiable
+        Mock -CommandName Write-Warning -ModuleName $script:DSCResourceName -Verifiable
 
         Context 'Change the system to the desired state' {
             It 'Should not restart SQL for a dynamic option' {
@@ -265,12 +246,37 @@ try
             It 'Should warn about restart when required, but not requested' {
                 Set-TargetResource @desiredState
 
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-WarningMessage -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Write-Warning -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Restart-SqlService -Scope It -Times 0 -Exactly
             }
 
             It 'Should call Connect-SQL to get option values' {
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope Context -Times 3
+            }
+        }
+
+        Context 'Invalid option name is supplied' {
+            Mock -CommandName Connect-SQL -MockWith {
+                $mock = New-Object -TypeName PSObject -Property @{
+                    Configuration = @{
+                        Properties = @(
+                            @{
+                                DisplayName = 'user connections'
+                                ConfigValue = 0
+                            }
+                        )
+                    }
+                }
+
+                # Add the Alter method.
+                $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
+
+                return $mock
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should throw the correct error message' {
+                $errorMessage = ($script:localizedData.ConfigurationOptionNotFound -f $invalidOption.OptionName)
+                { Set-TargetResource @invalidOption } | Should -Throw $errorMessage
             }
         }
     }

--- a/en-US/SqlServerDscHelper.strings.psd1
+++ b/en-US/SqlServerDscHelper.strings.psd1
@@ -91,10 +91,6 @@ ConvertFrom-StringData @'
     PermissionGetError = Unexpected result when trying to get permissions for '{0}'.
     ChangingPermissionFailed = Changing permission for principal '{0}' failed.
 
-    # Configuration
-    ConfigurationOptionNotFound = Specified option '{0}' could not be found.
-    ConfigurationRestartRequired = Configuration option '{0}' has been updated, but a manual restart of SQL Server is required for it to take effect.
-
     # AlwaysOnService
     AlterAlwaysOnServiceFailed = Failed to ensure Always On is {0} on the instance '{1}'.
     UnexpectedAlwaysOnStatus = The status of property Server.IsHadrEnabled was neither $true or $false. Status is '{0}'.


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to SqlServerConfiguration
  - Now the verbose message say what option is changing and to what value (issue #1014).
  - Changed the RestartTimeout parameter from type SInt32 to type UInt32.
  - Added localization (issue #605).

**This Pull Request (PR) fixes the following issues:**
Fixes #1014 
Fixes #605 

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/1021)
<!-- Reviewable:end -->
