### PR TITLE
SqlServerLogin: Addresses issue #1096 - doesn't check properties if login is not present on server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@
   - Fix unit tests that didn't mock some of the calls. It no longer fail
     when a SQL Server installation is not present on the node running the
     unit test ([issue #983](https://github.com/PowerShell/SqlServerDsc/issues/983)).
+- Change to SqlServerLogin so it doesn't check properties for absent logins.
+  - Fix for ([issue #1096](https://github.com/PowerShell/SqlServerDsc/issues/1096))
 
 ## 12.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
     step to make sure the are no residual changes left from a previous SQL
     Server install on the Build Worker done by the AppVeyor Team
     ([issue #1260](https://github.com/PowerShell/SqlServerDsc/issues/1260)).
+- Change to SqlServerLogin so it doesn't check properties for absent logins.
+  - Fix for ([issue #1096](https://github.com/PowerShell/SqlServerDsc/issues/1096))
 
 ## 12.1.0.0
 
@@ -62,8 +64,6 @@
   - Fix unit tests that didn't mock some of the calls. It no longer fail
     when a SQL Server installation is not present on the node running the
     unit test ([issue #983](https://github.com/PowerShell/SqlServerDsc/issues/983)).
-- Change to SqlServerLogin so it doesn't check properties for absent logins.
-  - Fix for ([issue #1096](https://github.com/PowerShell/SqlServerDsc/issues/1096))
 
 ## 12.0.0.0
 

--- a/DSCResources/MSFT_SqlServerLogin/MSFT_SqlServerLogin.psm1
+++ b/DSCResources/MSFT_SqlServerLogin/MSFT_SqlServerLogin.psm1
@@ -381,7 +381,7 @@ function Test-TargetResource
         $testPassed = $false
     }
 
-    if ( $Ensure -eq 'Present' )
+    if ( $Ensure -eq 'Present' -and $($loginInfo.Ensure) -ne 'Absent' )
     {
         if ( $LoginType -ne $loginInfo.LoginType )
         {

--- a/DSCResources/MSFT_SqlServerLogin/MSFT_SqlServerLogin.psm1
+++ b/DSCResources/MSFT_SqlServerLogin/MSFT_SqlServerLogin.psm1
@@ -381,7 +381,7 @@ function Test-TargetResource
         $testPassed = $false
     }
 
-    if ( $Ensure -eq 'Present' -and $($loginInfo.Ensure) -ne 'Absent' )
+    if ( $Ensure -eq 'Present' -and $($loginInfo.Ensure) -eq 'Present' )
     {
         if ( $LoginType -ne $loginInfo.LoginType )
         {

--- a/Tests/Unit/MSFT_SqlServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerLogin.Tests.ps1
@@ -385,6 +385,17 @@ try
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 }
 
+                It 'Should not be checking login properties when Windows user is Absent' {
+                    Mock -CommandName New-VerboseMessage -ParameterFilter {$message.contains('rather than WindowsUser')}
+
+                    $testTargetResource_WindowsUserAbsent_EnsurePresent = $testTargetResource_WindowsUserAbsent.Clone()
+                    $testTargetResource_WindowsUserAbsent_EnsurePresent.Add( 'Ensure', 'Present' )
+
+                    ( Test-TargetResource @testTargetResource_WindowsUserAbsent_EnsurePresent ) | Should -Be $false
+
+                    Assert-MockCalled -CommandName New-VerboseMessage -Scope It -Times 0 -Exactly
+                }
+
                 It 'Should return $false when the specified Windows group is Absent' {
                     $testTargetResource_WindowsGroupAbsent_EnsurePresent = $testTargetResource_WindowsGroupAbsent.Clone()
                     $testTargetResource_WindowsGroupAbsent_EnsurePresent.Add( 'Ensure', 'Present' )
@@ -394,6 +405,17 @@ try
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 }
 
+                It 'Should not be checking login properties when Windows group is Absent' {
+                    Mock -CommandName New-VerboseMessage -ParameterFilter {$message.contains('rather than WindowsGroup')}
+
+                    $testTargetResource_WindowsGroupAbsent_EnsurePresent = $testTargetResource_WindowsGroupAbsent.Clone()
+                    $testTargetResource_WindowsGroupAbsent_EnsurePresent.Add( 'Ensure', 'Present' )
+
+                    ( Test-TargetResource @testTargetResource_WindowsGroupAbsent_EnsurePresent ) | Should -Be $false
+
+                    Assert-MockCalled -CommandName New-VerboseMessage -Scope It -Times 0 -Exactly
+                }
+
                 It 'Should return $false when the specified SQL Login is Absent' {
                     $testTargetResource_SqlLoginAbsent_EnsurePresent = $testTargetResource_SqlLoginAbsent.Clone()
                     $testTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure', 'Present' )
@@ -401,6 +423,17 @@ try
                     ( Test-TargetResource @testTargetResource_SqlLoginAbsent_EnsurePresent ) | Should -Be $false
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                }
+
+                It 'Should not be checking login properties when SQL Login is Absent' {
+                    Mock -CommandName New-VerboseMessage -ParameterFilter {$message.contains('rather than SqlLogin')}
+
+                    $testTargetResource_SqlLoginAbsent_EnsurePresent = $testTargetResource_SqlLoginAbsent.Clone()
+                    $testTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure', 'Present' )
+
+                    ( Test-TargetResource @testTargetResource_SqlLoginAbsent_EnsurePresent ) | Should -Be $false
+
+                    Assert-MockCalled -CommandName New-VerboseMessage -Scope It -Times 0 -Exactly
                 }
 
                 It 'Should return $true when the specified Windows user is Present' {


### PR DESCRIPTION
#### Pull Request (PR) description
Addresses issue #1096 where when a login doesn't exist there are null values in the verbose output from the test function by skipping that output if the login is absent and expected to be present.

#### This Pull Request (PR) fixes the following issues
Fixes #1096 

#### Task list
- [X] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [X] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/1240)
<!-- Reviewable:end -->
