### PR TITLE
SqlServerNetwork: Refactored to not load assembly from GAC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Changes to SqlAlwaysOnService
   - Integration tests was updated to handle new IPv6 addresses on the AppVeyor
     build worker ([issue #1155](https://github.com/PowerShell/SqlServerDsc/issues/1155)).
+- Changes to SqlServerNetwork
+  - Refactor SqlServerNetwork to not load assembly from GAC ([issue #1151](https://github.com/PowerShell/SqlServerDsc/issues/1151)).
 
 ## 11.3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Changes to SqlServerDsc
   - Updated helper function Restart-SqlService to have to new optional parameters
-    `SkipClusterCheck` and `SkipWaitForOnline`. This was to support more aspectes
+    `SkipClusterCheck` and `SkipWaitForOnline`. This was to support more aspects
     of the resource SqlServerNetwork.
 - Changes to SqlAlwaysOnService
   - Integration tests was updated to handle new IPv6 addresses on the AppVeyor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,19 @@
 
 ## Unreleased
 
+- Changes to SqlServerDsc
+  - Updated helper function Restart-SqlService to have to new optional parameters
+    `SkipClusterCheck` and `SkipWaitForOnline`. This was to support more aspectes
+    of the resource SqlServerNetwork.
 - Changes to SqlAlwaysOnService
   - Integration tests was updated to handle new IPv6 addresses on the AppVeyor
     build worker ([issue #1155](https://github.com/PowerShell/SqlServerDsc/issues/1155)).
 - Changes to SqlServerNetwork
   - Refactor SqlServerNetwork to not load assembly from GAC ([issue #1151](https://github.com/PowerShell/SqlServerDsc/issues/1151)).
+  - The resource now supports restarting the SQL Server service when both
+    enabling and disabling the protocol.
+  - Added integration tests for this resource
+    ([issue #751](https://github.com/PowerShell/SqlServerDsc/issues/751)).
 
 ## 11.3.0.0
 

--- a/Tests/Integration/MSFT_SqlServerNetwork.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlServerNetwork.Integration.Tests.ps1
@@ -1,0 +1,151 @@
+# This is used to make sure the integration test run in the correct order.
+[Microsoft.DscResourceKit.IntegrationTest(OrderNumber = 2)]
+param()
+
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceFriendlyName = 'SqlServerNetwork'
+$script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
+
+if (-not $env:APPVEYOR -eq $true)
+{
+    Write-Warning -Message ('Integration test for {0} will be skipped unless $env:APPVEYOR equals $true' -f $script:DSCResourceName)
+    return
+}
+
+#region HEADER
+# Integration Test Template Version: 1.1.2
+[System.String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))
+}
+
+Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Integration
+
+#endregion
+
+$mockSqlInstallAccountPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
+$mockSqlInstallAccountUserName = "$env:COMPUTERNAME\SqlInstall"
+$mockSqlInstallCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlInstallAccountUserName, $mockSqlInstallAccountPassword
+
+try
+{
+    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
+    . $configFile
+
+    $mockProtocolName = $ConfigurationData.AllNodes.ProtocolName
+    $mockEnabled = $ConfigurationData.AllNodes.Enabled
+    $mockDisabled = $ConfigurationData.AllNodes.Disabled
+    $mockTcpDynamicPort = $ConfigurationData.AllNodes.TcpDynamicPort
+
+    Describe "$($script:DSCResourceName)_Integration" {
+        BeforeAll {
+            $resourceId = "[$($script:DSCResourceFriendlyName)]Integration_Test"
+        }
+
+        $configurationName = "$($script:DSCResourceName)_SetDisabled_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        SqlInstallCredential = $mockSqlInstallCredential
+                        OutputPath           = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData    = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName
+                } | Where-Object -FilterScript {
+                    $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.IsEnabled | Should -Be $mockDisabled
+                $resourceCurrentState.ProtocolName | Should -Be $mockProtocolName
+                $resourceCurrentState.TcpDynamicPort | Should -Be $mockTcpDynamicPort
+            }
+        }
+
+        $configurationName = "$($script:DSCResourceName)_SetEnabled_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        SqlInstallCredential = $mockSqlInstallCredential
+                        OutputPath           = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData    = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName
+                } | Where-Object -FilterScript {
+                    $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.IsEnabled | Should -Be $mockEnabled
+                $resourceCurrentState.ProtocolName | Should -Be $mockProtocolName
+                $resourceCurrentState.TcpDynamicPort | Should -Be $mockTcpDynamicPort
+            }
+        }
+    }
+}
+finally
+{
+    #region FOOTER
+
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+
+    #endregion
+}

--- a/Tests/Integration/MSFT_SqlServerNetwork.config.ps1
+++ b/Tests/Integration/MSFT_SqlServerNetwork.config.ps1
@@ -1,0 +1,70 @@
+$ConfigurationData = @{
+    AllNodes = @(
+        @{
+            NodeName                    = 'localhost'
+            ServerName                  = $env:COMPUTERNAME
+            InstanceName                = 'DSCSQL2016'
+
+            PSDscAllowPlainTextPassword = $true
+
+            ProtocolName                = 'Tcp'
+            Enabled                     = $true
+            Disabled                    = $false
+            TcpDynamicPort              = $true
+            RestartService              = $true
+        }
+    )
+}
+
+Configuration MSFT_SqlServerNetwork_SetDisabled_Config
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SqlInstallCredential
+    )
+
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node localhost {
+        SqlServerNetwork 'Integration_Test'
+        {
+            ServerName           = $Node.ServerName
+            InstanceName         = $Node.InstanceName
+            ProtocolName         = $Node.ProtocolName
+            IsEnabled            = $Node.Disabled
+            TcpDynamicPort       = $Node.TcpDynamicPort
+
+            PsDscRunAsCredential = $SqlInstallCredential
+        }
+    }
+}
+
+Configuration MSFT_SqlServerNetwork_SetEnabled_Config
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SqlInstallCredential
+    )
+
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node localhost {
+        SqlServerNetwork 'Integration_Test'
+        {
+            ServerName           = $Node.ServerName
+            InstanceName         = $Node.InstanceName
+            ProtocolName         = $Node.ProtocolName
+            IsEnabled            = $Node.Enabled
+            TcpDynamicPort       = $Node.TcpDynamicPort
+
+            PsDscRunAsCredential = $SqlInstallCredential
+        }
+    }
+}
+

