### PR TITLE
Write-ModuleStubFile: Add Aliases for Functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@
   - Create aliases for cmdlets in the stubbed module which have aliases
     ([issue #1224](https://github.com/PowerShell/SqlServerDsc/issues/1224)).
     [Dan Reist (@randomnote1)](https://github.com/randomnote1)
-  - Use a string builder rather to build the stubs
-  - Fixed formatting issues so that it will work with modules other than SqlServer
+  - Use a string builder to build the function stubs.
+  - Fixed formatting issues for the function to work with modules other than SqlServer.
 
 ## 12.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
     ([issue #1182](https://github.com/PowerShell/SqlServerDsc/issues/1182)).
 - Changes to SqlServerDatabaseMail
   - Minor update to Ensure parameter description in the README.md.
+- Changes to Write-ModuleStubFile.ps1
+  - Create aliases for cmdlets in the stubbed module which have aliases
+    ([issue #1224](https://github.com/PowerShell/SqlServerDsc/issues/1224)).
+    [Dan Reist (@randomnote1)](https://github.com/randomnote1)
+  - Use a string builder rather to build the stubs
+  - Fixed formatting issues so that it will work with modules other than SqlServer
 
 ## 12.0.0.0
 

--- a/Tests/Unit/Stubs/Write-ModuleStubFile.ps1
+++ b/Tests/Unit/Stubs/Write-ModuleStubFile.ps1
@@ -3,67 +3,169 @@
         Generates a file contaning function stubs of all cmdlets from the module given as a parameter.
 
     .PARAMETER ModuleName
-        The name of the module to load and generate stubs from. This module must exist on the computer where this function is ran.
+        The name of the module to load and generate stubs from. This module must exist on the computer where this function is run.
 
     .PARAMETER Path
-         Path to where to write the stubs file. The filename will be generated from the module name.
+         Path to where to write the stubs file. The filename will be generated from the module name. The default path is the working directory.
 
     .EXAMPLE
-        Write-ModuleStubFile -ModuleName 'SqlServer' -Path 'C:\Source'
+        Write-ModuleStubFile -ModuleName OperationsManager
+
+    .EXAMPLE
+        Write-ModuleStubFile -ModuleName SqlServer -Path C:\Source
 #>
-function Write-ModuleStubFile {
+function Write-ModuleStubFile
+{
     param
     (
-        [Parameter( Mandatory )]
-        [System.String] $ModuleName,
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $ModuleName,
 
-        [Parameter( Mandatory )]
-        [System.String] $Path
+        [Parameter()]
+        [System.IO.DirectoryInfo]
+        $Path = ( Get-Location ).Path
     )
 
-    Import-Module $ModuleName -DisableNameChecking -Force
+    # Import the supplied module
+    Import-Module -Name $ModuleName -DisableNameChecking -Force -ErrorAction Stop
 
-    ( ( get-command -Module $ModuleName -CommandType 'Cmdlet' ) | ForEach-Object -Begin {
-        "# Suppressing this rule because these functions are from an external module"
-        "# and are only being used as stubs",
-        "[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '')]"
-        "param()"
-        ""
-    } -Process {
-        $signature = $null
-        $command = $_
+    # Get the module object
+    $module = Get-Module -Name $ModuleName
+
+    # Define the output file name
+    $outFile = Join-Path -Path $Path -ChildPath "$($module.Name )_$($module.Version)_Stubs.psm1"
+
+    # Verify the output file doesn't already exist
+    if ( Test-Path -Path $outFile )
+    {
+        throw "The file '$outFile' already exists."
+    }
+
+    # Define the header of the file
+    $headerStringBuilder = New-Object -TypeName System.Text.StringBuilder
+    [System.Void]$headerStringBuilder.AppendLine('<#')
+    [System.Void]$headerStringBuilder.AppendLine('    .SYNOPSIS')
+    [System.Void]$headerStringBuilder.AppendLine("        Cmdlet stubs for the module $($module.Name).")
+    [System.Void]$headerStringBuilder.AppendLine()
+    [System.Void]$headerStringBuilder.AppendLine('    .DESCRIPTION')
+    [System.Void]$headerStringBuilder.AppendLine("        This module contains the stubs for the cmdlets in the module $($module.Name) version $($module.Version.ToString()).")
+    [System.Void]$headerStringBuilder.AppendLine()
+    [System.Void]$headerStringBuilder.AppendLine('    .NOTES')
+    [System.Void]$headerStringBuilder.AppendLine("        The stubs in this module were generated from the $($MyInvocation.MyCommand) function which is distributed as part of the SqlServerDsc module.")
+    [System.Void]$headerStringBuilder.AppendLine('#>')
+    [System.Void]$headerStringBuilder.AppendLine()
+    [System.Void]$headerStringBuilder.AppendLine('# Suppressing this rule because these functions are from an external module and are only being used as stubs')
+    [System.Void]$headerStringBuilder.AppendLine('[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(''PSAvoidUsingUserNameAndPassWordParams'', '''')]')
+    [System.Void]$headerStringBuilder.AppendLine('param()')
+    $headerStringBuilder.ToString() | Out-File -FilePath $outFile -Encoding utf8 -Append
+
+
+    # Get the cmdlets in the module
+    $cmdlets = Get-Command -Module $ModuleName -CommandType Cmdlet
+
+    foreach ( $cmdlet in $cmdlets )
+    {
+        # Clear the alias variable to ensure unnecessary aliases are not created
+        Remove-Variable -Name alias -ErrorAction SilentlyContinue
+
+        # Create a string builder object to build the functions
+        $functionDefinition = New-Object -TypeName System.Text.StringBuilder
+
+        # Reset the end of definition variable
         $endOfDefinition = $false
-        $metadata = New-Object -TypeName System.Management.Automation.CommandMetaData -ArgumentList $command
+
+        # Get the Cmdlet metadata
+        $metadata = New-Object -TypeName System.Management.Automation.CommandMetaData -ArgumentList $cmdlet
+
+        # Get the definition of the cmdlet
         $definition = [System.Management.Automation.ProxyCommand]::Create($metadata)
-        foreach ($line in $definition -split "`n")
+
+        # Define the beginning of the function
+        [System.Void]$functionDefinition.AppendLine("function $($cmdlet.Name)")
+        [System.Void]$functionDefinition.AppendLine('{')
+
+
+        # Iterate over each line in the cmdlet
+        foreach ( $line in $definition.Split([System.Environment]::NewLine) )
         {
-            $line = $line -replace '\[Microsoft.SqlServer.*.\]', '[object]'
+            # Reset variables which are used to determine what kind of line this is currently on
+            $endOfParameter = $false
+            $formatParam = $false
+
+            # Make the objects generic to better support mocking
+            $line = $line -replace '\[Microsoft.*.\]', '[System.Object]'
             $line = $line -replace 'SupportsShouldProcess=\$true, ', ''
 
-            if( $line.Contains( '})' ) )
+            # Determine if any line modifications need to be made
+            switch -Regex ( $line.TrimEnd() )
             {
-                $line = $line.Remove( $line.Length - 2 )
-                $endOfDefinition = $true
+                # Last line of param section
+                '\}\)$'
+                {
+                    $line = $line -replace '\}\)(\s+)?$','}'
+                    $endOfDefinition = $true
+                }
+
+                # Last line of a parameter definition
+                ',$'
+                {
+                    $endOfParameter = $true
+                }
+
+                # Format Param line
+                'param\($'
+                {
+                    $line = $line -replace 'param\(','param'
+                    $formatParam = $true
+                }
             }
 
-            if( $line.Trim() -ne '' ) {
-                $signature += "    $line"
-            } else {
-                $signature += $line
+            # Write the current line with an indent
+            if ( -not [System.String]::IsNullOrEmpty($line.Trim()) )
+            {
+                [System.Void]$functionDefinition.Append('    ')
+                [System.Void]$functionDefinition.AppendLine($line.TrimEnd())
             }
 
-            if( $endOfDefinition )
+            # Add a blank line after the parameter section
+            if ( $endOfParameter )
             {
-                $signature += "`n   )"
+                [System.Void]$functionDefinition.AppendLine()
+            }
+
+            # Move the right paranthesis at the end of the param section to a new line
+            if ( $endOfDefinition )
+            {
+                [System.Void]$functionDefinition.AppendLine('    )')
                 break
+            }
+
+            # Move the left parenthesis to the next line after the "param" keyword
+            if ( $formatParam )
+            {
+                [System.Void]$functionDefinition.AppendLine('    (')
             }
         }
 
-        "function $($command.Name) {"
-        "$signature"
-        ""
-        "   throw '{0}: StubNotImplemented' -f $`MyInvocation.MyCommand"
-        "}"
-        ""
-    } ) | Out-String | Out-File ( Join-Path -Path $Path -ChildPath "$(( get-module $moduleName -ListAvailable).Name )Stub.psm1") -Encoding utf8 -Append
+        # Build the body of the function
+        [System.Void]$functionDefinition.AppendLine()
+        [System.Void]$functionDefinition.AppendLine('    throw ''{0}: StubNotImplemented'' -f $MyInvocation.MyCommand')
+        [System.Void]$functionDefinition.AppendLine('}')
+        [System.Void]$functionDefinition.AppendLine()
+
+        # Find any aliases which may exist for the cmdlet
+        $alias = Get-Alias -Definition $cmdlet.Name -ErrorAction SilentlyContinue
+
+        # If any aliases exist
+        if ( $alias )
+        {
+            # Create an alias in the stubs
+            [System.Void]$functionDefinition.Append("New-Alias -Name $($alias.DisplayName) -Value $($alias.Definition)")
+            [System.Void]$functionDefinition.AppendLine()
+        }
+
+        # Export the function text to the file
+        $functionDefinition.ToString() | Out-File -FilePath $outFile -Encoding utf8 -Append
+    }
 }

--- a/Tests/Unit/Stubs/Write-ModuleStubFile.ps1
+++ b/Tests/Unit/Stubs/Write-ModuleStubFile.ps1
@@ -42,17 +42,29 @@ function Write-ModuleStubFile
         throw "The file '$outFile' already exists."
     }
 
+    # Define the length of the indent
+    $indent = ' ' * 4
+
     # Define the header of the file
     $headerStringBuilder = New-Object -TypeName System.Text.StringBuilder
     [System.Void]$headerStringBuilder.AppendLine('<#')
-    [System.Void]$headerStringBuilder.AppendLine('    .SYNOPSIS')
-    [System.Void]$headerStringBuilder.AppendLine("        Cmdlet stubs for the module $($module.Name).")
+    [System.Void]$headerStringBuilder.Append($indent)
+    [System.Void]$headerStringBuilder.AppendLine('.SYNOPSIS')
+    [System.Void]$headerStringBuilder.Append($indent)
+    [System.Void]$headerStringBuilder.Append($indent)
+    [System.Void]$headerStringBuilder.AppendLine("Cmdlet stubs for the module $($module.Name).")
     [System.Void]$headerStringBuilder.AppendLine()
-    [System.Void]$headerStringBuilder.AppendLine('    .DESCRIPTION')
-    [System.Void]$headerStringBuilder.AppendLine("        This module contains the stubs for the cmdlets in the module $($module.Name) version $($module.Version.ToString()).")
+    [System.Void]$headerStringBuilder.Append($indent)
+    [System.Void]$headerStringBuilder.AppendLine('.DESCRIPTION')
+    [System.Void]$headerStringBuilder.Append($indent)
+    [System.Void]$headerStringBuilder.Append($indent)
+    [System.Void]$headerStringBuilder.AppendLine("This module contains the stubs for the cmdlets in the module $($module.Name) version $($module.Version.ToString()).")
     [System.Void]$headerStringBuilder.AppendLine()
-    [System.Void]$headerStringBuilder.AppendLine('    .NOTES')
-    [System.Void]$headerStringBuilder.AppendLine("        The stubs in this module were generated from the $($MyInvocation.MyCommand) function which is distributed as part of the SqlServerDsc module.")
+    [System.Void]$headerStringBuilder.Append($indent)
+    [System.Void]$headerStringBuilder.AppendLine('.NOTES')
+    [System.Void]$headerStringBuilder.Append($indent)
+    [System.Void]$headerStringBuilder.Append($indent)
+    [System.Void]$headerStringBuilder.AppendLine("The stubs in this module were generated from the $($MyInvocation.MyCommand) function which is distributed as part of the SqlServerDsc module.")
     [System.Void]$headerStringBuilder.AppendLine('#>')
     [System.Void]$headerStringBuilder.AppendLine()
     [System.Void]$headerStringBuilder.AppendLine('# Suppressing this rule because these functions are from an external module and are only being used as stubs')
@@ -94,7 +106,7 @@ function Write-ModuleStubFile
             $formatParam = $false
 
             # Make the objects generic to better support mocking
-            $line = $line -replace '\[Microsoft.*.\]', '[System.Object]'
+            $line = $line -replace '\[Microsoft.[\d\w\.]+\]', '[System.Object]'
             $line = $line -replace 'SupportsShouldProcess=\$true, ', ''
 
             # Determine if any line modifications need to be made
@@ -124,7 +136,7 @@ function Write-ModuleStubFile
             # Write the current line with an indent
             if ( -not [System.String]::IsNullOrEmpty($line.Trim()) )
             {
-                [System.Void]$functionDefinition.Append('    ')
+                [System.Void]$functionDefinition.Append($indent)
                 [System.Void]$functionDefinition.AppendLine($line.TrimEnd())
             }
 
@@ -137,20 +149,23 @@ function Write-ModuleStubFile
             # Move the right paranthesis at the end of the param section to a new line
             if ( $endOfDefinition )
             {
-                [System.Void]$functionDefinition.AppendLine('    )')
+                [System.Void]$functionDefinition.Append($indent)
+                [System.Void]$functionDefinition.AppendLine(')')
                 break
             }
 
             # Move the left parenthesis to the next line after the "param" keyword
             if ( $formatParam )
             {
-                [System.Void]$functionDefinition.AppendLine('    (')
+                [System.Void]$functionDefinition.Append($indent)
+                [System.Void]$functionDefinition.AppendLine('(')
             }
         }
 
         # Build the body of the function
         [System.Void]$functionDefinition.AppendLine()
-        [System.Void]$functionDefinition.AppendLine('    throw ''{0}: StubNotImplemented'' -f $MyInvocation.MyCommand')
+        [System.Void]$functionDefinition.Append($indent)
+        [System.Void]$functionDefinition.AppendLine('throw ''{0}: StubNotImplemented'' -f $MyInvocation.MyCommand')
         [System.Void]$functionDefinition.AppendLine('}')
         [System.Void]$functionDefinition.AppendLine()
 

--- a/Tests/Unit/Stubs/Write-ModuleStubFile.ps1
+++ b/Tests/Unit/Stubs/Write-ModuleStubFile.ps1
@@ -47,29 +47,29 @@ function Write-ModuleStubFile
 
     # Define the header of the file
     $headerStringBuilder = New-Object -TypeName System.Text.StringBuilder
-    [System.Void] $headerStringBuilder.AppendLine('<#')
-    [System.Void] $headerStringBuilder.Append($indent)
-    [System.Void] $headerStringBuilder.AppendLine('.SYNOPSIS')
-    [System.Void] $headerStringBuilder.Append($indent)
-    [System.Void] $headerStringBuilder.Append($indent)
-    [System.Void] $headerStringBuilder.AppendLine("Cmdlet stubs for the module $($module.Name).")
-    [System.Void] $headerStringBuilder.AppendLine()
-    [System.Void] $headerStringBuilder.Append($indent)
-    [System.Void] $headerStringBuilder.AppendLine('.DESCRIPTION')
-    [System.Void] $headerStringBuilder.Append($indent)
-    [System.Void] $headerStringBuilder.Append($indent)
-    [System.Void] $headerStringBuilder.AppendLine("This module contains the stubs for the cmdlets in the module $($module.Name) version $($module.Version.ToString()).")
-    [System.Void] $headerStringBuilder.AppendLine()
-    [System.Void] $headerStringBuilder.Append($indent)
-    [System.Void] $headerStringBuilder.AppendLine('.NOTES')
-    [System.Void] $headerStringBuilder.Append($indent)
-    [System.Void] $headerStringBuilder.Append($indent)
-    [System.Void] $headerStringBuilder.AppendLine("The stubs in this module were generated from the $($MyInvocation.MyCommand) function which is distributed as part of the SqlServerDsc module.")
-    [System.Void] $headerStringBuilder.AppendLine('#>')
-    [System.Void] $headerStringBuilder.AppendLine()
-    [System.Void] $headerStringBuilder.AppendLine('# Suppressing this rule because these functions are from an external module and are only being used as stubs')
-    [System.Void] $headerStringBuilder.AppendLine('[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(''PSAvoidUsingUserNameAndPassWordParams'', '''')]')
-    [System.Void] $headerStringBuilder.AppendLine('param()')
+    $null = $headerStringBuilder.AppendLine('<#')
+    $null = $headerStringBuilder.Append($indent)
+    $null = $headerStringBuilder.AppendLine('.SYNOPSIS')
+    $null = $headerStringBuilder.Append($indent)
+    $null = $headerStringBuilder.Append($indent)
+    $null = $headerStringBuilder.AppendLine("Cmdlet stubs for the module $($module.Name).")
+    $null = $headerStringBuilder.AppendLine()
+    $null = $headerStringBuilder.Append($indent)
+    $null = $headerStringBuilder.AppendLine('.DESCRIPTION')
+    $null = $headerStringBuilder.Append($indent)
+    $null = $headerStringBuilder.Append($indent)
+    $null = $headerStringBuilder.AppendLine("This module contains the stubs for the cmdlets in the module $($module.Name) version $($module.Version.ToString()).")
+    $null = $headerStringBuilder.AppendLine()
+    $null = $headerStringBuilder.Append($indent)
+    $null = $headerStringBuilder.AppendLine('.NOTES')
+    $null = $headerStringBuilder.Append($indent)
+    $null = $headerStringBuilder.Append($indent)
+    $null = $headerStringBuilder.AppendLine("The stubs in this module were generated from the $($MyInvocation.MyCommand) function which is distributed as part of the SqlServerDsc module.")
+    $null = $headerStringBuilder.AppendLine('#>')
+    $null = $headerStringBuilder.AppendLine()
+    $null = $headerStringBuilder.AppendLine('# Suppressing this rule because these functions are from an external module and are only being used as stubs')
+    $null = $headerStringBuilder.AppendLine('[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(''PSAvoidUsingUserNameAndPassWordParams'', '''')]')
+    $null = $headerStringBuilder.AppendLine('param()')
     $headerStringBuilder.ToString() | Out-File -FilePath $outFile -Encoding utf8 -Append
 
 
@@ -94,8 +94,8 @@ function Write-ModuleStubFile
         $definition = [System.Management.Automation.ProxyCommand]::Create($metadata)
 
         # Define the beginning of the function
-        [System.Void] $functionDefinition.AppendLine("function $($cmdlet.Name)")
-        [System.Void] $functionDefinition.AppendLine('{')
+        $null = $functionDefinition.AppendLine("function $($cmdlet.Name)")
+        $null = $functionDefinition.AppendLine('{')
 
 
         # Iterate over each line in the cmdlet
@@ -137,38 +137,38 @@ function Write-ModuleStubFile
             # Write the current line with an indent
             if ( -not [System.String]::IsNullOrEmpty($line.Trim()) )
             {
-                [System.Void] $functionDefinition.Append($indent)
-                [System.Void] $functionDefinition.AppendLine($line.TrimEnd())
+                $null = $functionDefinition.Append($indent)
+                $null = $functionDefinition.AppendLine($line.TrimEnd())
             }
 
             # Add a blank line after the parameter section
             if ( $endOfParameter )
             {
-                [System.Void] $functionDefinition.AppendLine()
+                $null = $functionDefinition.AppendLine()
             }
 
             # Move the right paranthesis at the end of the param section to a new line
             if ( $endOfDefinition )
             {
-                [System.Void] $functionDefinition.Append($indent)
-                [System.Void] $functionDefinition.AppendLine(')')
+                $null = $functionDefinition.Append($indent)
+                $null = $functionDefinition.AppendLine(')')
                 break
             }
 
             # Move the left parenthesis to the next line after the "param" keyword
             if ( $formatParam )
             {
-                [System.Void] $functionDefinition.Append($indent)
-                [System.Void] $functionDefinition.AppendLine('(')
+                $null = $functionDefinition.Append($indent)
+                $null = $functionDefinition.AppendLine('(')
             }
         }
 
         # Build the body of the function
-        [System.Void] $functionDefinition.AppendLine()
-        [System.Void] $functionDefinition.Append($indent)
-        [System.Void] $functionDefinition.AppendLine('throw ''{0}: StubNotImplemented'' -f $MyInvocation.MyCommand')
-        [System.Void] $functionDefinition.AppendLine('}')
-        [System.Void] $functionDefinition.AppendLine()
+        $null = $functionDefinition.AppendLine()
+        $null = $functionDefinition.Append($indent)
+        $null = $functionDefinition.AppendLine('throw ''{0}: StubNotImplemented'' -f $MyInvocation.MyCommand')
+        $null = $functionDefinition.AppendLine('}')
+        $null = $functionDefinition.AppendLine()
 
         # Find any aliases which may exist for the cmdlet
         $alias = Get-Alias -Definition $cmdlet.Name -ErrorAction SilentlyContinue
@@ -177,8 +177,8 @@ function Write-ModuleStubFile
         if ( $alias )
         {
             # Create an alias in the stubs
-            [System.Void] $functionDefinition.Append("New-Alias -Name $($alias.DisplayName) -Value $($alias.Definition)")
-            [System.Void] $functionDefinition.AppendLine()
+            $null = $functionDefinition.Append("New-Alias -Name $($alias.DisplayName) -Value $($alias.Definition)")
+            $null = $functionDefinition.AppendLine()
         }
 
         # Export the function text to the file

--- a/Tests/Unit/Stubs/Write-ModuleStubFile.ps1
+++ b/Tests/Unit/Stubs/Write-ModuleStubFile.ps1
@@ -106,6 +106,7 @@ function Write-ModuleStubFile
             $formatParam = $false
 
             # Make the objects generic to better support mocking
+            $line = $line -replace '\[Microsoft.[\d\w\.]+\[\]\]', '[System.Object[]]'
             $line = $line -replace '\[Microsoft.[\d\w\.]+\]', '[System.Object]'
             $line = $line -replace 'SupportsShouldProcess=\$true, ', ''
 

--- a/Tests/Unit/Stubs/Write-ModuleStubFile.ps1
+++ b/Tests/Unit/Stubs/Write-ModuleStubFile.ps1
@@ -47,29 +47,29 @@ function Write-ModuleStubFile
 
     # Define the header of the file
     $headerStringBuilder = New-Object -TypeName System.Text.StringBuilder
-    [System.Void]$headerStringBuilder.AppendLine('<#')
-    [System.Void]$headerStringBuilder.Append($indent)
-    [System.Void]$headerStringBuilder.AppendLine('.SYNOPSIS')
-    [System.Void]$headerStringBuilder.Append($indent)
-    [System.Void]$headerStringBuilder.Append($indent)
-    [System.Void]$headerStringBuilder.AppendLine("Cmdlet stubs for the module $($module.Name).")
-    [System.Void]$headerStringBuilder.AppendLine()
-    [System.Void]$headerStringBuilder.Append($indent)
-    [System.Void]$headerStringBuilder.AppendLine('.DESCRIPTION')
-    [System.Void]$headerStringBuilder.Append($indent)
-    [System.Void]$headerStringBuilder.Append($indent)
-    [System.Void]$headerStringBuilder.AppendLine("This module contains the stubs for the cmdlets in the module $($module.Name) version $($module.Version.ToString()).")
-    [System.Void]$headerStringBuilder.AppendLine()
-    [System.Void]$headerStringBuilder.Append($indent)
-    [System.Void]$headerStringBuilder.AppendLine('.NOTES')
-    [System.Void]$headerStringBuilder.Append($indent)
-    [System.Void]$headerStringBuilder.Append($indent)
-    [System.Void]$headerStringBuilder.AppendLine("The stubs in this module were generated from the $($MyInvocation.MyCommand) function which is distributed as part of the SqlServerDsc module.")
-    [System.Void]$headerStringBuilder.AppendLine('#>')
-    [System.Void]$headerStringBuilder.AppendLine()
-    [System.Void]$headerStringBuilder.AppendLine('# Suppressing this rule because these functions are from an external module and are only being used as stubs')
-    [System.Void]$headerStringBuilder.AppendLine('[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(''PSAvoidUsingUserNameAndPassWordParams'', '''')]')
-    [System.Void]$headerStringBuilder.AppendLine('param()')
+    [System.Void] $headerStringBuilder.AppendLine('<#')
+    [System.Void] $headerStringBuilder.Append($indent)
+    [System.Void] $headerStringBuilder.AppendLine('.SYNOPSIS')
+    [System.Void] $headerStringBuilder.Append($indent)
+    [System.Void] $headerStringBuilder.Append($indent)
+    [System.Void] $headerStringBuilder.AppendLine("Cmdlet stubs for the module $($module.Name).")
+    [System.Void] $headerStringBuilder.AppendLine()
+    [System.Void] $headerStringBuilder.Append($indent)
+    [System.Void] $headerStringBuilder.AppendLine('.DESCRIPTION')
+    [System.Void] $headerStringBuilder.Append($indent)
+    [System.Void] $headerStringBuilder.Append($indent)
+    [System.Void] $headerStringBuilder.AppendLine("This module contains the stubs for the cmdlets in the module $($module.Name) version $($module.Version.ToString()).")
+    [System.Void] $headerStringBuilder.AppendLine()
+    [System.Void] $headerStringBuilder.Append($indent)
+    [System.Void] $headerStringBuilder.AppendLine('.NOTES')
+    [System.Void] $headerStringBuilder.Append($indent)
+    [System.Void] $headerStringBuilder.Append($indent)
+    [System.Void] $headerStringBuilder.AppendLine("The stubs in this module were generated from the $($MyInvocation.MyCommand) function which is distributed as part of the SqlServerDsc module.")
+    [System.Void] $headerStringBuilder.AppendLine('#>')
+    [System.Void] $headerStringBuilder.AppendLine()
+    [System.Void] $headerStringBuilder.AppendLine('# Suppressing this rule because these functions are from an external module and are only being used as stubs')
+    [System.Void] $headerStringBuilder.AppendLine('[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(''PSAvoidUsingUserNameAndPassWordParams'', '''')]')
+    [System.Void] $headerStringBuilder.AppendLine('param()')
     $headerStringBuilder.ToString() | Out-File -FilePath $outFile -Encoding utf8 -Append
 
 
@@ -94,8 +94,8 @@ function Write-ModuleStubFile
         $definition = [System.Management.Automation.ProxyCommand]::Create($metadata)
 
         # Define the beginning of the function
-        [System.Void]$functionDefinition.AppendLine("function $($cmdlet.Name)")
-        [System.Void]$functionDefinition.AppendLine('{')
+        [System.Void] $functionDefinition.AppendLine("function $($cmdlet.Name)")
+        [System.Void] $functionDefinition.AppendLine('{')
 
 
         # Iterate over each line in the cmdlet
@@ -137,38 +137,38 @@ function Write-ModuleStubFile
             # Write the current line with an indent
             if ( -not [System.String]::IsNullOrEmpty($line.Trim()) )
             {
-                [System.Void]$functionDefinition.Append($indent)
-                [System.Void]$functionDefinition.AppendLine($line.TrimEnd())
+                [System.Void] $functionDefinition.Append($indent)
+                [System.Void] $functionDefinition.AppendLine($line.TrimEnd())
             }
 
             # Add a blank line after the parameter section
             if ( $endOfParameter )
             {
-                [System.Void]$functionDefinition.AppendLine()
+                [System.Void] $functionDefinition.AppendLine()
             }
 
             # Move the right paranthesis at the end of the param section to a new line
             if ( $endOfDefinition )
             {
-                [System.Void]$functionDefinition.Append($indent)
-                [System.Void]$functionDefinition.AppendLine(')')
+                [System.Void] $functionDefinition.Append($indent)
+                [System.Void] $functionDefinition.AppendLine(')')
                 break
             }
 
             # Move the left parenthesis to the next line after the "param" keyword
             if ( $formatParam )
             {
-                [System.Void]$functionDefinition.Append($indent)
-                [System.Void]$functionDefinition.AppendLine('(')
+                [System.Void] $functionDefinition.Append($indent)
+                [System.Void] $functionDefinition.AppendLine('(')
             }
         }
 
         # Build the body of the function
-        [System.Void]$functionDefinition.AppendLine()
-        [System.Void]$functionDefinition.Append($indent)
-        [System.Void]$functionDefinition.AppendLine('throw ''{0}: StubNotImplemented'' -f $MyInvocation.MyCommand')
-        [System.Void]$functionDefinition.AppendLine('}')
-        [System.Void]$functionDefinition.AppendLine()
+        [System.Void] $functionDefinition.AppendLine()
+        [System.Void] $functionDefinition.Append($indent)
+        [System.Void] $functionDefinition.AppendLine('throw ''{0}: StubNotImplemented'' -f $MyInvocation.MyCommand')
+        [System.Void] $functionDefinition.AppendLine('}')
+        [System.Void] $functionDefinition.AppendLine()
 
         # Find any aliases which may exist for the cmdlet
         $alias = Get-Alias -Definition $cmdlet.Name -ErrorAction SilentlyContinue
@@ -177,8 +177,8 @@ function Write-ModuleStubFile
         if ( $alias )
         {
             # Create an alias in the stubs
-            [System.Void]$functionDefinition.Append("New-Alias -Name $($alias.DisplayName) -Value $($alias.Definition)")
-            [System.Void]$functionDefinition.AppendLine()
+            [System.Void] $functionDefinition.Append("New-Alias -Name $($alias.DisplayName) -Value $($alias.Definition)")
+            [System.Void] $functionDefinition.AppendLine()
         }
 
         # Export the function text to the file


### PR DESCRIPTION
#### Pull Request (PR) description
When a stub file is created for a module, also create the aliases for the cmdlets within the module.

#### This Pull Request (PR) fixes the following issues
Fixes #1224

#### Task list
- [X] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [X] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [X] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [X] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/1225)
<!-- Reviewable:end -->
