### PR TITLE
SqlServiceAccount: Fix unit tests that didn't mock some of the calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## Unreleased
 
 - Changes to SqlServerDsc
-  - Add support for validating the code with the DSC ResourceKit Script Analyzer
-    rules, both in Visual Studio Code and directly using `Invoke-ScriptAnalyzer`.
+  - Add support for validating the code with the DSC ResourceKit
+    Script Analyzer rules, both in Visual Studio Code and directly using
+    `Invoke-ScriptAnalyzer`.
   - Opt-in for common test "Common Tests - Validate Markdown Links".
   - Updated broken links in `\README.md` and in `\Examples\README.md`
   - Opt-in for common test 'Common Tests - Relative Path Length'.
@@ -32,12 +33,18 @@
     ([issue #1224](https://github.com/PowerShell/SqlServerDsc/issues/1224)).
     [Dan Reist (@randomnote1)](https://github.com/randomnote1)
   - Use a string builder to build the function stubs.
-  - Fixed formatting issues for the function to work with modules other than SqlServer.
+  - Fixed formatting issues for the function to work with modules other
+    than SqlServer.
 - New DSC resource SqlServerSecureConnection
-  - New resource to configure a SQL Server instance for encrypted SQL connections.
+  - New resource to configure a SQL Server instance for encrypted SQL
+    connections.
 - Changes to SqlAlwaysOnService
   - Updated integration tests to use NetworkingDsc
     ([issue #1129](https://github.com/PowerShell/SqlServerDsc/issues/1129)).
+- Changes to SqlServiceAccount
+  - Fix unit tests that didn't mock some of the calls. It no longer fail
+    when a SQL Server installation is not present on the node running the
+    unit test ([issue #983](https://github.com/PowerShell/SqlServerDsc/issues/983)).
 
 ## 12.0.0.0
 


### PR DESCRIPTION
#### Pull Request (PR) description
- Changes to SqlServiceAccount
  - Fix unit tests that didn't mock some of the calls. It no longer fail
    when a SQL Server installation is not present on the node running the
    unit test (issue #983).

#### This Pull Request (PR) fixes the following issues
- Fixes #983 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/1235)
<!-- Reviewable:end -->