--- a/Tests/Unit/MSFT_SqlServerNetwork.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerNetwork.Tests.ps1
@@ -90,10 +90,6 @@ try
             $TypeName -eq 'Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer'
         }
 
-        $mockFunction_RegisterSqlWmiManagement = {
-            return [System.AppDomain]::CreateDomain('DummyTestApplicationDomain')
-        }
-
         $mockDefaultParameters = @{
             InstanceName = $mockInstanceName
             ProtocolName = $mockTcpProtocolName
@@ -103,10 +99,7 @@ try
             BeforeEach {
                 $testParameters = $mockDefaultParameters.Clone()
 
-                Mock -CommandName Register-SqlWmiManagement `
-                    -MockWith $mockFunction_RegisterSqlWmiManagement `
-                    -Verifiable
-
+                Mock -CommandName Import-SQLPSModule
                 Mock -CommandName New-Object `
                     -MockWith $mockFunction_NewObject_ManagedComputer `
                     -ParameterFilter $mockFunction_NewObject_ManagedComputer_ParameterFilter -Verifiable
@@ -126,7 +119,6 @@ try
                     $result.TcpDynamicPort | Should -Be $false
                     $result.TcpPort | Should -Be $mockDynamicValue_TcpPort
 
-                    Assert-MockCalled -CommandName Register-SqlWmiManagement -Exactly -Times 1 -Scope It
                     Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
                         -ParameterFilter $mockFunction_NewObject_ManagedComputer_ParameterFilter
                 }
@@ -145,10 +137,7 @@ try
             BeforeEach {
                 $testParameters = $mockDefaultParameters.Clone()
 
-                Mock -CommandName Register-SqlWmiManagement `
-                    -MockWith $mockFunction_RegisterSqlWmiManagement `
-                    -Verifiable
-
+                Mock -CommandName Import-SQLPSModule
                 Mock -CommandName New-Object `
                     -MockWith $mockFunction_NewObject_ManagedComputer `
                     -ParameterFilter $mockFunction_NewObject_ManagedComputer_ParameterFilter -Verifiable
@@ -314,10 +303,7 @@ try
                 $testParameters = $mockDefaultParameters.Clone()
 
                 Mock -CommandName Restart-SqlService -Verifiable
-                Mock -CommandName Register-SqlWmiManagement `
-                    -MockWith $mockFunction_RegisterSqlWmiManagement `
-                    -Verifiable
-
+                Mock -CommandName Import-SQLPSModule
                 Mock -CommandName New-Object `
                     -MockWith $mockFunction_NewObject_ManagedComputer `
                     -ParameterFilter $mockFunction_NewObject_ManagedComputer_ParameterFilter -Verifiable

--- a/en-US/SqlServerDscHelper.strings.psd1
+++ b/en-US/SqlServerDscHelper.strings.psd1
@@ -6,10 +6,6 @@ ConvertFrom-StringData @'
     ConnectedToAnalysisServicesInstance = Connected to Analysis Services instance '{0}'.
     FailedToConnectToAnalysisServicesInstance = Failed to connected to Analysis Services instance '{0}'.
     SqlMajorVersion = SQL major version is {0}.
-    CreatingApplicationDomain = Creating application domain '{0}'.
-    ReusingApplicationDomain = Reusing application domain '{0}'.
-    LoadingAssembly = Loading assembly '{0}'.
-    UnloadingApplicationDomain = Unloading application domain '{0}'.
     SqlServerVersionIsInvalid = Could not get the SQL version for the instance '{0}'.
     PropertyTypeInvalidForDesiredValues = Property 'DesiredValues' must be either a [System.Collections.Hashtable], [CimInstance] or [PSBoundParametersDictionary]. The type detected was {0}.
     PropertyTypeInvalidForValuesToCheck = If 'DesiredValues' is a CimInstance, then property 'ValuesToCheck' must contain a value.

--- a/sv-SE/SqlServerDscHelper.strings.psd1
+++ b/sv-SE/SqlServerDscHelper.strings.psd1
@@ -6,10 +6,6 @@ ConvertFrom-StringData @'
     ConnectedToAnalysisServicesInstance = Ansluten till Analysis Services instans '{0}'.
     FailedToConnectToAnalysisServicesInstance = Misslyckades att ansluta till Analysis Services instans '{0}'.
     SqlMajorVersion = SQL major version är {0}.
-    CreatingApplicationDomain = Skapar applikationsdomän '{0}'.
-    ReusingApplicationDomain = Återanvänder applikationsdomän '{0}'.
-    LoadingAssembly = Laddar samling '{0}'.
-    UnloadingApplicationDomain = Återställer applikationsdomän '{0}'.
     SqlServerVersionIsInvalid = Kunde inte hämta SQL version för instansen '{0}'.
     PropertyTypeInvalidForDesiredValues = Egenskapen 'DesiredValues' måste vara endera en [System.Collections.Hashtable], [CimInstance] eller [PSBoundParametersDictionary]. Den typ som hittades var {0}.
     PropertyTypeInvalidForValuesToCheck = Om 'DesiredValues' är av typ CimInstance, då måste egenskapen 'ValuesToCheck' sättas till ett värde.
@@ -37,7 +33,7 @@ ConvertFrom-StringData @'
     ExecuteQueryWithResultsFailed = Exekvering av fråga med resultat misslyckades mot databas '{0}'.
     ExecuteNonQueryFailed = Exekvering av icke-fråga misslyckades på databas '{0}'.
     AlterAvailabilityGroupReplicaFailed = Misslyckades att ändra Availability Group kopia '{0}'.
-    GetEffectivePermissionForLogin = Hämtar effektiva behörigeter för inloggningen '{0}' på '{1}'.
+    GetEffectivePermissionForLogin = Hämtar effektiva behörigheter för inloggningen '{0}' på '{1}'.
 
     # - NOTE!
     # - Below strings are used by helper functions New-TerminatingError and New-WarningMessage.


### PR DESCRIPTION
#### Pull Request (PR) description
- Changes to SqlServerDsc
  - Updated helper function Restart-SqlService to have to new optional parameters
    `SkipClusterCheck` and `SkipWaitForOnline`. This was to support more aspects
    of the resource SqlServerNetwork.
- Changes to SqlServerNetwork
  - Refactor SqlServerNetwork to not load assembly from GAC (issue #1151).
  - The resource now supports restarting the SQL Server service when both
    enabling and disabling the protocol.
  - Added integration tests for this resource
    (issue #751).

#### This Pull Request (PR) fixes the following issues
Helps with issue #1151
Fixes #1051 (closing this since the issue is around code that has been removed).
Fixes #751 
Fixes #581 (closing this since the issue is around code that has been removed).

#### Task list
<!--
    To aid community reviewers in reviewing and merging your pull request (PR),
    please take the time to run through the below checklist.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [x] Added an entry under the Unreleased section in the CHANGELOG.md? Entry
      should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md?
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help?
- [x] Comment-based help added/updated?
- [x] Localization strings added/updated in all localization files as appropriate?
- [ ] Examples appropriately added/updated?
- [x] Unit tests added/updated?
      See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible)?
      See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to
      [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)
      and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md)?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/1172)
<!-- Reviewable:end -->
