### PR TITLE
SqlSetup: MSFT_SqlSetup.psm1 enable Robocopy to use paths containing spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     DscResource.Tests.
   - New resources:
     - Added SqlScriptQueryResource. [Chase Wilson (@chasewilson)](https://github.com/chasewilson)
+  - Fix for issue #779 (https://github.com/PowerShell/SqlServerDsc/issues/779) [Paul Kelly (@prkelly)](https://github.com/prkelly)
 
 ## 11.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
     DscResource.Tests.
   - New resources:
     - Added SqlScriptQueryResource. [Chase Wilson (@chasewilson)](https://github.com/chasewilson)
-  - Fix for issue #779 (https://github.com/PowerShell/SqlServerDsc/issues/779) [Paul Kelly (@prkelly)](https://github.com/prkelly)
+  - Fix for issue #779 [Paul Kelly (@prkelly)](https://github.com/prkelly)
 
 ## 11.2.0.0
 

--- a/DSCResources/MSFT_SqlSetup/MSFT_SqlSetup.psm1
+++ b/DSCResources/MSFT_SqlSetup/MSFT_SqlSetup.psm1
@@ -1926,7 +1926,7 @@ function Copy-ItemWithRobocopy
         [ValidateNotNullOrEmpty()]
         [System.String]
         $DestinationPath
-    }
+    )
     $quotedPath = '"{0}"' -f $Path
     $quotedDestinationPath = '"{0}"' -f $DestinationPath
     $robocopyExecutable = Get-Command -Name "Robocopy.exe" -ErrorAction Stop

--- a/DSCResources/MSFT_SqlSetup/MSFT_SqlSetup.psm1
+++ b/DSCResources/MSFT_SqlSetup/MSFT_SqlSetup.psm1
@@ -1927,7 +1927,8 @@ function Copy-ItemWithRobocopy
         [System.String]
         $DestinationPath
     )
-
+    $quotedPath = '"{0}"' -f $Path
+    $quotedDestinationPath = '"{0}"' -f $DestinationPath
     $robocopyExecutable = Get-Command -Name "Robocopy.exe" -ErrorAction Stop
 
     $robocopyArgumentSilent = '/njh /njs /ndl /nc /ns /nfl'
@@ -1945,8 +1946,8 @@ function Copy-ItemWithRobocopy
         Write-Verbose -Message $script:localizedData.RobocopyNotUsingUnbufferedIo
     }
 
-    $robocopyArgumentList = '{0} {1} {2} {3} {4} {5}' -f $Path,
-                                                         $DestinationPath,
+    $robocopyArgumentList = '{0} {1} {2} {3} {4} {5}' -f $quotedPath,
+                                                         $quotedDestinationPath,
                                                          $robocopyArgumentCopySubDirectoriesIncludingEmpty,
                                                          $robocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource,
                                                          $robocopyArgumentUseUnbufferedIO,

--- a/DSCResources/MSFT_SqlSetup/MSFT_SqlSetup.psm1
+++ b/DSCResources/MSFT_SqlSetup/MSFT_SqlSetup.psm1
@@ -1926,7 +1926,7 @@ function Copy-ItemWithRobocopy
         [ValidateNotNullOrEmpty()]
         [System.String]
         $DestinationPath
-    )
+    }
     $quotedPath = '"{0}"' -f $Path
     $quotedDestinationPath = '"{0}"' -f $DestinationPath
     $robocopyExecutable = Get-Command -Name "Robocopy.exe" -ErrorAction Stop

--- a/Tests/Unit/MSFT_SqlSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlSetup.Tests.ps1
@@ -661,6 +661,8 @@ try
         $mockRobocopyArgumentUseUnbufferedIO = '/J'
         $mockRobocopyArgumentSourcePath = 'C:\Source\SQL2016'
         $mockRobocopyArgumentDestinationPath = 'D:\Temp'
