### PR TITLE
SqlAlwaysOnService: Resolve failing integration test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Changes to SqlAlwaysOnService
   - Integration tests was updated to handle new IPv6 addresses on the AppVeyor
-    build worker [issue #1155](https://github.com/PowerShell/SqlServerDsc/issues/1155))
+    build worker ([issue #1155](https://github.com/PowerShell/SqlServerDsc/issues/1155)).
 
 ## 11.3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Changes to SqlAlwaysOnService
+  - Integration tests was updated to handle new IPv6 addresses on the AppVeyor
+    build worker [issue #1155](https://github.com/PowerShell/SqlServerDsc/issues/1155))
+
 ## 11.3.0.0
 
 - Changes to SqlServerDsc

--- a/Tests/Integration/MSFT_SqlAlwaysOnService.config.ps1
+++ b/Tests/Integration/MSFT_SqlAlwaysOnService.config.ps1
@@ -2,10 +2,12 @@
     Get all adapters with static IP addresses, all of which should be ignored
     when creating the cluster.
 #>
+
 $ignoreAdapterIpAddress = Get-NetAdapter |
     Get-NetIPInterface |
         Where-Object -FilterScript {
-            $_.Dhcp -eq 'Disabled'
+            $_.AddressFamily -eq 'IPv4' `
+            -and $_.Dhcp -eq 'Disabled'
         } | Get-NetIPAddress
 
 $ignoreIpNetwork = @()
@@ -72,7 +74,7 @@ Configuration MSFT_SqlAlwaysOnService_CreateDependencies_Config
         #>
         xDefaultGatewayAddress LoopbackAdapterIPv4DefaultGateway
         {
-            Address      = $Node.LoopbackAdapterGateway
+            Address        = $Node.LoopbackAdapterGateway
             InterfaceAlias = $Node.LoopbackAdapterName
             AddressFamily  = 'IPv4'
         }
@@ -153,7 +155,7 @@ Configuration MSFT_SqlAlwaysOnService_CreateDependencies_Config
                 }
             }
 
-            DependsOn            = @(
+            DependsOn  = @(
                 '[WindowsFeature]AddFeatureFailoverClustering'
                 '[WindowsFeature]AddFeatureFailoverClusteringPowerShellModule'
             )


### PR DESCRIPTION
#### Pull Request (PR) description
- Changes to SqlAlwaysOnService
  - Integration tests was updated to handle new IPv6 addresses on the AppVeyor
    build worker (issue #1155)

#### This Pull Request (PR) fixes the following issues
Fixes #1155

#### Task list
<!--
    To aid community reviewers in reviewing and merging your pull request (PR),
    please take the time to run through the below checklist.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [x] Added an entry under the Unreleased section in the CHANGELOG.md? Entry
      should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md?
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help?
- [ ] Comment-based help added/updated?
- [ ] Localization strings added/updated in all localization files as appropriate?
- [ ] Examples appropriately added/updated?
- [ ] Unit tests added/updated?
      See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible)?
      See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to
      [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)
      and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md)?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/1169)
<!-- Reviewable:end -->
