### PR TITLE
SqlServerEndpoind - Add parameter "Owner"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,62 @@
 ## Unreleased
 
 - Changes to SqlServerDsc
+  - Reverting the change that was made as part of the
+    [issue #1260](https://github.com/PowerShell/SqlServerDsc/issues/1260)
+    in the previous release, as it only mitigated the issue, it did not
+    solve the issue.
+  - Removed the container testing since that broke the integration tests,
+    possible due to using excessive amount of memory on the AppVeyor build
+    worker. This will make the unit tests to take a bit longer to run.
+    ([issue #1260](https://github.com/PowerShell/SqlServerDsc/issues/1260)).
+  - The unit tests and the integration tests are now run in two separate
+    build workers in AppVeyor. One build worker runs the integration tests,
+    while a second build worker runs the unit tests. The build workers runs
+    in parallel on paid accounts, but sequentially on free accounts.
+    ([issue #1260](https://github.com/PowerShell/SqlServerDsc/issues/1260)).
+  - Clean up error handling in some of the integration tests that was
+    part of a workaround for a bug in Pester. The bug is resolved, and
+    the error handling is not again built into Pester.
+- Changes to SqlServiceAccount
+  - Fixed Get-ServiceObject when searching for Integration Services service.
+    Unlike the rest of SQL Server services, the Integration Services service
+    cannot be instanced, however you can have multiple versions installed.
+    Get-Service object would return the correct service name that you
+    are looking for, but it appends the version number at the end. Added
+    parameter VersionNumber so the search would return the correct
+    service name.
+  - Added code to allow for using Managed Service Accounts.
+- Changes to SqlServerLogin
+  - Fixed issue in Test-TargetResource to valid password on disabled accounts.
+    ([issue #915](https://github.com/PowerShell/SqlServerDsc/issues/915)).
+- Changes to SqlSetup
+  - Updated the integration test to stop the named instance while installing
+    the other instances to mitigate
+    [issue #1260](https://github.com/PowerShell/SqlServerDsc/issues/1260).
+- Changes to SqlServerEndpoint
+  - Add the optional parameter Owner. The default owner remains the login used for 
+  the creation of the endpoint
+    ([issue #1251](https://github.com/PowerShell/SqlServerDsc/issues/1251).
+    [Maxime Daniou (@mdaniou)](https://github.com/mdaniou)
+
+## 12.2.0.0
+
+- Changes to SqlServerDsc
+  - During testing in AppVeyor the Build Worker is restarted in the install
+    step to make sure the are no residual changes left from a previous SQL
+    Server install on the Build Worker done by the AppVeyor Team
+    ([issue #1260](https://github.com/PowerShell/SqlServerDsc/issues/1260)).
+  - Code cleanup: Change parameter names of Connect-SQL to align with resources.
+  - Updated README.md in the Examples folder.
+    - Added a link to the new xADObjectPermissionEntry examples in
+      ActiveDirectory, fixed a broken link and a typo.
+      [Adam Rush (@adamrushuk)](https://github.com/adamrushuk)
+- Change to SqlServerLogin so it doesn't check properties for absent logins.
+  - Fix for ([issue #1096](https://github.com/PowerShell/SqlServerDsc/issues/1096))
+
+## 12.1.0.0
+
+- Changes to SqlServerDsc
   - Add support for validating the code with the DSC ResourceKit
     Script Analyzer rules, both in Visual Studio Code and directly using
     `Invoke-ScriptAnalyzer`.

--- a/DSCResources/MSFT_SqlServerEndpoint/MSFT_SqlServerEndpoint.psm1
+++ b/DSCResources/MSFT_SqlServerEndpoint/MSFT_SqlServerEndpoint.psm1
@@ -40,9 +40,10 @@ function Get-TargetResource
         EndpointName = ''
         Port         = ''
         IpAddress    = ''
+        Owner        = ''
     }
 
-    $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
     if ($sqlServerObject)
     {
         Write-Verbose -Message ('Connected to {0}\{1}' -f $ServerName, $InstanceName)
@@ -61,6 +62,7 @@ function Get-TargetResource
             $getTargetResourceReturnValues.EndpointName = $endpointObject.Name
             $getTargetResourceReturnValues.Port = $endpointObject.Protocol.Tcp.ListenerPort
             $getTargetResourceReturnValues.IpAddress = $endpointObject.Protocol.Tcp.ListenerIPAddress
+            $getTargetResourceReturnValues.Owner = $endpointObject.Owner
         }
         else
         {
@@ -68,6 +70,7 @@ function Get-TargetResource
             $getTargetResourceReturnValues.EndpointName = ''
             $getTargetResourceReturnValues.Port = ''
             $getTargetResourceReturnValues.IpAddress = ''
+            $getTargetResourceReturnValues.Owner = ''
         }
     }
     else
@@ -101,6 +104,9 @@ function Get-TargetResource
 
     .PARAMETER IpAddress
         The network IP address the endpoint is listening on. Defaults to '0.0.0.0' which means listen on any valid IP address.
+
+    .PARAMETER Owner
+        The owner of the endpoint. Default is the login used for the creation.
 #>
 function Set-TargetResource
 {
@@ -130,12 +136,16 @@ function Set-TargetResource
 
         [Parameter()]
         [System.String]
-        $IpAddress = '0.0.0.0'
+        $IpAddress = '0.0.0.0',
+
+        [Parameter()]
+        [System.String]
+        $Owner
     )
 
     $getTargetResourceResult = Get-TargetResource -EndpointName $EndpointName -ServerName $ServerName -InstanceName $InstanceName
 
-    $sqlServerObject = Connect-SQL -SQLServer $ServerName -SQLInstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
     if ($sqlServerObject)
     {
         if ($Ensure -eq 'Present' -and $getTargetResourceResult.Ensure -eq 'Absent')
@@ -147,6 +157,12 @@ function Set-TargetResource
             $endpointObject.ProtocolType = [Microsoft.SqlServer.Management.Smo.ProtocolType]::Tcp
             $endpointObject.Protocol.Tcp.ListenerPort = $Port
             $endpointObject.Protocol.Tcp.ListenerIPAddress = $IpAddress
+
+            if ($PSBoundParameters.ContainsKey('Owner'))
+            {
+                $endpointObject.Owner = $Owner
+            }
+
             $endpointObject.Payload.DatabaseMirroring.ServerMirroringRole = [Microsoft.SqlServer.Management.Smo.ServerMirroringRole]::All
             $endpointObject.Payload.DatabaseMirroring.EndpointEncryption = [Microsoft.SqlServer.Management.Smo.EndpointEncryption]::Required
             $endpointObject.Payload.DatabaseMirroring.EndpointEncryptionAlgorithm = [Microsoft.SqlServer.Management.Smo.EndpointEncryptionAlgorithm]::Aes
@@ -170,6 +186,13 @@ function Set-TargetResource
                 {
                     Write-Verbose -Message ('Updating endpoint {0} port to {1}.' -f $EndpointName, $Port)
                     $endpointObject.Protocol.Tcp.ListenerPort = $Port
+                    $endpointObject.Alter()
+                }
+
+                if ($endpointObject.Owner -ne $Owner)
+                {
+                    Write-Verbose -Message ('Updating endpoint {0} Owner to {1}.' -f $EndpointName, $Owner)
+                    $endpointObject.Owner = $Owner
                     $endpointObject.Alter()
                 }
             }
@@ -222,6 +245,9 @@ function Set-TargetResource
 
     .PARAMETER IpAddress
         The network IP address the endpoint is listening on. Defaults to '0.0.0.0' which means listen on any valid IP address.
+
+    .PARAMETER Owner
+        The owner of the endpoint. Default is the login used for the creation.
 #>
 function Test-TargetResource
 {
@@ -252,7 +278,11 @@ function Test-TargetResource
 
         [Parameter()]
         [System.String]
-        $IpAddress = '0.0.0.0'
+        $IpAddress = '0.0.0.0',
+
+        [Parameter()]
+        [System.String]
+        $Owner
     )
 
     $getTargetResourceResult = Get-TargetResource -EndpointName $EndpointName -ServerName $ServerName -InstanceName $InstanceName
@@ -262,10 +292,14 @@ function Test-TargetResource
 
         if ($getTargetResourceResult.Ensure -eq 'Present' `
                 -and (
-                $getTargetResourceResult.Port -ne $Port `
+                        $getTargetResourceResult.Port -ne $Port `
                     -or $getTargetResourceResult.IpAddress -ne $IpAddress
-            )
+                )
         )
+        {
+            $result = $false
+        }
+		elseif ($getTargetResourceResult.Ensure -eq 'Present' -and $Owner)
         {
             $result = $false
         }

--- a/DSCResources/MSFT_SqlServerEndpoint/MSFT_SqlServerEndpoint.schema.mof
+++ b/DSCResources/MSFT_SqlServerEndpoint/MSFT_SqlServerEndpoint.schema.mof
@@ -7,4 +7,5 @@ class MSFT_SqlServerEndpoint : OMI_BaseResource
     [Write, Description("The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.")] String ServerName;
     [Key, Description("The name of the SQL instance to be configured.")] String InstanceName;
     [Write, Description("The network IP address the endpoint is listening on. Default the endpoint will listen on any valid IP address.")] String IpAddress;
+    [Write, Description("The owner of the endpoint. Default is the login used for the creation.")] String EndPointOwner;
 };

--- a/Examples/Resources/SqlServerEndpoint/2-CreateEndpointWithSpecificPortIPAddressOwner.ps1
+++ b/Examples/Resources/SqlServerEndpoint/2-CreateEndpointWithSpecificPortIPAddressOwner.ps1
@@ -1,6 +1,6 @@
 <#
     .EXAMPLE
-        This example will add a Database Mirror endpoint with a specific listener port and a specific listener IP address.
+        This example will add a Database Mirror endpoint with specific listener port, listener IP address and owner.
 #>
 Configuration Example
 {
@@ -22,6 +22,7 @@ Configuration Example
             EndpointName         = 'HADR'
             Port                 = 9001
             IpAddress            = '192.168.0.20'
+            Owner                = 'sa'
 
             ServerName           = 'server1.company.local'
             InstanceName         = 'INST1'

--- a/README.md
+++ b/README.md
@@ -1041,11 +1041,13 @@ the resource [**SqlServerEndpointPermission**](#sqlserverendpointpermission).
 * **`[String]` InstanceName** _(Key)_: The name of the SQL instance to be configured.
 * **`[String]` IpAddress** _(Write)_: The network IP address the endpoint is listening
   on. Defaults to '0.0.0.0' which means listen on any valid IP address.
+* **`[String]` Owner** _(Write)_: The owner of the endpoint. Default is the login used
+  for the creation.
 
 #### Examples
 
 * [Create an endpoint with default values](/Examples/Resources/SqlServerEndpoint/1-CreateEndpointWithDefaultValues.ps1)
-* [Create an endpoint with specific port and IP address](/Examples/Resources/SqlServerEndpoint/2-CreateEndpointWithSpecificPortAndIPAddress.ps1)
+* [Create an endpoint with specific port and IP address](/Examples/Resources/SqlServerEndpoint/2-CreateEndpointWithSpecificPortIPAddressOwner.ps1)
 * [Remove an endpoint](/Examples/Resources/SqlServerEndpoint/3-RemoveEndpoint.ps1)
 
 #### Known issues
@@ -1527,6 +1529,9 @@ Manage the service account for SQL Server services.
 * **`[Boolean]` Force** (Write): Forces the service account to be updated.
   Useful for password changes. This will cause `Set-TargetResource` to be run on
   each consecutive run.
+* **`[String]` VersionNumber** (Write): The version number of the SQL Server,
+  mandatory for when IntegrationServices is used as **ServiceType**.
+  Eg. 130 for SQL 2016.  
 
 #### Read-Only Properties from Get-TargetResource
 


### PR DESCRIPTION
#### Pull Request (PR) description

    Adding the parameter "Owner" to allow to specify it at creation
It seems like there is no integration test for this resource.

#### This Pull Request (PR) fixes the following issues

    - Fixes #1251

#### Task list
- [X] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [X] Resource documentation added/updated in README.md.
- [X] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [X] Comment-based help added/updated.
- [X] Localization strings added/updated in all localization files as appropriate.
- [X] Examples appropriately added/updated.
- [X] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [X] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
