### PR TITLE
SqlServerLogin: Fix password test fails for nativ sql users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Changes to SqlServerLogin
+  - Fix password test fails for nativ sql users ([issue #1048](https://github.com/PowerShell/SqlServerDsc/issues/1048)).
+
 ## 11.0.0.0
 
 - Changes to SqlServerDsc

--- a/DSCResources/MSFT_SqlServerLogin/MSFT_SqlServerLogin.psm1
+++ b/DSCResources/MSFT_SqlServerLogin/MSFT_SqlServerLogin.psm1
@@ -416,7 +416,14 @@ function Test-TargetResource
 
                 try
                 {
-                    Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName -SetupCredential $userCredential | Out-Null
+                    if ($LoginType -eq 'SqlLogin')
+                    {
+                        Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName -SetupCredential $userCredential -LoginType 'SqlLogin' | Out-Null
+                    }
+                    else
+                    {
+                        Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName -SetupCredential $userCredential | Out-Null
+                    }
                 }
                 catch
                 {

--- a/Tests/Unit/SqlServerDSCHelper.Tests.ps1
+++ b/Tests/Unit/SqlServerDSCHelper.Tests.ps1
@@ -81,6 +81,9 @@ InModuleScope $script:moduleName {
             Add-Member -MemberType NoteProperty -Name ConnectionContext -Value (
                 New-Object -TypeName Object |
                     Add-Member -MemberType NoteProperty -Name ServerInstance -Value $serverInstance -PassThru |
+                    Add-Member -MemberType ScriptProperty -Name LoginSecure -Value { [System.Boolean] $mockExpectedDatabaseEngineLoginSecure } -PassThru -Force |
+                    Add-Member -MemberType NoteProperty -Name Login -Value '' -PassThru |
+                    Add-Member -MemberType NoteProperty -Name SecurePassword -Value $null -PassThru |
                     Add-Member -MemberType NoteProperty -Name ConnectAsUser -Value $false -PassThru |
                     Add-Member -MemberType NoteProperty -Name ConnectAsUserPassword -Value '' -PassThru |
                     Add-Member -MemberType NoteProperty -Name ConnectAsUserName -Value '' -PassThru |
@@ -1169,12 +1172,42 @@ InModuleScope $script:moduleName {
             }
         }
 
+        Context 'When connecting to the default instance using SQL Server Authentication' {
+            It 'Should return the correct service instance' {
+                $mockExpectedDatabaseEngineServer = 'TestServer'
+                $mockExpectedDatabaseEngineInstance = 'MSSQLSERVER'
+                $mockExpectedDatabaseEngineLoginSecure = $false
+
+                $databaseEngineServerObject = Connect-SQL -SQLServer $mockExpectedDatabaseEngineServer -LoginType 'SqlLogin'
+                $databaseEngineServerObject.ConnectionContext.LoginSecure | Should -Be $false
+                $databaseEngineServerObject.ConnectionContext.ServerInstance | Should -BeExactly $mockExpectedDatabaseEngineServer
+
+                Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
+                    -ParameterFilter $mockNewObject_MicrosoftDatabaseEngine_ParameterFilter
+            }
+        }
+
         Context 'When connecting to the named instance using Windows Authentication' {
             It 'Should return the correct service instance' {
                 $mockExpectedDatabaseEngineServer = $env:COMPUTERNAME
                 $mockExpectedDatabaseEngineInstance = $mockInstanceName
 
                 $databaseEngineServerObject = Connect-SQL -SQLInstanceName $mockExpectedDatabaseEngineInstance
+                $databaseEngineServerObject.ConnectionContext.ServerInstance | Should -BeExactly "$mockExpectedDatabaseEngineServer\$mockExpectedDatabaseEngineInstance"
+
+                Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
+                    -ParameterFilter $mockNewObject_MicrosoftDatabaseEngine_ParameterFilter
+            }
+        }
+
+        Context 'When connecting to the named instance using SQL Server Authentication' {
+            It 'Should return the correct service instance' {
+                $mockExpectedDatabaseEngineServer = $env:COMPUTERNAME
+                $mockExpectedDatabaseEngineInstance = $mockInstanceName
+                $mockExpectedDatabaseEngineLoginSecure = $false
+
+                $databaseEngineServerObject = Connect-SQL -SQLInstanceName $mockExpectedDatabaseEngineInstance
+                $databaseEngineServerObject.ConnectionContext.LoginSecure | Should -Be $false
                 $databaseEngineServerObject.ConnectionContext.ServerInstance | Should -BeExactly "$mockExpectedDatabaseEngineServer\$mockExpectedDatabaseEngineInstance"
 
                 Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `


### PR DESCRIPTION
**Pull Request (PR) description**
Bug in the Connect-SQL helper function, the resource is not able to test a nativ SQL user password. It tries to test the native SQL user password like a Windows login, which always fails.

**This Pull Request (PR) fixes the following issues:**
#1048 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?
