### PR TITLE
SqlAGDatabase: Fix impersonate permission test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@
   - Fix unit tests that didn't mock some of the calls. It no longer fail
     when a SQL Server installation is not present on the node running the
     unit test ([issue #983](https://github.com/PowerShell/SqlServerDsc/issues/983)).
+- Changes to SqlAGDatabase
+  - Fix MatchDatabaseOwner to check for CONTROL SERVER and IMPERSONATE
+    LOGIN permission in addition to IMPERSONATE ANY LOGIN.
+  - Fix MatchDatabaseOwner help text.
 
 ## 12.0.0.0
 

--- a/DSCResources/MSFT_SqlAGDatabase/MSFT_SqlAGDatabase.psm1
+++ b/DSCResources/MSFT_SqlAGDatabase/MSFT_SqlAGDatabase.psm1
@@ -246,7 +246,7 @@ function Set-TargetResource
                     $currentAvailabilityGroupReplicaServerObject = Connect-SQL -SQLServer $availabilityGroupReplica.Name
                     $impersonatePermissionsStatus.Add(
                         $availabilityGroupReplica.Name,
-                        ( Test-ImpersonatePermissions -ServerObject $currentAvailabilityGroupReplicaServerObject -LoginName $databaseObject.Owner )
+                        ( Test-ImpersonatePermissions -ServerObject $currentAvailabilityGroupReplicaServerObject -Securable $databaseObject.Owner )
                     )
                 }
 

--- a/SqlServerDscHelper.psm1
+++ b/SqlServerDscHelper.psm1
@@ -1249,8 +1249,8 @@ function Get-PrimaryReplicaServerObject
     .PARAMETER ServerObject
         The server object on which to perform the test.
 
-    .PARAMETER LoginName
-        If set then this specific login is also checked for the specific permission.
+    .PARAMETER Securable
+        If set then impersonate permission on tihs specific securable (login) is also checked.
 
 #>
 function Test-ImpersonatePermissions
@@ -1261,7 +1261,7 @@ function Test-ImpersonatePermissions
         [Microsoft.SqlServer.Management.Smo.Server]
         $ServerObject,
 
-        [System.String] $LoginName
+        [System.String] $Securable
     )
 
     $impersonatePermissionsPresent = $false
@@ -1287,7 +1287,7 @@ function Test-ImpersonatePermissions
         $impersonatePermissionsPresent = Test-LoginEffectivePermissions @testLoginEffectivePermissionsParams
     }
 