+        $mockRobocopyArgumentSourcePathWithSpaces = 'C:\Source\SQL2016 STD SP1'
+        $mockRobocopyArgumentDestinationPathWithSpaces = 'D:\Temp\DSC SQL2016'
 
         $mockGetCommand = {
             return @(
@@ -4672,6 +4674,54 @@ try
                     $copyItemWithRobocopyParameter = @{
                         Path = $mockRobocopyArgumentSourcePath
                         DestinationPath = $mockRobocopyArgumentDestinationPath
+                    }
+
+                    { Copy-ItemWithRobocopy @copyItemWithRobocopyParameter } | Should -Not -Throw
+                }
+            }
+            Context 'When Copy-ItemWithRobocopy is called with spaces in paths and finishes successfully it should return the correct exit code' {
+                BeforeEach {
+                    $mockRobocopyExecutableVersion = $mockRobocopyExecutableVersionWithUnbufferedIO
+
+                    Mock -CommandName Get-Command -MockWith $mockGetCommand -Verifiable
+                    Mock -CommandName Start-Process -MockWith $mockStartSqlSetupProcess_Robocopy_WithExitCode -Verifiable
+                }
+
+                AfterEach {
+                    Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+                }
+
+                It 'Should finish successfully with exit code 1' {
+                    $mockStartSqlSetupProcessExitCode = 1
+
+                    $copyItemWithRobocopyParameter = @{
+                        Path = $mockRobocopyArgumentSourcePathWithSpaces
+                        DestinationPath = $mockRobocopyArgumentDestinationPathWithSpaces
+                    }
+
+                    { Copy-ItemWithRobocopy @copyItemWithRobocopyParameter } | Should -Not -Throw
+                   
+                }
+
+                It 'Should finish successfully with exit code 2' {
+                    $mockStartSqlSetupProcessExitCode = 2
+
+                    $copyItemWithRobocopyParameter = @{
+                        Path = $mockRobocopyArgumentSourcePathWithSpaces
+                        DestinationPath = $mockRobocopyArgumentDestinationPathWithSpaces
+                    }
+
+                    { Copy-ItemWithRobocopy @copyItemWithRobocopyParameter } | Should -Not -Throw
+
+                }
+
+                It 'Should finish successfully with exit code 3' {
+                    $mockStartSqlSetupProcessExitCode = 3
+
+                    $copyItemWithRobocopyParameter = @{
+                        Path = $mockRobocopyArgumentSourcePathWithSpaces
+                        DestinationPath = $mockRobocopyArgumentDestinationPathWithSpaces
                     }
 
                     { Copy-ItemWithRobocopy @copyItemWithRobocopyParameter } | Should -Not -Throw

--- a/Tests/Unit/MSFT_SqlSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlSetup.Tests.ps1
@@ -4524,6 +4524,8 @@ try
                 BeforeEach {
                     Mock -CommandName Get-Command -MockWith $mockGetCommand -Verifiable
                     Mock -CommandName Start-Process -MockWith $mockStartSqlSetupProcess_Robocopy -Verifiable
+                    $mockRobocopyArgumentSourcePathQuoted = '"{0}"' -f $mockRobocopyArgumentSourcePath
+                    $mockRobocopyArgumentDestinationPathQuoted = '"{0}"' -f $mockRobocopyArgumentDestinationPath
                 }
 
 
@@ -4531,8 +4533,8 @@ try
                     $mockRobocopyExecutableVersion = $mockRobocopyExecutableVersionWithUnbufferedIO
 
                     $mockStartSqlSetupProcessExpectedArgument =
-                        $mockRobocopyArgumentSourcePath,
-                        $mockRobocopyArgumentDestinationPath,
+                        $mockRobocopyArgumentSourcePathQuoted,
+                        $mockRobocopyArgumentDestinationPathQuoted,
                         $mockRobocopyArgumentCopySubDirectoriesIncludingEmpty,
                         $mockRobocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource,
                         $mockRobocopyArgumentUseUnbufferedIO,
@@ -4553,8 +4555,8 @@ try
                     $mockRobocopyExecutableVersion = $mockRobocopyExecutableVersionWithoutUnbufferedIO
 
                     $mockStartSqlSetupProcessExpectedArgument =
-                        $mockRobocopyArgumentSourcePath,
-                        $mockRobocopyArgumentDestinationPath,
+                        $mockRobocopyArgumentSourcePathQuoted,
+                        $mockRobocopyArgumentDestinationPathQuoted,
                         $mockRobocopyArgumentCopySubDirectoriesIncludingEmpty,
                         $mockRobocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource,
                         '',


### PR DESCRIPTION
Enabling Robocopy to use paths containing spaces (https://github.com/PowerShell/SqlServerDsc/issues/779)

<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please make sure you have read the contributing section
    at https://github.com/PowerShell/SqlServerDsc#contributing.

    Please prefix the PR title with the resource name,
    i.e. 'SqlSetup: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    i.e. 'BREAKING CHANGE: SqlSetup: My short description'.

    You may remove this and the other comments, but please keep the headers
    and the task list.
-->
#### Pull Request (PR) description
    SqlSetup: MSFT_SqlSetup.psm1 enable Robocopy to use paths containing spaces

#### This Pull Request (PR) fixes the following issues
Fixes #779 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your pull request (PR),
    please take the time to run through the below checklist.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [x] Added an entry under the Unreleased section in the CHANGELOG.md? Entry
      should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md?
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help?
- [ ] Comment-based help added/updated?
- [ ] Localization strings added/updated in all localization files as appropriate?
- [ ] Examples appropriately added/updated?
- [x] Unit tests added/updated?
      See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible)?
      See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x ] New/changed code adheres to
      [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)
      and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md)?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/1131)
<!-- Reviewable:end -->
