### PR TITLE
SqlServerDatabaseMail: Corrected and reorganized documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Changes to SqlServerDatabaseMail
+  - DisplayName is now properly treated as display name for the originating email address. ([issue #1200](https://github.com/PowerShell/SqlServerDsc/issue/1200). [Nick Reilingh (@NReilingh)](https://github.com/NReilingh)
+    - DisplayName property now defaults to email address instead of server name.
+    - Minor improvements to documentation.
 - Changes to SqlAGDatabase
   - Corrected reference to "PsDscRunAsAccount" in documentation
     ([issue #1199](https://github.com/PowerShell/SqlServerDsc/issues/1199)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 - Changes to SqlServerDatabaseMail
-  - DisplayName is now properly treated as display name for the originating email address. ([issue #1200](https://github.com/PowerShell/SqlServerDsc/issue/1200). [Nick Reilingh (@NReilingh)](https://github.com/NReilingh)
+  - DisplayName is now properly treated as display name
+    for the originating email address ([issue #1200](https://github.com/PowerShell/SqlServerDsc/issue/1200)). [Nick Reilingh (@NReilingh)](https://github.com/NReilingh)
     - DisplayName property now defaults to email address instead of server name.
     - Minor improvements to documentation.
 - Changes to SqlAGDatabase

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Changes to SqlServerDatabaseMail
   - DisplayName is now properly treated as display name
-    for the originating email address ([issue #1200](https://github.com/PowerShell/SqlServerDsc/issue/1200)). [Nick Reilingh (@NReilingh)](https://github.com/NReilingh)
+    for the originating email address ([issue #1200](https://github.com/PowerShell/SqlServerDsc/issue/1200)).
+    [Nick Reilingh (@NReilingh)](https://github.com/NReilingh)
     - DisplayName property now defaults to email address instead of server name.
     - Minor improvements to documentation.
 - Changes to SqlAGDatabase

--- a/DSCResources/MSFT_SqlServerDatabaseMail/MSFT_SqlServerDatabaseMail.psm1
+++ b/DSCResources/MSFT_SqlServerDatabaseMail/MSFT_SqlServerDatabaseMail.psm1
@@ -209,6 +209,7 @@ function Get-TargetResource
 
     .PARAMETER DisplayName
         The display name of the originating e-mail address.
+        Default value is the same value assigned to the EmailAddress parameter.
 
     .PARAMETER ReplyToAddress
         The e-mail address to which the receiver of e-mails will reply to.

--- a/DSCResources/MSFT_SqlServerDatabaseMail/MSFT_SqlServerDatabaseMail.psm1
+++ b/DSCResources/MSFT_SqlServerDatabaseMail/MSFT_SqlServerDatabaseMail.psm1
@@ -29,7 +29,7 @@ $script:localizedData = Get-LocalizedData -ResourceName 'MSFT_SqlServerDatabaseM
         sent.
 
     .PARAMETER ProfileName
-        The profile name of the Database Mail.
+        The name of the Database Mail profile.
 #>
 function Get-TargetResource
 {
@@ -205,18 +205,17 @@ function Get-TargetResource
         sent.
 
     .PARAMETER ProfileName
-        The profile name of the Database Mail.
+        The name of the Database Mail profile.
 
     .PARAMETER DisplayName
-        The display name of the outgoing mail server. Default value is the same
-        value assigned to parameter MailServerName.
+        The display name of the originating e-mail address.
 
     .PARAMETER ReplyToAddress
         The e-mail address to which the receiver of e-mails will reply to.
         Default value is the same e-mail address assigned to parameter EmailAddress.
 
     .PARAMETER Description
-        The description of the Database Mail.
+        The description for the Database Mail profile and account.
 
     .PARAMETER LoggingLevel
         The logging level that the Database Mail will use. If not specified the
@@ -606,18 +605,17 @@ function Set-TargetResource
         sent.
 
     .PARAMETER ProfileName
-        The profile name of the Database Mail.
+        The name of the Database Mail profile.
 
     .PARAMETER DisplayName
-        The display name of the outgoing mail server. Default value is the same
-        value assigned to parameter MailServerName.
+        The display name of the originating e-mail address.
 
     .PARAMETER ReplyToAddress
         The e-mail address to which the receiver of e-mails will reply to.
         Default value is the same e-mail address assigned to parameter EmailAddress.
 
     .PARAMETER Description
-        The description of the Database Mail.
+        The description for the Database Mail profile and account.
 
     .PARAMETER LoggingLevel
         The logging level that the Database Mail will use. If not specified the

--- a/DSCResources/MSFT_SqlServerDatabaseMail/MSFT_SqlServerDatabaseMail.psm1
+++ b/DSCResources/MSFT_SqlServerDatabaseMail/MSFT_SqlServerDatabaseMail.psm1
@@ -266,7 +266,7 @@ function Set-TargetResource
 
         [Parameter()]
         [System.String]
-        $DisplayName = $MailServerName,
+        $DisplayName = $EmailAddress,
 
         [Parameter()]
         [System.String]
@@ -662,7 +662,7 @@ function Test-TargetResource
 
         [Parameter()]
         [System.String]
-        $DisplayName = $MailServerName,
+        $DisplayName = $EmailAddress,
 
         [Parameter()]
         [System.String]

--- a/DSCResources/MSFT_SqlServerDatabaseMail/MSFT_SqlServerDatabaseMail.schema.mof
+++ b/DSCResources/MSFT_SqlServerDatabaseMail/MSFT_SqlServerDatabaseMail.schema.mof
@@ -8,7 +8,7 @@ class MSFT_SqlServerDatabaseMail : OMI_BaseResource
     [Required, Description("The name of the Database Mail profile.")] String ProfileName;
     [Write, Description("Specifies the desired state of the Database Mail. When set to 'Present', the Database Mail will be created. When set to 'Absent', the Database Mail will be removed. Default value is 'Present'."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("The hostname of the SQL Server to be configured. Defaults to $env:COMPUTERNAME.")] String ServerName;
-    [Write, Description("The display name of the originating email address.")] String DisplayName;
+    [Write, Description("The display name of the originating email address. Default value is the same value assigned to the EmailAddress parameter.")] String DisplayName;
     [Write, Description("The e-mail address to which the receiver of e-mails will reply to. Default value is the same e-mail address assigned to parameter EmailAddress.")] String ReplyToAddress;
     [Write, Description("The description for the Database Mail profile and account.")] String Description;
     [Write, Description("The logging level that the Database Mail will use. If not specified the default logging level is 'Extended'."), ValueMap{"Normal","Extended","Verbose"}, Values{"Normal","Extended","Verbose"}] String LoggingLevel;

--- a/DSCResources/MSFT_SqlServerDatabaseMail/MSFT_SqlServerDatabaseMail.schema.mof
+++ b/DSCResources/MSFT_SqlServerDatabaseMail/MSFT_SqlServerDatabaseMail.schema.mof
@@ -5,12 +5,12 @@ class MSFT_SqlServerDatabaseMail : OMI_BaseResource
     [Key, Description("The name of the SQL instance to be configured.")] String InstanceName;
     [Required, Description("The e-mail address from which mail will originate.")] String EmailAddress;
     [Required, Description("The fully qualified domain name of the mail server name to which e-mail are sent.")] String MailServerName;
-    [Required, Description("The profile name of the Database Mail.")] String ProfileName;
+    [Required, Description("The name of the Database Mail profile.")] String ProfileName;
     [Write, Description("Specifies the desired state of the Database Mail. When set to 'Present', the Database Mail will be created. When set to 'Absent', the Database Mail will be removed. Default value is 'Present'."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("The hostname of the SQL Server to be configured. Defaults to $env:COMPUTERNAME.")] String ServerName;
-    [Write, Description("The display name of the outgoing mail server. Default value is the same value assigned to parameter MailServerName.")] String DisplayName;
+    [Write, Description("The display name of the originating email address.")] String DisplayName;
     [Write, Description("The e-mail address to which the receiver of e-mails will reply to. Default value is the same e-mail address assigned to parameter EmailAddress.")] String ReplyToAddress;
-    [Write, Description("The description of the Database Mail.")] String Description;
+    [Write, Description("The description for the Database Mail profile and account.")] String Description;
     [Write, Description("The logging level that the Database Mail will use. If not specified the default logging level is 'Extended'."), ValueMap{"Normal","Extended","Verbose"}, Values{"Normal","Extended","Verbose"}] String LoggingLevel;
     [Write, Description("The TCP port used for communication. Default value is port 25.")] UInt16 TcpPort;
 };

--- a/README.md
+++ b/README.md
@@ -988,7 +988,7 @@ Resource to manage SQL Server Database Mail.
 * **`[String]` EmailAddress** _(Required)_: The e-mail address from which mail
   will originate.
 * **`[String]` DisplayName** _(Write)_: The display name of the originating e-mail
-  address.
+  address. Default value is the same value assigned to the EmailAddress parameter.
 * **`[String]` ReplyToAddress** _(Write)_: The e-mail address to which the receiver
   of e-mails will reply to. Default value is the same e-mail address assigned to
   parameter EmailAddress.

--- a/README.md
+++ b/README.md
@@ -976,28 +976,29 @@ Resource to manage SQL Server Database Mail.
 #### Parameters
 
 * **`[String]` AccountName** _(Key)_: The name of the Database Mail account.
+* **`[String]` ServerName** _(Write)_: The hostname of the SQL Server to be configured.
+  Defaults to $env:COMPUTERNAME.
 * **`[String]` InstanceName** _(Key)_: Name of the SQL instance to be configured.
-* **`[String]` EmailAddress** _(Required)_: The e-mail address from which mail
-  will originate.
-* **`[String]` MailServerName** _(Required)_: The fully qualified domain name of
-  the mail server name to which e-mail are sent.
-* **`[String]` ProfileName** _(Required)_: The profile name of the Database Mail.
 * **`[String]` Ensure** _(Write)_: Specifies the desired state of the Database Mail.
   When set to 'Present', the Database Mail will be created. When set to 'Absent',
   the Database Mail will be removed. Default value is 'Present'.
-* **`[String]` ServerName** _(Write)_: The hostname of the SQL Server to be configured.
-  Defaults to $env:COMPUTERNAME.
-* **`[String]` DisplayName** _(Write)_: The display name of the outgoing mail server.
-  Default value is the same value assigned to parameter MailServerName.
+* **`[String]` ProfileName** _(Required)_: The name of the Database Mail profile.
+* **`[String]` Description** _(Write)_: The description for the Database Mail
+  profile and account.
+* **`[String]` EmailAddress** _(Required)_: The e-mail address from which mail
+  will originate.
+* **`[String]` DisplayName** _(Write)_: The display name of the originating e-mail
+  address.
 * **`[String]` ReplyToAddress** _(Write)_: The e-mail address to which the receiver
   of e-mails will reply to. Default value is the same e-mail address assigned to
   parameter EmailAddress.
-* **`[String]` Description** _(Write)_: The description of the Database Mail.
+* **`[String]` MailServerName** _(Required)_: The fully qualified domain name of
+  the mail server name to which e-mail are sent.
+* **`[UInt16]` TcpPort** _(Write)_: The TCP port used for communication. Default
+  value is port 25.
 * **`[String]` LoggingLevel** _(Write)_: The logging level that the Database Mail
   will use. If not specified the default logging level is 'Extended'.
   { Normal | *Extended* | Verbose }.
-* **`[UInt16]` TcpPort** _(Write)_: The TCP port used for communication. Default
-  value is port 25.
 
 #### Examples
 


### PR DESCRIPTION
#### Pull Request (PR) description

DisplayName is used for the display name of the email address, for example, the "SQL Server" part of a `From: "SQL Server" <mssql@example.com>` header. This was incorrectly indicated to be a display name for the mail server FQDN.

Also clarified some description and name fields. Tried to catch this in the psm1 file as well as the readme.

I also reordered the parameters listed in the readme for this resource since they seemed a bit random before.

#### Task list

- [x] Added an entry under the Unreleased section in the CHANGELOG.md? Entry
      should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in README.md?
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help?
- [x] Comment-based help added/updated?
- [ ] Localization strings added/updated in all localization files as appropriate?
- [ ] Examples appropriately added/updated?
- [ ] Unit tests added/updated?
      See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible)?
      See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to
      [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)
      and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md)?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/1200)
<!-- Reviewable:end -->
