### PR TITLE
SqlSetup: Accounts containing '$' will be able to be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -580,10 +580,10 @@
     SHIFT+ALT+F, or press F1 and choose 'Format document' in the list. The
     PowerShell code will then be formatted according to the Style Guideline
     (although maybe not complete, but would help a long way).
-      - Removed powershell.codeFormatting.alignPropertyValuePairs setting since
-        it does not align with the style guideline.
-      - Added powershell.codeFormatting.preset with a value of 'Custom' so that
-        workspace formatting settings are honored (issue #665).
+    - Removed powershell.codeFormatting.alignPropertyValuePairs setting since
+      it does not align with the style guideline.
+    - Added powershell.codeFormatting.preset with a value of 'Custom' so that
+      workspace formatting settings are honored (issue #665).
   - Fixed lint error MD013 and MD036 in README.md.
   - Updated .markdownlint.json to enable rule MD013 and MD036 to enforce those
     lint markdown rules in the common tests.
@@ -1048,11 +1048,11 @@
   - BREAKING CHANGE: Removed default value "$PSScriptRoot\..\..\" from parameter
     SourcePath.
   - Old code, that no longer filled any function, has been replaced.
-      - Function `ResolvePath` has been replaced with
+    - Function `ResolvePath` has been replaced with
       `[Environment]::ExpandEnvironmentVariables($SourcePath)` so that environment
       variables still can be used in Source Path.
-      - Function `NetUse` has been replaced with `New-SmbMapping` and
-        `Remove-SmbMapping`.
+    - Function `NetUse` has been replaced with `New-SmbMapping` and
+      `Remove-SmbMapping`.
   - Renamed function `GetSQLVersion` to `Get-SqlMajorVersion`.
   - BREAKING CHANGE: Renamed parameter PID to ProductKey to avoid collision with
     automatic variable $PID
@@ -1291,28 +1291,28 @@
     - Grant-CNOPerms
     - New-ListenerADObject
 - xSQLDatabaseRecoveryModel
-    - Updated Verbose statements to use new function New-VerboseMessage
+  - Updated Verbose statements to use new function New-VerboseMessage
 - xSQLServerDatabase
-    - Updated Verbose statements to use new function New-VerboseMessage
-    - Removed ConnectSQL function and replaced with new Connect-SQL function
+  - Updated Verbose statements to use new function New-VerboseMessage
+  - Removed ConnectSQL function and replaced with new Connect-SQL function
 - xSQLServerDatabaseOwner
-    - Removed ConnectSQL function and replaced with new Connect-SQL function
+  - Removed ConnectSQL function and replaced with new Connect-SQL function
 - xSQLServerDatabasePermissions
-    - Removed ConnectSQL function and replaced with new Connect-SQL function
+  - Removed ConnectSQL function and replaced with new Connect-SQL function
 - xSQLServerDatabaseRole
-    - Removed ConnectSQL function and replaced with new Connect-SQL function
+  - Removed ConnectSQL function and replaced with new Connect-SQL function
 - xSQLServerLogin
-    - Removed ConnectSQL function and replaced with new Connect-SQL function
+  - Removed ConnectSQL function and replaced with new Connect-SQL function
 - xSQLServerMaxDop
-    - Updated Verbose statements to use new function New-VerboseMessage
-    - Removed ConnectSQL function and replaced with new Connect-SQL function
+  - Updated Verbose statements to use new function New-VerboseMessage
+  - Removed ConnectSQL function and replaced with new Connect-SQL function
 - xSQLServerMemory
-    - Updated Verbose statements to use new function New-VerboseMessage
-    - Removed ConnectSQL function and replaced with new Connect-SQL function
+  - Updated Verbose statements to use new function New-VerboseMessage
+  - Removed ConnectSQL function and replaced with new Connect-SQL function
 - xSQLServerPowerPlan
-    - Updated Verbose statements to use new function New-VerboseMessage
+  - Updated Verbose statements to use new function New-VerboseMessage
 - Examples
-    - Added xSQLServerConfiguration resource example
+  - Added xSQLServerConfiguration resource example
 
 ## 1.5.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,19 @@
 ## Unreleased
 
 - Changes to SqlServerLogin
-  - Fix password test fails for nativ sql users ([issue #1048](https://github.com/PowerShell/SqlServerDsc/issues/1048)).
+  - Fix password test fails for nativ sql users
+    ([issue #1048](https://github.com/PowerShell/SqlServerDsc/issues/1048)).
 - Changes to SqlSetup
   - Clarify usage of 'SecurityMode' along with adding parameter
-    validations for the only 2 supported values. ([issue #1010](https://github.com/PowerShell/SqlServerDsc/issues/1010))
+    validations for the only 2 supported values
+    ([issue #1010](https://github.com/PowerShell/SqlServerDsc/issues/1010)).
+  - Now accounts containing '$' will be able to be used for installing
+    SQL Server. Although, if the account ends with '$' it is considered a
+    Managed Service Account
+    ([issue #1055](https://github.com/PowerShell/SqlServerDsc/issues/1055)).
 - Changes to Integration Tests
-  - Replace xStorage dsc resource module with StorageDsc ([issue #1038](https://github.com/PowerShell/SqlServerDsc/issues/1038)).
+  - Replace xStorage dsc resource module with StorageDsc
+    ([issue #1038](https://github.com/PowerShell/SqlServerDsc/issues/1038)).
 
 ## 11.0.0.0
 

--- a/DSCResources/MSFT_SqlSetup/MSFT_SqlSetup.psm1
+++ b/DSCResources/MSFT_SqlSetup/MSFT_SqlSetup.psm1
@@ -2121,6 +2121,7 @@ function Get-ServiceAccountParameters
             }
         }
 
+        # Testing if account is a Managed Service Account, which ends with '$'.
         '\$$'
         {
             $parameters = @{
@@ -2128,6 +2129,7 @@ function Get-ServiceAccountParameters
             }
         }
 
+        # Normal local or domain service account.
         default
         {
             $parameters = @{

--- a/DSCResources/MSFT_SqlSetup/MSFT_SqlSetup.psm1
+++ b/DSCResources/MSFT_SqlSetup/MSFT_SqlSetup.psm1
@@ -2121,7 +2121,7 @@ function Get-ServiceAccountParameters
             }
         }
 
-        '.*\$'
+        '\$$'
         {
             $parameters = @{
                 "$($ServiceType)SVCACCOUNT" = $ServiceAccount.UserName

--- a/README.md
+++ b/README.md
@@ -1480,7 +1480,7 @@ Account.
 
 ##### Managed Service Accounts
 
-If a service account username have a dollar sign at the end of the name it will
+If a service account username has a dollar sign at the end of the name it will
 be considered a Managed Service Account. Any password passed in
 the credential object will be ignored, meaning the account is not expected to
 need a '*SVCPASSWORD' argument in the setup arguments.

--- a/README.md
+++ b/README.md
@@ -1456,7 +1456,7 @@ cluster. This is a limitation of SQL Server. See article
 [You cannot add or remove features to a SQL Server 2008, SQL Server 2008 R2, or
 SQL Server 2012 failover cluster](https://support.microsoft.com/en-us/help/2547273/you-cannot-add-or-remove-features-to-a-sql-server-2008,-sql-server-2008-r2,-or-sql-server-2012-failover-cluster).
 
-#### Credentials
+#### Credentials for running the resource
 
 ##### PsDscRunAsCredential
 
@@ -1469,6 +1469,21 @@ If PsDscRunAsCredential is not assigned credentials then installation will be
 performed by the SYSTEM account. When installing as the SYSTEM account, then
 parameter SQLSysAdminAccounts and ASSysAdminAccounts must be specified when
 installing feature Database Engine and Analysis Services respectively.
+
+#### Credentials for service accounts
+
+##### Service Accounts
+
+Service account username containing dollar sign ('$') is allowed, but if the
+dollar sign is at the end of the username it will be considered a Managed Service
+Account.
+
+##### Managed Service Accounts
+
+If a service account username have a dollar sign at the end of the name it will
+be considered a Managed Service Account. Any password passed in
+the credential object will be ignored, meaning the account is not expected to
+need a '*SVCPASSWORD' argument in the setup arguments.
 
 #### Parameters
 

--- a/Tests/Unit/MSFT_SqlSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlSetup.Tests.ps1
@@ -4698,6 +4698,10 @@ try
                 $mockDomainServiceAccount = (
                     New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'COMPANY\sql.service', $mockServiceAccountPassword
                 )
+
+                $mockDomainServiceAccountContainingDollarSign = (
+                    New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'COMPANY\$sql.service', $mockServiceAccountPassword
+                )
             }
 
             $serviceTypes | ForEach-Object {
@@ -4705,34 +4709,45 @@ try
                 $serviceType = $_
 
                 Context "When service type is $serviceType" {
+                    $mockAccountArgumentName = ('{0}SVCACCOUNT' -f $serviceType)
+                    $mockPasswordArgumentName = ('{0}SVCPASSWORD' -f $serviceType)
 
-                    It "Should return the correct parameters when the account is a system account." {
+                    It 'Should return the correct parameters when the account is a system account.' {
                         $result = Get-ServiceAccountParameters -ServiceAccount $mockSystemServiceAccount -ServiceType $serviceType
 
-                        $result.$("$($serviceType)SVCACCOUNT") | Should -BeExactly $mockSystemServiceAccount.UserName
-                        $result.ContainsKey("$($serviceType)SVCPASSWORD") | Should -Be $false
+                        $result.$mockAccountArgumentName | Should -BeExactly $mockSystemServiceAccount.UserName
+                        $result.ContainsKey($mockPasswordArgumentName) | Should -Be $false
                     }
 
-                    It "Should return the correct parameters when the account is a virtual service account" {
+                    It 'Should return the correct parameters when the account is a virtual service account' {
                         $result = Get-ServiceAccountParameters -ServiceAccount $mockVirtualServiceAccount -ServiceType $serviceType
 
-                        $result.$("$($serviceType)SVCACCOUNT") | Should -BeExactly $mockVirtualServiceAccount.UserName
-                        $result.ContainsKey("$($serviceType)SVCPASSWORD") | Should -Be $false
+                        $result.$mockAccountArgumentName | Should -BeExactly $mockVirtualServiceAccount.UserName
+                        $result.ContainsKey($mockPasswordArgumentName) | Should -Be $false
                     }
 
-                    It "Should return the correct parameters when the account is a managed service account" {
+                    It 'Should return the correct parameters when the account is a managed service account' {
                         $result = Get-ServiceAccountParameters -ServiceAccount $mockManagedServiceAccount -ServiceType $serviceType
 
-                        $result.$("$($serviceType)SVCACCOUNT") | Should -BeExactly $mockManagedServiceAccount.UserName
-                        $result.ContainsKey("$($serviceType)SVCPASSWORD") | Should -Be $false
+                        $result.$mockAccountArgumentName | Should -BeExactly $mockManagedServiceAccount.UserName
+                        $result.ContainsKey($mockPasswordArgumentName) | Should -Be $false
                     }
 
-                    It "Should return the correct parameters when the account is a domain account" {
+                    It 'Should return the correct parameters when the account is a domain account' {
                         $result = Get-ServiceAccountParameters -ServiceAccount $mockDomainServiceAccount -ServiceType $serviceType
 
-                        $result.$("$($serviceType)SVCACCOUNT") | Should -BeExactly $mockDomainServiceAccount.UserName
-                        $result.$("$($serviceType)SVCPASSWORD") | Should -BeExactly $mockDomainServiceAccount.GetNetworkCredential().Password
+                        $result.$mockAccountArgumentName | Should -BeExactly $mockDomainServiceAccount.UserName
+                        $result.$mockPasswordArgumentName | Should -BeExactly $mockDomainServiceAccount.GetNetworkCredential().Password
                     }
+
+                    # Regression test for issue #1055
+                    It 'Should return the correct parameters when the account is a domain account containing a dollar sign ($)' {
+                        $result = Get-ServiceAccountParameters -ServiceAccount $mockDomainServiceAccountContainingDollarSign -ServiceType $serviceType
+
+                        $result.$mockAccountArgumentName | Should -BeExactly $mockDomainServiceAccountContainingDollarSign.UserName
+                        $result.$mockPasswordArgumentName | Should -BeExactly $mockDomainServiceAccountContainingDollarSign.GetNetworkCredential().Password
+                    }
+
                 }
             }
         }

--- a/Tests/Unit/MSFT_SqlSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlSetup.Tests.ps1
@@ -4683,29 +4683,23 @@ try
             BeforeAll {
                 $mockServiceAccountPassword = ConvertTo-SecureString 'Password' -AsPlainText -Force
 
-                $mockSystemServiceAccount = (
+                $mockSystemServiceAccount = `
                     New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'NT AUTHORITY\SYSTEM', $mockServiceAccountPassword
-                )
 
-                $mockVirtualServiceAccount = (
+                $mockVirtualServiceAccount = `
                     New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'NT SERVICE\MSSQLSERVER', $mockServiceAccountPassword
-                )
 
-                $mockManagedServiceAccount = (
+                $mockManagedServiceAccount = `
                     New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'COMPANY\ManagedAccount$', $mockServiceAccountPassword
-                )
 
-                $mockDomainServiceAccount = (
+                $mockDomainServiceAccount = `
                     New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'COMPANY\sql.service', $mockServiceAccountPassword
-                )
 
-                $mockDomainServiceAccountContainingDollarSign = (
+                $mockDomainServiceAccountContainingDollarSign = `
                     New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'COMPANY\$sql.service', $mockServiceAccountPassword
-                )
             }
 
             $serviceTypes | ForEach-Object {
-
                 $serviceType = $_
 
                 Context "When service type is $serviceType" {


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to SqlSetup
  - Now accounts containing '$' will be able to be used for installing
    SQL Server. Although, if the account ends with '$' it is considered a
    Managed Service Account (issue #1055).

**This Pull Request (PR) fixes the following issues:**
Fixes #1055

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/1060)
<!-- Reviewable:end -->