-    if ( -not $impersonatePermissionsPresent -and -not [System.String]::IsNullOrEmpty($LoginName) ) {
+    if ( -not $impersonatePermissionsPresent -and -not [System.String]::IsNullOrEmpty($Securable) ) {
         # Check for login-specific impersonation permissions
         $testLoginEffectivePermissionsParams = @{
             SQLServer       = $ServerObject.ComputerNamePhysicalNetBIOS
@@ -1295,7 +1295,7 @@ function Test-ImpersonatePermissions
             LoginName       = $ServerObject.ConnectionContext.TrueLogin
             Permissions     = @('IMPERSONATE')
             SecurableClass  = 'LOGIN'
-            Securable       = $LoginName
+            Securable       = $Securable
         }
         $impersonatePermissionsPresent = Test-LoginEffectivePermissions @testLoginEffectivePermissionsParams
     }

--- a/Tests/Unit/MSFT_SqlAGDatabase.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAGDatabase.Tests.ps1
@@ -76,6 +76,8 @@ try
 
         #region mock names
 
+            $mockTrueLogin = 'Login1'
+            $mockDatabaseOwner = 'DatabaseOwner1'
             $mockServerObjectDomainInstanceName = 'Server1'
             $mockPrimaryServerObjectDomainInstanceName = 'Server2'
             $mockAvailabilityGroupObjectName = 'AvailabilityGroup1'
@@ -235,8 +237,6 @@ try
 
         #region Database Mocks
 
-            $mockDatabaseOwner = 'DatabaseOwner1'
-
             # The databases found on the instance
             $mockPresentDatabaseNames = @(
                 'DB1'
@@ -312,6 +312,9 @@ try
             $mockServerObject.AvailabilityGroups.Add($mockAvailabilityGroupObject.Clone())
             $mockServerObject.AvailabilityGroups.Add($mockAvailabilityGroupWithoutDatabasesObject.Clone())
             $mockServerObject.AvailabilityGroups.Add($mockAvailabilityGroupObjectWithPrimaryReplicaOnAnotherServer.Clone())
+            $mockServerObject.ComputerNamePhysicalNetBIOS = $mockServerObjectDomainInstanceName
+            $mockServerObject.ConnectionContext = New-Object -TypeName Microsoft.SqlServer.Management.Smo.ConnectionContext
+            $mockServerObject.ConnectionContext.TrueLogin = $mockTrueLogin
             $mockServerObject.Databases = $mockDatabaseObjects
             $mockServerObject.DomainInstanceName = $mockServerObjectDomainInstanceName
             $mockServerObject.NetName = $mockServerObjectDomainInstanceName
@@ -325,6 +328,9 @@ try
             $mockServer2Object.AvailabilityGroups.Add($mockAvailabilityGroupObject.Clone())
             $mockServer2Object.AvailabilityGroups.Add($mockAvailabilityGroupWithoutDatabasesObject.Clone())
             $mockServer2Object.AvailabilityGroups.Add($mockAvailabilityGroupObjectWithPrimaryReplicaOnAnotherServer.Clone())
+            $mockServer2Object.ComputerNamePhysicalNetBIOS = $mockPrimaryServerObjectDomainInstanceName
+            $mockServer2Object.ConnectionContext = New-Object -TypeName Microsoft.SqlServer.Management.Smo.ConnectionContext
+            $mockServer2Object.ConnectionContext.TrueLogin = $mockTrueLogin
             $mockServer2Object.Databases = $mockDatabaseObjects
             $mockServer2Object.DomainInstanceName = $mockPrimaryServerObjectDomainInstanceName
             $mockServer2Object.NetName = $mockPrimaryServerObjectDomainInstanceName

--- a/Tests/Unit/MSFT_SqlAGDatabase.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAGDatabase.Tests.ps1
@@ -235,6 +235,8 @@ try
 
         #region Database Mocks
 
+            $mockDatabaseOwner = 'DatabaseOwner1'
+
             # The databases found on the instance
             $mockPresentDatabaseNames = @(
                 'DB1'
@@ -272,6 +274,7 @@ try
                 $newDatabaseObject.LogFiles = @{
                     FileName = ( [IO.Path]::Combine( $mockLogFilePath, "$($mockPresentDatabaseName).ldf" ) )
                 }
+                $newDatabaseObject.Owner = $mockDatabaseOwner
 
                 # Add the database object to the database collection
                 $mockDatabaseObjects.Add($newDatabaseObject)
@@ -292,6 +295,7 @@ try
                 $newDatabaseObject.LogFiles = @{
                     FileName = ( [IO.Path]::Combine( $mockLogFilePathIncorrect, "$($mockPresentDatabaseName).ldf" ) )
                 }
+                $newDatabaseObject.Owner = $mockDatabaseOwner
 
                 # Add the database object to the database collection
                 $mockDatabaseObjectsWithIncorrectFileNames.Add($newDatabaseObject)

--- a/Tests/Unit/SqlServerDSCHelper.Tests.ps1
+++ b/Tests/Unit/SqlServerDSCHelper.Tests.ps1
@@ -1255,18 +1255,24 @@ InModuleScope $script:moduleName {
                 $mockInvokeQueryImpersonatePermissionsSet = $mockImpersonateAnyLoginPermissionsPresent.Clone()
 
                 Test-ImpersonatePermissions -ServerObject $mockServerObject | Should -Be $true
+                # It's called once because it short-circuits with the IMPERSONATE ANY LOGIN persmission is present
+                Assert-MockCalled -CommandName Invoke-Query -Exactly -Times 1 -Scope It
             }
 
             It 'Should return true when the control server permission is present'{
                 $mockInvokeQueryImpersonatePermissionsSet = $mockControlServerPermissionsPresent.Clone()
 
                 Test-ImpersonatePermissions -ServerObject $mockServerObject | Should -Be $true
+                # It's called twice, once for IMPERSONATE ANY LOGIN and again for CONTROL SERVER
+                Assert-MockCalled -CommandName Invoke-Query -Exactly -Times 2 -Scope It
             }
 
             It 'Should return true when the impersonate login permission is present'{
                 $mockInvokeQueryImpersonatePermissionsSet = $mockImpersonateLoginPermissionsPresent.Clone()
 
-                Test-ImpersonatePermissions -ServerObject $mockServerObject -LoginName 'SomeLogin' | Should -Be $true
+                Test-ImpersonatePermissions -ServerObject $mockServerObject -Securable 'DatabaseOwner1' | Should -Be $true
+                # It's called three times, IMPERSONATE ANY, CONTROL SERVER, and then a specific IMPERSONATE LOGIN
+                Assert-MockCalled -CommandName Invoke-Query -Exactly -Times 3 -Scope It
             }
         }
 


### PR DESCRIPTION
#### Pull Request (PR) description
When adding a database to an AG using SqlAGDatabase and the MatchDatabaseOwner switch, it checks for an IMPERSONATE ANY LOGIN permission.

That permission doesn't exist < SQL 2014. There are two alternatives:
- CONTROL SERVER (also granted as part of the sysadmin server role) permission
- IMPERSONATE <LoginName> permission

This change adds those two checks. It also fixes the help text that said MatchDatabaseOwner is true by default, when it was always false by default.

#### This Pull Request (PR) fixes the following issues
- Fixes #1237 

#### Task list
- [X] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [X] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/1239)
<!-- Reviewable:end -->
