### PR TITLE
SqlServerDsc: Configurations are no longer using PSDscAllowPlainTextPassword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
     - To always import the latest version of 'SqlServer' or 'SQLPS' module, if
       more than one version exist on the target node. It will still prefer to
       use 'SqlServer' module.
+  - Updated all the examples and integration tests to not use
+    `PSDscAllowPlainTextPassword`, so examples using credentials or
+    passwords by default are secure.
 - Changes to SqlAlwaysOnService
   - Integration tests was updated to handle new IPv6 addresses on the AppVeyor
     build worker ([issue #1155](https://github.com/PowerShell/SqlServerDsc/issues/1155)).

--- a/Examples/Resources/SqlAG/1-CreateAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAG/1-CreateAvailabilityGroup.ps1
@@ -6,19 +6,8 @@
 $ConfigurationData = @{
     AllNodes = @(
         @{
-            NodeName                    = '*'
-            InstanceName                = 'MSSQLSERVER'
-
-            <#
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-                This is added so that AppVeyor automatic tests can pass, otherwise
-                the tests will fail on passwords being in plain text and not being
-                encrypted. Because it is not possible to have a certificate in
-                AppVeyor to encrypt the passwords we need to add the parameter
-                'PSDscAllowPlainTextPassword'.
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-            #>
-            PSDscAllowPlainTextPassword = $true
+            NodeName     = '*'
+            InstanceName = 'MSSQLSERVER'
         },
 
         @{

--- a/Examples/Resources/SqlAG/2-RemoveAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAG/2-RemoveAvailabilityGroup.ps1
@@ -6,19 +6,8 @@ This example shows how to ensure that the Availability Group 'TestAG' does not e
 $ConfigurationData = @{
     AllNodes = @(
         @{
-            NodeName                    = '*'
-            InstanceName                = 'MSSQLSERVER'
-
-            <#
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-                This is added so that AppVeyor automatic tests can pass, otherwise
-                the tests will fail on passwords being in plain text and not being
-                encrypted. Because it is not possible to have a certificate in
-                AppVeyor to encrypt the passwords we need to add the parameter
-                'PSDscAllowPlainTextPassword'.
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-            #>
-            PSDscAllowPlainTextPassword = $true
+            NodeName     = '*'
+            InstanceName = 'MSSQLSERVER'
         },
 
         @{

--- a/Examples/Resources/SqlAG/3-CreateAvailabilityGroupDetailed.ps1
+++ b/Examples/Resources/SqlAG/3-CreateAvailabilityGroupDetailed.ps1
@@ -26,17 +26,6 @@ $ConfigurationData = @{
             BasicAvailabilityGroup        = $False
             DatabaseHealthTrigger         = $True
             DtcSupportEnabled             = $True
-
-            <#
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-                This is added so that AppVeyor automatic tests can pass, otherwise
-                the tests will fail on passwords being in plain text and not being
-                encrypted. Because it is not possible to have a certificate in
-                AppVeyor to encrypt the passwords we need to add the parameter
-                'PSDscAllowPlainTextPassword'.
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-            #>
-            PSDscAllowPlainTextPassword   = $true
         },
 
         @{

--- a/Examples/Resources/SqlAGDatabase/1-AddDatabaseToAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAGDatabase/1-AddDatabaseToAvailabilityGroup.ps1
@@ -11,19 +11,9 @@
 $ConfigurationData = @{
     AllNodes = @(
         @{
-            NodeName                    = '*'
-            SQLInstanceName             = 'MSSQLSERVER'
-            AvailabilityGroupName       = 'TestAG'
-            <#
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-                This is added so that AppVeyor automatic tests can pass, otherwise
-                the tests will fail on passwords being in plain text and not being
-                encrypted. Because it is not possible to have a certificate in
-                AppVeyor to encrypt the passwords we need to add the parameter
-                'PSDscAllowPlainTextPassword'.
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-            #>
-            PSDscAllowPlainTextPassword = $true
+            NodeName              = '*'
+            SQLInstanceName       = 'MSSQLSERVER'
+            AvailabilityGroupName = 'TestAG'
         },
 
         @{

--- a/Examples/Resources/SqlAGDatabase/2-RemoveDatabaseFromAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAGDatabase/2-RemoveDatabaseFromAvailabilityGroup.ps1
@@ -6,20 +6,9 @@
 $ConfigurationData = @{
     AllNodes = @(
         @{
-            NodeName                    = '*'
-            SQLInstanceName             = 'MSSQLSERVER'
-            AvailabilityGroupName       = 'TestAG'
-
-            <#
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-                This is added so that AppVeyor automatic tests can pass, otherwise
-                the tests will fail on passwords being in plain text and not being
-                encrypted. Because it is not possible to have a certificate in
-                AppVeyor to encrypt the passwords we need to add the parameter
-                'PSDscAllowPlainTextPassword'.
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-            #>
-            PSDscAllowPlainTextPassword = $true
+            NodeName              = '*'
+            SQLInstanceName       = 'MSSQLSERVER'
+            AvailabilityGroupName = 'TestAG'
         },
 
         @{

--- a/Examples/Resources/SqlAGDatabase/3-MatchDefinedDatabaseInAvailabilityGroup.ps1
+++ b/Examples/Resources/SqlAGDatabase/3-MatchDefinedDatabaseInAvailabilityGroup.ps1
@@ -6,20 +6,9 @@
 $ConfigurationData = @{
     AllNodes = @(
         @{
-            NodeName                    = '*'
-            SQLInstanceName             = 'MSSQLSERVER'
-            AvailabilityGroupName       = 'TestAG'
-
-            <#
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-                This is added so that AppVeyor automatic tests can pass, otherwise
-                the tests will fail on passwords being in plain text and not being
-                encrypted. Because it is not possible to have a certificate in
-                AppVeyor to encrypt the passwords we need to add the parameter
-                'PSDscAllowPlainTextPassword'.
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-            #>
-            PSDscAllowPlainTextPassword = $true
+            NodeName              = '*'
+            SQLInstanceName       = 'MSSQLSERVER'
+            AvailabilityGroupName = 'TestAG'
         },
 
         @{

--- a/Examples/Resources/SqlAGReplica/1-CreateAvailabilityGroupReplica.ps1
+++ b/Examples/Resources/SqlAGReplica/1-CreateAvailabilityGroupReplica.ps1
@@ -11,21 +11,10 @@
 $ConfigurationData = @{
     AllNodes = @(
         @{
-            NodeName                    = '*'
-            SQLInstanceName             = 'MSSQLSERVER'
-            AvailabilityGroupName       = 'TestAG'
-            ProcessOnlyOnActiveNode     = $true
-
-            <#
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-                This is added so that AppVeyor automatic tests can pass, otherwise
-                the tests will fail on passwords being in plain text and not being
-                encrypted. Because it is not possible to have a certificate in
-                AppVeyor to encrypt the passwords we need to add the parameter
-                'PSDscAllowPlainTextPassword'.
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-            #>
-            PSDscAllowPlainTextPassword = $true
+            NodeName                = '*'
+            SQLInstanceName         = 'MSSQLSERVER'
+            AvailabilityGroupName   = 'TestAG'
+            ProcessOnlyOnActiveNode = $true
         },
 
         @{

--- a/Examples/Resources/SqlAGReplica/2-RemoveAvailabilityGroupReplica.ps1
+++ b/Examples/Resources/SqlAGReplica/2-RemoveAvailabilityGroupReplica.ps1
@@ -6,20 +6,9 @@
 $ConfigurationData = @{
     AllNodes = @(
         @{
-            NodeName                    = '*'
-            SQLInstanceName             = 'MSSQLSERVER'
-            AvailabilityGroupName       = 'TestAG'
-
-            <#
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-                This is added so that AppVeyor automatic tests can pass, otherwise
-                the tests will fail on passwords being in plain text and not being
-                encrypted. Because it is not possible to have a certificate in
-                AppVeyor to encrypt the passwords we need to add the parameter
-                'PSDscAllowPlainTextPassword'.
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-            #>
-            PSDscAllowPlainTextPassword = $true
+            NodeName              = '*'
+            SQLInstanceName       = 'MSSQLSERVER'
+            AvailabilityGroupName = 'TestAG'
         },
 
         @{

--- a/Examples/Resources/SqlRS/4-CompleteWithTwoInstances.ps1
+++ b/Examples/Resources/SqlRS/4-CompleteWithTwoInstances.ps1
@@ -14,35 +14,24 @@
 $ConfigurationData = @{
     AllNodes = @(
         @{
-            NodeName                    = 'localhost'
+            NodeName                   = 'localhost'
 
             # This is values used for the Reporting Services instance.
-            InstanceName                = 'RS'
-            Features                    = 'RS'
+            InstanceName               = 'RS'
+            Features                   = 'RS'
 
             # This is values used for the Database Engine instance.
-            DatabaseServerName          = $env:COMPUTERNAME
-            DatabaseServerInstanceName  = 'RSDB'
-            DatabaseServerFeatures      = 'SQLENGINE'
-            DatabaseServerCollation     = 'Finnish_Swedish_CI_AS'
+            DatabaseServerName         = $env:COMPUTERNAME
+            DatabaseServerInstanceName = 'RSDB'
+            DatabaseServerFeatures     = 'SQLENGINE'
+            DatabaseServerCollation    = 'Finnish_Swedish_CI_AS'
 
             # This is values used for both instances.
-            MediaPath                   = 'Z:\Sql2016Media'
-            InstallSharedDir            = 'C:\Program Files\Microsoft SQL Server'
-            InstallSharedWOWDir         = 'C:\Program Files (x86)\Microsoft SQL Server'
-            UpdateEnabled               = 'False'
-            BrowserSvcStartupType       = 'Automatic'
-
-            <#
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-                This is added so that AppVeyor automatic tests can pass, otherwise
-                the tests will fail on passwords being in plain text and not being
-                encrypted. Because it is not possible to have a certificate in
-                AppVeyor to encrypt the passwords we need to add the parameter
-                'PSDscAllowPlainTextPassword'.
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-            #>
-            PSDscAllowPlainTextPassword = $true
+            MediaPath                  = 'Z:\Sql2016Media'
+            InstallSharedDir           = 'C:\Program Files\Microsoft SQL Server'
+            InstallSharedWOWDir        = 'C:\Program Files (x86)\Microsoft SQL Server'
+            UpdateEnabled              = 'False'
+            BrowserSvcStartupType      = 'Automatic'
         }
     )
 }

--- a/Examples/Resources/SqlScript/3-RunScriptCompleteExample.ps1
+++ b/Examples/Resources/SqlScript/3-RunScriptCompleteExample.ps1
@@ -7,22 +7,22 @@
 $ConfigurationData = @{
     AllNodes = @(
         @{
-            NodeName                    = 'localhost'
+            NodeName          = 'localhost'
 
-            ServerName                  = $env:COMPUTERNAME
-            InstanceName                = 'DSCTEST'
+            ServerName        = $env:COMPUTERNAME
+            InstanceName      = 'DSCTEST'
 
-            DatabaseName                = 'ScriptDatabase1'
+            DatabaseName      = 'ScriptDatabase1'
 
-            GetSqlScriptPath            = Join-Path -Path $env:SystemDrive -ChildPath ([System.IO.Path]::GetRandomFileName())
-            SetSqlScriptPath            = Join-Path -Path $env:SystemDrive -ChildPath ([System.IO.Path]::GetRandomFileName())
-            TestSqlScriptPath           = Join-Path -Path $env:SystemDrive -ChildPath ([System.IO.Path]::GetRandomFileName())
+            GetSqlScriptPath  = Join-Path -Path $env:SystemDrive -ChildPath ([System.IO.Path]::GetRandomFileName())
+            SetSqlScriptPath  = Join-Path -Path $env:SystemDrive -ChildPath ([System.IO.Path]::GetRandomFileName())
+            TestSqlScriptPath = Join-Path -Path $env:SystemDrive -ChildPath ([System.IO.Path]::GetRandomFileName())
 
-            GetSqlScript                = @'
+            GetSqlScript      = @'
 SELECT Name FROM sys.databases WHERE Name = '$(DatabaseName)' FOR JSON AUTO
 '@
 
-            TestSqlScript               = @'
+            TestSqlScript     = @'
 if (select count(name) from sys.databases where name = '$(DatabaseName)') = 0
 BEGIN
     RAISERROR ('Did not find database [$(DatabaseName)]', 16, 1)
@@ -33,20 +33,9 @@ BEGIN
 END
 '@
 
-            SetSqlScript                = @'
+            SetSqlScript      = @'
 CREATE DATABASE [$(DatabaseName)]
 '@
-
-            <#
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-                This is added so that AppVeyor automatic tests can pass, otherwise
-                the tests will fail on passwords being in plain text and not being
-                encrypted. Because it is not possible to have a certificate in
-                AppVeyor to encrypt the passwords we need to add the parameter
-                'PSDscAllowPlainTextPassword'.
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-            #>
-            PSDscAllowPlainTextPassword = $true
         }
     )
 }

--- a/Examples/Resources/SqlScriptQuery/3-RunScriptCompleteExample.ps1
+++ b/Examples/Resources/SqlScriptQuery/3-RunScriptCompleteExample.ps1
@@ -26,20 +26,9 @@ BEGIN
 END
 '@
 
-            SetSqlQuery = @'
+            SetSqlQuery  = @'
 CREATE DATABASE [$(DatabaseName)]
 '@
-
-            <#
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-                This is added so that AppVeyor automatic tests can pass, otherwise
-                the tests will fail on passwords being in plain text and not being
-                encrypted. Because it is not possible to have a certificate in
-                AppVeyor to encrypt the passwords we need to add the parameter
-                'PSDscAllowPlainTextPassword'.
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-            #>
-            PSDscAllowPlainTextPassword = $true
         }
     )
 }

--- a/Examples/Resources/SqlServerDatabaseMail/1-EnableDatabaseMail.ps1
+++ b/Examples/Resources/SqlServerDatabaseMail/1-EnableDatabaseMail.ps1
@@ -7,28 +7,17 @@
 $ConfigurationData = @{
     AllNodes = @(
         @{
-            NodeName                    = 'localhost'
-            ServerName                  = $env:COMPUTERNAME
-            InstanceName                = 'DSCSQL2016'
+            NodeName       = 'localhost'
+            ServerName     = $env:COMPUTERNAME
+            InstanceName   = 'DSCSQL2016'
 
-            MailServerName              = 'mail.company.local'
-            AccountName                 = 'MyMail'
-            ProfileName                 = 'MyMailProfile'
-            EmailAddress                = 'NoReply@company.local'
-            Description                 = 'Default mail account and profile.'
-            LoggingLevel                = 'Normal'
-            TcpPort                     = 25
-
-            <#
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-                This is added so that AppVeyor automatic tests can pass, otherwise
-                the tests will fail on passwords being in plain text and not being
-                encrypted. Because it is not possible to have a certificate in
-                AppVeyor to encrypt the passwords we need to add the parameter
-                'PSDscAllowPlainTextPassword'.
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-            #>
-            PSDscAllowPlainTextPassword = $true
+            MailServerName = 'mail.company.local'
+            AccountName    = 'MyMail'
+            ProfileName    = 'MyMailProfile'
+            EmailAddress   = 'NoReply@company.local'
+            Description    = 'Default mail account and profile.'
+            LoggingLevel   = 'Normal'
+            TcpPort        = 25
         }
     )
 }

--- a/Examples/Resources/SqlServerDatabaseMail/2-DisableDatabaseMail.ps1
+++ b/Examples/Resources/SqlServerDatabaseMail/2-DisableDatabaseMail.ps1
@@ -7,28 +7,17 @@
 $ConfigurationData = @{
     AllNodes = @(
         @{
-            NodeName                    = 'localhost'
-            ServerName                  = $env:COMPUTERNAME
-            InstanceName                = 'DSCSQL2016'
+            NodeName       = 'localhost'
+            ServerName     = $env:COMPUTERNAME
+            InstanceName   = 'DSCSQL2016'
 
-            MailServerName              = 'mail.company.local'
-            AccountName                 = 'MyMail'
-            ProfileName                 = 'MyMailProfile'
-            EmailAddress                = 'NoReply@company.local'
-            Description                 = 'Default mail account and profile.'
-            LoggingLevel                = 'Normal'
-            TcpPort                     = 25
-
-            <#
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-                This is added so that AppVeyor automatic tests can pass, otherwise
-                the tests will fail on passwords being in plain text and not being
-                encrypted. Because it is not possible to have a certificate in
-                AppVeyor to encrypt the passwords we need to add the parameter
-                'PSDscAllowPlainTextPassword'.
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-            #>
-            PSDscAllowPlainTextPassword = $true
+            MailServerName = 'mail.company.local'
+            AccountName    = 'MyMail'
+            ProfileName    = 'MyMailProfile'
+            EmailAddress   = 'NoReply@company.local'
+            Description    = 'Default mail account and profile.'
+            LoggingLevel   = 'Normal'
+            TcpPort        = 25
         }
     )
 }

--- a/Examples/Resources/SqlServerEndpointPermission/3-AddConnectPermissionToTwoReplicasEachWithDifferentServiceAccount.ps1
+++ b/Examples/Resources/SqlServerEndpointPermission/3-AddConnectPermissionToTwoReplicasEachWithDifferentServiceAccount.ps1
@@ -7,19 +7,8 @@
 $ConfigurationData = @{
     AllNodes = @(
         @{
-            NodeName                    = '*'
-            SqlInstanceName             = 'MSSQLSERVER'
-
-            <#
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-                This is added so that AppVeyor automatic tests can pass, otherwise
-                the tests will fail on passwords being in plain text and not being
-                encrypted. Because it is not possible to have a certificate in
-                AppVeyor to encrypt the passwords we need to add the parameter
-                'PSDscAllowPlainTextPassword'.
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-            #>
-            PSDscAllowPlainTextPassword = $true
+            NodeName        = '*'
+            SqlInstanceName = 'MSSQLSERVER'
         },
 
         @{

--- a/Examples/Resources/SqlServerEndpointPermission/4-RemoveConnectPermissionForTwoReplicasEachWithDifferentServiceAccount.ps1
+++ b/Examples/Resources/SqlServerEndpointPermission/4-RemoveConnectPermissionForTwoReplicasEachWithDifferentServiceAccount.ps1
@@ -7,19 +7,8 @@
 $ConfigurationData = @{
     AllNodes = @(
         @{
-            NodeName                    = '*'
-            SqlInstanceName             = 'MSSQLSERVER'
-
-            <#
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-                This is added so that AppVeyor automatic tests can pass, otherwise
-                the tests will fail on passwords being in plain text and not being
-                encrypted. Because it is not possible to have a certificate in
-                AppVeyor to encrypt the passwords we need to add the parameter
-                'PSDscAllowPlainTextPassword'.
-                NOTE! THIS IS NOT RECOMMENDED IN PRODUCTION.
-            #>
-            PSDscAllowPlainTextPassword = $true
+            NodeName        = '*'
+            SqlInstanceName = 'MSSQLSERVER'
         },
 
         @{

--- a/Tests/Integration/MSFT_SqlAlwaysOnService.config.ps1
+++ b/Tests/Integration/MSFT_SqlAlwaysOnService.config.ps1
@@ -5,10 +5,10 @@
 
 $ignoreAdapterIpAddress = Get-NetAdapter |
     Get-NetIPInterface |
-        Where-Object -FilterScript {
-            $_.AddressFamily -eq 'IPv4' `
-            -and $_.Dhcp -eq 'Disabled'
-        } | Get-NetIPAddress
+    Where-Object -FilterScript {
+    $_.AddressFamily -eq 'IPv4' `
+        -and $_.Dhcp -eq 'Disabled'
+} | Get-NetIPAddress
 
 $ignoreIpNetwork = @()
 foreach ($adapterIpAddress in $ignoreAdapterIpAddress)
@@ -24,19 +24,19 @@ foreach ($adapterIpAddress in $ignoreAdapterIpAddress)
 $ConfigurationData = @{
     AllNodes = @(
         @{
-            NodeName                    = 'localhost'
-            ComputerName                = $env:COMPUTERNAME
-            InstanceName                = 'DSCSQL2016'
-            RestartTimeout              = 120
+            NodeName                 = 'localhost'
+            ComputerName             = $env:COMPUTERNAME
+            InstanceName             = 'DSCSQL2016'
+            RestartTimeout           = 120
 
-            LoopbackAdapterName         = 'ClusterNetwork'
-            LoopbackAdapterIpAddress    = '192.168.40.10'
-            LoopbackAdapterGateway      = '192.168.40.254'
+            LoopbackAdapterName      = 'ClusterNetwork'
+            LoopbackAdapterIpAddress = '192.168.40.10'
+            LoopbackAdapterGateway   = '192.168.40.254'
 
-            ClusterStaticIpAddress      = '192.168.40.11'
-            IgnoreNetwork               = $ignoreIpNetwork
+            ClusterStaticIpAddress   = '192.168.40.11'
+            IgnoreNetwork            = $ignoreIpNetwork
 
-            PSDscAllowPlainTextPassword = $true
+            CertificateFile          = $env:DscPublicCertificatePath
         }
     )
 }

--- a/Tests/Integration/MSFT_SqlDatabaseDefaultLocation.config.ps1
+++ b/Tests/Integration/MSFT_SqlDatabaseDefaultLocation.config.ps1
@@ -1,16 +1,16 @@
 $ConfigurationData = @{
     AllNodes = @(
         @{
-            NodeName                    = 'localhost'
-            ComputerName                = $env:COMPUTERNAME
-            InstanceName                = 'DSCSQL2016'
-            RestartTimeout              = 120
+            NodeName        = 'localhost'
+            ComputerName    = $env:COMPUTERNAME
+            InstanceName    = 'DSCSQL2016'
+            RestartTimeout  = 120
 
-            PSDscAllowPlainTextPassword = $true
+            DataFilePath    = 'C:\SQLData\'
+            LogFilePath     = 'C:\SQLLog\'
+            BackupFilePath  = 'C:\Backups\'
 
-            DataFilePath                = 'C:\SQLData\'
-            LogFilePath                 = 'C:\SQLLog\'
-            BackupFilePath              = 'C:\Backups\'
+            CertificateFile = $env:DscPublicCertificatePath
         }
     )
 }

--- a/Tests/Integration/MSFT_SqlRS.config.ps1
+++ b/Tests/Integration/MSFT_SqlRS.config.ps1
@@ -5,23 +5,23 @@ $mockIsoMediaDriveLetter = [char](([int][char]$mockLastDrive) + 1)
 $ConfigurationData = @{
     AllNodes = @(
         @{
-            NodeName                    = 'localhost'
+            NodeName             = 'localhost'
 
-            InstanceName                = 'DSCRS2016'
-            Features                    = 'RS'
-            InstallSharedDir            = 'C:\Program Files\Microsoft SQL Server'
-            InstallSharedWOWDir         = 'C:\Program Files (x86)\Microsoft SQL Server'
-            UpdateEnabled               = 'False'
-            SuppressReboot              = $true # Make sure we don't reboot during testing.
-            ForceReboot                 = $false
+            InstanceName         = 'DSCRS2016'
+            Features             = 'RS'
+            InstallSharedDir     = 'C:\Program Files\Microsoft SQL Server'
+            InstallSharedWOWDir  = 'C:\Program Files (x86)\Microsoft SQL Server'
+            UpdateEnabled        = 'False'
+            SuppressReboot       = $true # Make sure we don't reboot during testing.
+            ForceReboot          = $false
 
-            ImagePath                   = "$env:TEMP\SQL2016.iso"
-            DriveLetter                 = $mockIsoMediaDriveLetter
+            ImagePath            = "$env:TEMP\SQL2016.iso"
+            DriveLetter          = $mockIsoMediaDriveLetter
 
-            DatabaseServerName          = $env:COMPUTERNAME
-            DatabaseInstanceName        = 'DSCSQL2016'
+            DatabaseServerName   = $env:COMPUTERNAME
+            DatabaseInstanceName = 'DSCSQL2016'
 
-            PSDscAllowPlainTextPassword = $true
+            CertificateFile      = $env:DscPublicCertificatePath
         }
     )
 }
@@ -197,8 +197,8 @@ Configuration MSFT_SqlRS_StopReportingServicesInstance_Config
     {
         Service ('StopReportingServicesInstance{0}' -f $Node.InstanceName)
         {
-            Name   = ('ReportServer${0}' -f $Node.InstanceName)
-            State  = 'Stopped'
+            Name  = ('ReportServer${0}' -f $Node.InstanceName)
+            State = 'Stopped'
         }
     }
 }

--- a/Tests/Integration/MSFT_SqlScript.config.ps1
+++ b/Tests/Integration/MSFT_SqlScript.config.ps1
@@ -1,23 +1,23 @@
 $ConfigurationData = @{
     AllNodes = @(
         @{
-            NodeName                    = 'localhost'
+            NodeName          = 'localhost'
 
-            ServerName                  = $env:COMPUTERNAME
-            InstanceName                = 'DSCSQL2016'
+            ServerName        = $env:COMPUTERNAME
+            InstanceName      = 'DSCSQL2016'
 
-            Database1Name               = 'ScriptDatabase1'
-            Database2Name               = 'ScriptDatabase2'
+            Database1Name     = 'ScriptDatabase1'
+            Database2Name     = 'ScriptDatabase2'
 
-            GetSqlScriptPath            = Join-Path -Path $env:SystemDrive -ChildPath ([System.IO.Path]::GetRandomFileName())
-            SetSqlScriptPath            = Join-Path -Path $env:SystemDrive -ChildPath ([System.IO.Path]::GetRandomFileName())
-            TestSqlScriptPath           = Join-Path -Path $env:SystemDrive -ChildPath ([System.IO.Path]::GetRandomFileName())
+            GetSqlScriptPath  = Join-Path -Path $env:SystemDrive -ChildPath ([System.IO.Path]::GetRandomFileName())
+            SetSqlScriptPath  = Join-Path -Path $env:SystemDrive -ChildPath ([System.IO.Path]::GetRandomFileName())
+            TestSqlScriptPath = Join-Path -Path $env:SystemDrive -ChildPath ([System.IO.Path]::GetRandomFileName())
 
-            GetSqlScript                = @'
+            GetSqlScript      = @'
 SELECT Name FROM sys.databases WHERE Name = '$(DatabaseName)' FOR JSON AUTO
 '@
 
-            TestSqlScript               = @'
+            TestSqlScript     = @'
 if (select count(name) from sys.databases where name = '$(DatabaseName)') = 0
 BEGIN
     RAISERROR ('Did not find database [$(DatabaseName)]', 16, 1)
@@ -28,11 +28,11 @@ BEGIN
 END
 '@
 
-            SetSqlScript                = @'
+            SetSqlScript      = @'
 CREATE DATABASE [$(DatabaseName)]
 '@
 
-            PSDscAllowPlainTextPassword = $true
+            CertificateFile   = $env:DscPublicCertificatePath
         }
     )
 }

--- a/Tests/Integration/MSFT_SqlScriptQuery.config.ps1
+++ b/Tests/Integration/MSFT_SqlScriptQuery.config.ps1
@@ -1,17 +1,17 @@
 $ConfigurationData = @{
     AllNodes = @(
         @{
-            NodeName      = 'localhost'
-            ServerName    = $env:COMPUTERNAME
-            InstanceName  = 'DSCSQL2016'
-            Database1Name = 'ScriptDatabase3'
-            Database2Name = 'ScriptDatabase4'
+            NodeName        = 'localhost'
+            ServerName      = $env:COMPUTERNAME
+            InstanceName    = 'DSCSQL2016'
+            Database1Name   = 'ScriptDatabase3'
+            Database2Name   = 'ScriptDatabase4'
 
-            GetQuery      = @'
+            GetQuery        = @'
 SELECT Name FROM sys.databases WHERE Name = '$(DatabaseName)' FOR JSON AUTO
 '@
 
-            TestQuery     = @'
+            TestQuery       = @'
 if (select count(name) from sys.databases where name = '$(DatabaseName)') = 0
 BEGIN
     RAISERROR ('Did not find database [$(DatabaseName)]', 16, 1)
@@ -22,11 +22,11 @@ BEGIN
 END
 '@
 
-            SetQuery      = @'
+            SetQuery        = @'
 CREATE DATABASE [$(DatabaseName)]
 '@
 
-            PSDscAllowPlainTextPassword = $true
+            CertificateFile = $env:DscPublicCertificatePath
         }
     )
 }
@@ -78,14 +78,14 @@ Configuration MSFT_SqlScriptQuery_RunSqlScriptQueryAsSqlUser_Config
         SqlScriptQuery 'Integration_Test'
         {
             ServerInstance = Join-Path -Path $Node.ServerName -ChildPath $Node.InstanceName
-            GetQuery     = $Node.GetQuery
-            TestQuery    = $Node.TestQuery
-            SetQuery     = $Node.SetQuery
-            Variable     = @(
+            GetQuery       = $Node.GetQuery
+            TestQuery      = $Node.TestQuery
+            SetQuery       = $Node.SetQuery
+            Variable       = @(
                 ('DatabaseName={0}' -f $Node.Database2Name)
             )
-            QueryTimeout = 30
-            Credential   = $UserCredential
+            QueryTimeout   = 30
+            Credential     = $UserCredential
         }
     }
 }

--- a/Tests/Integration/MSFT_SqlServerDatabaseMail.config.ps1
+++ b/Tests/Integration/MSFT_SqlServerDatabaseMail.config.ps1
@@ -1,19 +1,19 @@
 $ConfigurationData = @{
     AllNodes = @(
         @{
-            NodeName                    = 'localhost'
-            ServerName                  = $env:COMPUTERNAME
-            InstanceName                = 'DSCSQL2016'
+            NodeName        = 'localhost'
+            ServerName      = $env:COMPUTERNAME
+            InstanceName    = 'DSCSQL2016'
 
-            PSDscAllowPlainTextPassword = $true
+            MailServerName  = 'mail.company.local'
+            AccountName     = 'MyMail'
+            ProfileName     = 'MyMailProfile'
+            EmailAddress    = 'NoReply@company.local'
+            Description     = 'Default mail account and profile.'
+            LoggingLevel    = 'Normal'
+            TcpPort         = 25
 
-            MailServerName              = 'mail.company.local'
-            AccountName                 = 'MyMail'
-            ProfileName                 = 'MyMailProfile'
-            EmailAddress                = 'NoReply@company.local'
-            Description                 = 'Default mail account and profile.'
-            LoggingLevel                = 'Normal'
-            TcpPort                     = 25
+            CertificateFile = $env:DscPublicCertificatePath
         }
     )
 }

--- a/Tests/Integration/MSFT_SqlServerLogin.config.ps1
+++ b/Tests/Integration/MSFT_SqlServerLogin.config.ps1
@@ -1,26 +1,26 @@
 $ConfigurationData = @{
     AllNodes = @(
         @{
-            NodeName                    = 'localhost'
-            ServerName                  = $env:COMPUTERNAME
-            InstanceName                = 'DSCSQL2016'
+            NodeName         = 'localhost'
+            ServerName       = $env:COMPUTERNAME
+            InstanceName     = 'DSCSQL2016'
 
-            PSDscAllowPlainTextPassword = $true
+            DscUser1Name     = ('{0}\{1}' -f $env:COMPUTERNAME, 'DscUser1')
+            DscUser1Type     = 'WindowsUser'
 
-            DscUser1Name                = ('{0}\{1}' -f $env:COMPUTERNAME, 'DscUser1')
-            DscUser1Type                = 'WindowsUser'
+            DscUser2Name     = ('{0}\{1}' -f $env:COMPUTERNAME, 'DscUser2')
+            DscUser2Type     = 'WindowsUser'
 
-            DscUser2Name                = ('{0}\{1}' -f $env:COMPUTERNAME, 'DscUser2')
-            DscUser2Type                = 'WindowsUser'
+            DscUser3Name     = ('{0}\{1}' -f $env:COMPUTERNAME, 'DscUser3')
+            DscUser3Type     = 'WindowsUser'
 
-            DscUser3Name                = ('{0}\{1}' -f $env:COMPUTERNAME, 'DscUser3')
-            DscUser3Type                = 'WindowsUser'
+            DscUser4Name     = 'DscUser4'
+            DscUser4Type     = 'SqlLogin'
 
-            DscUser4Name                = 'DscUser4'
-            DscUser4Type                = 'SqlLogin'
+            DscSqlUsers1Name = ('{0}\{1}' -f $env:COMPUTERNAME, 'DscSqlUsers1')
+            DscSqlUsers1Type = 'WindowsGroup'
 
-            DscSqlUsers1Name            = ('{0}\{1}' -f $env:COMPUTERNAME, 'DscSqlUsers1')
-            DscSqlUsers1Type            = 'WindowsGroup'
+            CertificateFile  = $env:DscPublicCertificatePath
         }
     )
 }

--- a/Tests/Integration/MSFT_SqlServerNetwork.config.ps1
+++ b/Tests/Integration/MSFT_SqlServerNetwork.config.ps1
@@ -1,17 +1,17 @@
 $ConfigurationData = @{
     AllNodes = @(
         @{
-            NodeName                    = 'localhost'
-            ServerName                  = $env:COMPUTERNAME
-            InstanceName                = 'DSCSQL2016'
+            NodeName        = 'localhost'
+            ServerName      = $env:COMPUTERNAME
+            InstanceName    = 'DSCSQL2016'
 
-            PSDscAllowPlainTextPassword = $true
+            ProtocolName    = 'Tcp'
+            Enabled         = $true
+            Disabled        = $false
+            TcpDynamicPort  = $true
+            RestartService  = $true
 
-            ProtocolName                = 'Tcp'
-            Enabled                     = $true
-            Disabled                    = $false
-            TcpDynamicPort              = $true
-            RestartService              = $true
+            CertificateFile = $env:DscPublicCertificatePath
         }
     )
 }

--- a/Tests/Integration/MSFT_SqlServerRole.config.ps1
+++ b/Tests/Integration/MSFT_SqlServerRole.config.ps1
@@ -1,19 +1,19 @@
 $ConfigurationData = @{
     AllNodes = @(
         @{
-            NodeName                    = 'localhost'
-            ServerName                  = $env:COMPUTERNAME
-            InstanceName                = 'DSCSQL2016'
+            NodeName        = 'localhost'
+            ServerName      = $env:COMPUTERNAME
+            InstanceName    = 'DSCSQL2016'
 
-            PSDscAllowPlainTextPassword = $true
+            Role1Name       = 'DscServerRole1'
+            Role2Name       = 'DscServerRole2'
+            Role3Name       = 'DscServerRole3'
 
-            Role1Name                   = 'DscServerRole1'
-            Role2Name                   = 'DscServerRole2'
-            Role3Name                   = 'DscServerRole3'
+            User1Name       = '{0}\{1}' -f $env:COMPUTERNAME, 'DscUser1'
+            User2Name       = '{0}\{1}' -f $env:COMPUTERNAME, 'DscUser2'
+            User4Name       = 'DscUser4'
 
-            User1Name                   = '{0}\{1}' -f $env:COMPUTERNAME, 'DscUser1'
-            User2Name                   = '{0}\{1}' -f $env:COMPUTERNAME, 'DscUser2'
-            User4Name                   = 'DscUser4'
+            CertificateFile = $env:DscPublicCertificatePath
         }
     )
 }

--- a/Tests/Integration/MSFT_SqlServiceAccount.config.ps1
+++ b/Tests/Integration/MSFT_SqlServiceAccount.config.ps1
@@ -1,15 +1,15 @@
 $ConfigurationData = @{
     AllNodes = @(
         @{
-            NodeName                    = 'localhost'
-            ServerName                  = $env:COMPUTERNAME
-            DefaultInstanceName         = 'MSSQLSERVER'
-            NamedInstanceName           = 'DSCSQL2016'
+            NodeName                  = 'localhost'
+            ServerName                = $env:COMPUTERNAME
+            DefaultInstanceName       = 'MSSQLSERVER'
+            NamedInstanceName         = 'DSCSQL2016'
 
-            ServiceTypeDatabaseEngine   = 'DatabaseEngine'
-            ServiceTypeSqlServerAgent   = 'SqlServerAgent'
+            ServiceTypeDatabaseEngine = 'DatabaseEngine'
+            ServiceTypeSqlServerAgent = 'SqlServerAgent'
 
-            PSDscAllowPlainTextPassword = $true
+            CertificateFile           = $env:DscPublicCertificatePath
         }
     )
 }
@@ -30,14 +30,14 @@ Configuration MSFT_SqlServiceAccount_CreateDependencies_Config
     {
         Service ('StartSqlServerDefaultInstance{0}' -f $Node.DefaultInstanceName)
         {
-            Name   = $Node.DefaultInstanceName
-            State  = 'Running'
+            Name  = $Node.DefaultInstanceName
+            State = 'Running'
         }
 
         Service ('StartSqlServerAgentForInstance{0}' -f $Node.DefaultInstanceName)
         {
-            Name   = 'SQLSERVERAGENT'
-            State  = 'Running'
+            Name  = 'SQLSERVERAGENT'
+            State = 'Running'
         }
     }
 }
@@ -198,14 +198,14 @@ Configuration MSFT_SqlServiceAccount_StopSqlServerDefaultInstance_Config
     {
         Service ('StartSqlServerAgentForInstance{0}' -f $Node.DefaultInstanceName)
         {
-            Name   = 'SQLSERVERAGENT'
-            State  = 'Stopped'
+            Name  = 'SQLSERVERAGENT'
+            State = 'Stopped'
         }
 
         Service ('StartSqlServerDefaultInstance{0}' -f $Node.DefaultInstanceName)
         {
-            Name   = $Node.DefaultInstanceName
-            State  = 'Stopped'
+            Name  = $Node.DefaultInstanceName
+            State = 'Stopped'
         }
     }
 }

--- a/Tests/Integration/MSFT_SqlSetup.config.ps1
+++ b/Tests/Integration/MSFT_SqlSetup.config.ps1
@@ -45,12 +45,7 @@ $ConfigurationData = @{
             ImagePath                             = "$env:TEMP\SQL2016.iso"
             DriveLetter                           = $mockIsoMediaDriveLetter
 
-            <#
-                We must compile the configuration using plain text since the
-                common integration test framework does not use certificates.
-                This should not be used in production.
-            #>
-            PSDscAllowPlainTextPassword           = $true
+            CertificateFile                       = $env:DscPublicCertificatePath
         }
     )
 }
@@ -247,8 +242,8 @@ Configuration MSFT_SqlSetup_StopMultiAnalysisServicesInstance_Config
 
         Service ('StopMultiAnalysisServicesInstance{0}' -f $Node.DatabaseEngineNamedInstanceName)
         {
-            Name   = ('MSOLAP${0}' -f $Node.DatabaseEngineNamedInstanceName)
-            State  = 'Stopped'
+            Name  = ('MSOLAP${0}' -f $Node.DatabaseEngineNamedInstanceName)
+            State = 'Stopped'
         }
     }
 }
@@ -312,15 +307,15 @@ Configuration MSFT_SqlSetup_StopSqlServerDefaultInstance_Config
     {
         Service ('StopSqlServerAgentForInstance{0}' -f $Node.DatabaseEngineDefaultInstanceName)
         {
-            Name   = 'SQLSERVERAGENT'
-            State  = 'Stopped'
+            Name  = 'SQLSERVERAGENT'
+            State = 'Stopped'
         }
 
 
         Service ('StopSqlServerInstance{0}' -f $Node.DatabaseEngineDefaultInstanceName)
         {
-            Name   = $Node.DatabaseEngineDefaultInstanceName
-            State  = 'Stopped'
+            Name  = $Node.DatabaseEngineDefaultInstanceName
+            State = 'Stopped'
         }
     }
 }
@@ -380,8 +375,8 @@ Configuration MSFT_SqlSetup_StopTabularAnalysisServices_Config
     {
         Service ('StopTabularAnalysisServicesInstance{0}' -f $Node.AnalysisServicesTabularInstanceName)
         {
-            Name   = ('MSOLAP${0}' -f $Node.DatabaseEngineNamedInstanceName)
-            State  = 'Stopped'
+            Name  = ('MSOLAP${0}' -f $Node.DatabaseEngineNamedInstanceName)
+            State = 'Stopped'
         }
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
- Updated all the examples and integration tests to not use `PSDscAllowPlainTextPassword`,
  so examples using credentials or passwords by default are secure.

#### This Pull Request (PR) fixes the following issues
n/a

#### Task list
<!--
    To aid community reviewers in reviewing and merging your pull request (PR),
    please take the time to run through the below checklist.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [x] Added an entry under the Unreleased section in the CHANGELOG.md? Entry
      should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md?
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help?
- [ ] Comment-based help added/updated?
- [ ] Localization strings added/updated in all localization files as appropriate?
- [x] Examples appropriately added/updated?
- [ ] Unit tests added/updated?
      See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible)?
      See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to
      [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)
      and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md)?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/1180)
<!-- Reviewable:end -->
