### PR TITLE
SqlServerMemory: Fix so auto memory on Azure VMs is reported correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
     the error handling is not again built into Pester.
   - Speeding up the AppVeyor tests by splitting the common tests in a
     separate build job.
+  - Updated the appveyor.yml to have the correct build step, and also
+    correct run the build step only in one of the jobs.
   - Added SqlAgentOperator resource.
 - Changes to SqlServiceAccount
   - Fixed Get-ServiceObject when searching for Integration Services service.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@
   - Updated the integration test to stop the named instance while installing
     the other instances to mitigate
     [issue #1260](https://github.com/PowerShell/SqlServerDsc/issues/1260).
+- Changes to SqlServerEndpoint
+  - Add the optional parameter Owner. The default owner remains the login used
+  for the creation of the endpoint
+    ([issue #1251](https://github.com/PowerShell/SqlServerDsc/issues/1251).
+    [Maxime Daniou (@mdaniou)](https://github.com/mdaniou)
 
 ## 12.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
     used for the creation of the endpoint
     ([issue #1251](https://github.com/PowerShell/SqlServerDsc/issues/1251)).
     [Maxime Daniou (@mdaniou)](https://github.com/mdaniou)
+- Added SqlAgentOperator Resource
 
 ## 12.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@
 - Changes to SqlServerLogin
   - Fixed issue in Test-TargetResource to valid password on disabled accounts.
     ([issue #915](https://github.com/PowerShell/SqlServerDsc/issues/915)).
+  - Now when adding a login of type SqlLogin, and the SQL Server login mode
+    is set to `'Integrated'`, an error is correctly thrown
+    ([issue #1179](https://github.com/PowerShell/SqlServerDsc/issues/1179)).
 - Changes to SqlSetup
   - Updated the integration test to stop the named instance while installing
     the other instances to mitigate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
     separate build job.
   - Updated the appveyor.yml to have the correct build step, and also
     correct run the build step only in one of the jobs.
+  - Update integration tests to use the new integration test template.
   - Added SqlAgentOperator resource.
 - Changes to SqlServiceAccount
   - Fixed Get-ServiceObject when searching for Integration Services service.
@@ -56,6 +57,13 @@
   - Add integration tests
     ([issue #744](https://github.com/PowerShell/SqlServerDsc/issues/744)).
     [Maxime Daniou (@mdaniou)](https://github.com/mdaniou)
+- Changes to SqlServiceAccount
+  - Now the correct service type string value is returned by the function
+    `Get-TargetResource`. Previously one value was passed in as a parameter
+    (e.g. `DatabaseEngine`), but a different string value as returned
+    (e.g. `SqlServer`). Now `Get-TargetResource` return the same values
+    that can be passed as values in the parameter `ServiceType`
+    ([issue #981](https://github.com/PowerShell/SqlServerDsc/issues/981)).
 
 ## 12.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
     the error handling is not again built into Pester.
   - Speeding up the AppVeyor tests by splitting the common tests in a
     separate build job.
+  - Added SqlAgentOperator resource.
 - Changes to SqlServiceAccount
   - Fixed Get-ServiceObject when searching for Integration Services service.
     Unlike the rest of SQL Server services, the Integration Services service
@@ -46,11 +47,13 @@
     SqlTempdbFileGrowth, SqlTempdbLogFileSize and SqlTempdbLogFileGrowth
     ([issue #1167](https://github.com/PowerShell/SqlServerDsc/issues/1167)).
 - Changes to SqlServerEndpoint
-  - Add the optional parameter Owner. The default owner remains the login
-    used for the creation of the endpoint
+  - Add the optional parameter Owner. The default owner remains the login used
+    for the creation of the endpoint
     ([issue #1251](https://github.com/PowerShell/SqlServerDsc/issues/1251)).
     [Maxime Daniou (@mdaniou)](https://github.com/mdaniou)
-- Added SqlAgentOperator Resource
+  - Add integration tests
+    ([issue #744](https://github.com/PowerShell/SqlServerDsc/issues/744)).
+    [Maxime Daniou (@mdaniou)](https://github.com/mdaniou)
 
 ## 12.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   - Clean up error handling in some of the integration tests that was
     part of a workaround for a bug in Pester. The bug is resolved, and
     the error handling is not again built into Pester.
+  - Speeding up the AppVeyor tests by splitting the common tests in a
+    separate build job.
 - Changes to SqlServiceAccount
   - Fixed Get-ServiceObject when searching for Integration Services service.
     Unlike the rest of SQL Server services, the Integration Services service

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@
   - Updated the integration test to stop the named instance while installing
     the other instances to mitigate
     [issue #1260](https://github.com/PowerShell/SqlServerDsc/issues/1260).
+- Changes to SqlSetup
+  - Add parameters to configure the Tempdb files during the installation of
+    the instance. The new parameters are SqlTempdbFileCount, SqlTempdbFileSize,
+    SqlTempdbFileGrowth, SqlTempdbLogFileSize and SqlTempdbLogFileGrowth
+    ([issue #1167](https://github.com/PowerShell/SqlServerDsc/issues/1167)).
 - Changes to SqlServerEndpoint
   - Add the optional parameter Owner. The default owner remains the login
     used for the creation of the endpoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- Changes to SqlServiceAccount
+  - Fixed Get-ServiceObject when searching for Integration Services service.
+    Unlike the rest of SQL Server services, the Integration Services service
+    cannot be instanced, however you can have multiple versions installed.
+    Get-Service object would return the correct service name that you
+    are looking for, but it appends the version number at the end. Added
+    parameter VersionNumber so the search would return the correct
+    service name.
+  - Added code to allow for using Managed Service Accounts.
+- Changes to SqlServerLogin
+  - Fixed issue in Test-TargetResource to valid password on disabled accounts.
+    ([issue #915](https://github.com/PowerShell/SqlServerDsc/issues/915)).
+
 ## 12.2.0.0
 
 - Changes to SqlServerDsc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+- Changes to SqlServerDsc
+  - Reverting the change that was made as part of the
+    [issue #1260](https://github.com/PowerShell/SqlServerDsc/issues/1260)
+    in the previous release, as it only mitigated the issue, it did not
+    solve the issue.
+  - Removed the container testing since that broke the integration tests,
+    possible due to using excessive amount of memory on the AppVeyor build
+    worker. This will make the unit tests to take a bit longer to run.
+    ([issue #1260](https://github.com/PowerShell/SqlServerDsc/issues/1260)).
+  - The unit tests and the integration tests are now run in two separate
+    build workers in AppVeyor. One build worker runs the integration tests,
+    while a second build worker runs the unit tests. The build workers runs
+    in parallel on paid accounts, but sequentially on free accounts.
+    ([issue #1260](https://github.com/PowerShell/SqlServerDsc/issues/1260)).
+  - Clean up error handling in some of the integration tests that was
+    part of a workaround for a bug in Pester. The bug is resolved, and
+    the error handling is not again built into Pester.
 - Changes to SqlServiceAccount
   - Fixed Get-ServiceObject when searching for Integration Services service.
     Unlike the rest of SQL Server services, the Integration Services service
@@ -14,6 +31,10 @@
 - Changes to SqlServerLogin
   - Fixed issue in Test-TargetResource to valid password on disabled accounts.
     ([issue #915](https://github.com/PowerShell/SqlServerDsc/issues/915)).
+- Changes to SqlSetup
+  - Updated the integration test to stop the named instance while installing
+    the other instances to mitigate
+    [issue #1260](https://github.com/PowerShell/SqlServerDsc/issues/1260).
 
 ## 12.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@
     solve the issue.
   - Removed the container testing since that broke the integration tests,
     possible due to using excessive amount of memory on the AppVeyor build
-    worker. This will make the unit tests to take a bit longer to run.
+    worker. This will make the unit tests to take a bit longer to run
     ([issue #1260](https://github.com/PowerShell/SqlServerDsc/issues/1260)).
   - The unit tests and the integration tests are now run in two separate
     build workers in AppVeyor. One build worker runs the integration tests,
     while a second build worker runs the unit tests. The build workers runs
-    in parallel on paid accounts, but sequentially on free accounts.
+    in parallel on paid accounts, but sequentially on free accounts
     ([issue #1260](https://github.com/PowerShell/SqlServerDsc/issues/1260)).
   - Clean up error handling in some of the integration tests that was
     part of a workaround for a bug in Pester. The bug is resolved, and
@@ -29,7 +29,7 @@
     service name.
   - Added code to allow for using Managed Service Accounts.
 - Changes to SqlServerLogin
-  - Fixed issue in Test-TargetResource to valid password on disabled accounts.
+  - Fixed issue in Test-TargetResource to valid password on disabled accounts
     ([issue #915](https://github.com/PowerShell/SqlServerDsc/issues/915)).
   - Now when adding a login of type SqlLogin, and the SQL Server login mode
     is set to `'Integrated'`, an error is correctly thrown
@@ -39,9 +39,9 @@
     the other instances to mitigate
     [issue #1260](https://github.com/PowerShell/SqlServerDsc/issues/1260).
 - Changes to SqlServerEndpoint
-  - Add the optional parameter Owner. The default owner remains the login used
-  for the creation of the endpoint
-    ([issue #1251](https://github.com/PowerShell/SqlServerDsc/issues/1251).
+  - Add the optional parameter Owner. The default owner remains the login
+    used for the creation of the endpoint
+    ([issue #1251](https://github.com/PowerShell/SqlServerDsc/issues/1251)).
     [Maxime Daniou (@mdaniou)](https://github.com/mdaniou)
 
 ## 12.2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@
     parameter VersionNumber so the search would return the correct
     service name.
   - Added code to allow for using Managed Service Accounts.
+  - Now the correct service type string value is returned by the function
+    `Get-TargetResource`. Previously one value was passed in as a parameter
+    (e.g. `DatabaseEngine`), but a different string value as returned
+    (e.g. `SqlServer`). Now `Get-TargetResource` return the same values
+    that can be passed as values in the parameter `ServiceType`
+    ([issue #981](https://github.com/PowerShell/SqlServerDsc/issues/981)).
 - Changes to SqlServerLogin
   - Fixed issue in Test-TargetResource to valid password on disabled accounts
     ([issue #915](https://github.com/PowerShell/SqlServerDsc/issues/915)).
@@ -44,7 +50,6 @@
   - Updated the integration test to stop the named instance while installing
     the other instances to mitigate
     [issue #1260](https://github.com/PowerShell/SqlServerDsc/issues/1260).
-- Changes to SqlSetup
   - Add parameters to configure the Tempdb files during the installation of
     the instance. The new parameters are SqlTempdbFileCount, SqlTempdbFileSize,
     SqlTempdbFileGrowth, SqlTempdbLogFileSize and SqlTempdbLogFileGrowth
@@ -57,13 +62,6 @@
   - Add integration tests
     ([issue #744](https://github.com/PowerShell/SqlServerDsc/issues/744)).
     [Maxime Daniou (@mdaniou)](https://github.com/mdaniou)
-- Changes to SqlServiceAccount
-  - Now the correct service type string value is returned by the function
-    `Get-TargetResource`. Previously one value was passed in as a parameter
-    (e.g. `DatabaseEngine`), but a different string value as returned
-    (e.g. `SqlServer`). Now `Get-TargetResource` return the same values
-    that can be passed as values in the parameter `ServiceType`
-    ([issue #981](https://github.com/PowerShell/SqlServerDsc/issues/981)).
 
 ## 12.2.0.0
 

--- a/DSCResources/MSFT_SqlAgentOperator/MSFT_SqlAgentOperator.psm1
+++ b/DSCResources/MSFT_SqlAgentOperator/MSFT_SqlAgentOperator.psm1
@@ -1,0 +1,332 @@
+Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) `
+        -ChildPath 'SqlServerDscHelper.psm1') `
+    -Force
+
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+    -ChildPath 'CommonResourceHelper.psm1')
+
+$script:localizedData = Get-LocalizedData -ResourceName 'MSFT_SqlAgentOperator'
+
+<#
+    .SYNOPSIS
+    This function gets the SQL Agent Operator.
+
+    .PARAMETER Name
+    The name of the SQL Agent Operator.
+
+    .PARAMETER ServerName
+    The host name of the SQL Server to be configured. Default is $env:COMPUTERNAME.
+
+    .PARAMETER InstanceName
+    The name of the SQL instance to be configured.
+
+#>
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Name,
+
+        [Parameter()]
+        [System.String]
+        $ServerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $InstanceName
+
+    )
+
+    $returnValue = @{
+        Name         = $null
+        Ensure       = 'Absent'
+        ServerName   = $ServerName
+        InstanceName = $InstanceName
+        EmailAddress = $null
+    }
+
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+
+    if ($sqlServerObject)
+    {
+        Write-Verbose -Message (
+            $script:localizedData.GetSqlAgents
+        )
+        # Check operator exists
+        $sqlOperatorObject = $sqlServerObject.JobServer.Operators | Where-Object {$_.Name -eq $Name}
+        if ($sqlOperatorObject)
+        {
+            Write-Verbose -Message (
+                $script:localizedData.SqlAgentPresent `
+                    -f $Name
+            )
+            $returnValue['Ensure'] = 'Present'
+            $returnValue['Name'] = $sqlOperatorObject.Name
+            $returnValue['EmailAddress'] = $sqlOperatorObject.EmailAddress
+        }
+        else
+        {
+            Write-Verbose -Message (
+                $script:localizedData.SqlAgentAbsent `
+                    -f $Name
+            )
+        }
+    }
+    else
+    {
+
+        $errorMessage = $script:localizedData.ConnectServerFailed -f $ServerName, $InstanceName
+        New-InvalidOperationException -Message $errorMessage -ErrorRecord $_
+    }
+
+    return $returnValue
+}
+
+<#
+    .SYNOPSIS
+    This function sets the SQL Agent Operator.
+
+    .PARAMETER Ensure
+    Specifies if the SQL Agent Operator should be present or absent. Default is Present
+
+    .PARAMETER Name
+    The name of the SQL Agent Operator.
+
+    .PARAMETER ServerName
+    The host name of the SQL Server to be configured. Default is $env:COMPUTERNAME.
+
+    .PARAMETER InstanceName
+    The name of the SQL instance to be configured.
+
+    .PARAMETER EmailAddress
+    The email address to be used for the SQL Agent Operator.
+#>
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter()]
+        [ValidateSet('Present', 'Absent')]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Ensure = 'Present',
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Name,
+
+        [Parameter()]
+        [System.String]
+        $ServerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $InstanceName,
+
+        [Parameter()]
+        [System.String]
+        $EmailAddress
+    )
+
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+
+    if ($sqlServerObject)
+    {
+        switch ($Ensure)
+        {
+            'Present'
+            {
+                $sqlOperatorObject = $sqlServerObject.JobServer.Operators | Where-Object {$_.Name -eq $Name}
+
+                if ($sqlOperatorObject)
+                {
+                    if ($PSBoundParameters.ContainsKey('EmailAddress'))
+                    {
+                        try
+                        {
+                            Write-Verbose -Message (
+                                $script:localizedData.UpdateEmailAddress `
+                                    -f $EmailAddress, $Name
+                            )
+                            $sqlOperatorObject.EmailAddress = $EmailAddress
+                            $sqlOperatorObject.Alter()
+                        }
+                        catch
+                        {
+                            $errorMessage = $script:localizedData.UpdateOperatorSetError -f $ServerName, $InstanceName, $Name, $EmailAddress
+                            New-InvalidOperationException -Message $errorMessage -ErrorRecord $_
+                        }
+                    }
+                }
+                else
+                {
+                    try
+                    {
+                        $sqlOperatorObjectToCreate = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Agent.Operator -ArgumentList $sqlServerObject.JobServer, $Name
+
+                        if ($sqlOperatorObjectToCreate)
+                        {
+                            Write-Verbose -Message (
+                                $script:localizedData.AddSqlAgentOperator `
+                                    -f $Name
+                            )
+                            if ($PSBoundParameters.ContainsKey('EmailAddress'))
+                            {
+                                Write-Verbose -Message (
+                                    $script:localizedData.UpdateEmailAddress `
+                                        -f $EmailAddress, $Name
+                                )
+                                $sqlOperatorObjectToCreate.EmailAddress = $EmailAddress
+                            }
+                            $sqlOperatorObjectToCreate.Create()
+                        }
+                    }
+                    catch
+                    {
+                        $errorMessage = $script:localizedData.CreateOperatorSetError -f $Name, $ServerName, $InstanceName
+                        New-InvalidOperationException -Message $errorMessage -ErrorRecord $_
+                    }
+                }
+            }
+
+            'Absent'
+            {
+                try
+                {
+                    $sqlOperatorObjectToDrop = $sqlServerObject.JobServer.Operators | Where-Object {$_.Name -eq $Name}
+                    if ($sqlOperatorObjectToDrop)
+                    {
+                        Write-Verbose -Message (
+                            $script:localizedData.DeleteSqlAgentOperator `
+                                -f $Name
+                        )
+                        $sqlOperatorObjectToDrop.Drop()
+                    }
+                }
+                catch
+                {
+                    $errorMessage = $script:localizedData.DropOperatorSetError -f $Name, $ServerName, $InstanceName
+                    New-InvalidOperationException -Message $errorMessage -ErrorRecord $_
+                }
+            }
+        }
+    }
+    else
+    {
+        $errorMessage = $script:localizedData.ConnectServerFailed -f $ServerName, $InstanceName
+        New-InvalidOperationException -Message $errorMessage -ErrorRecord $_
+    }
+}
+
+<#
+    .SYNOPSIS
+    This function tests the SQL Agent Operator.
+
+    .PARAMETER Ensure
+    Specifies if the SQL Agent Operator should be present or absent. Default is Present
+
+    .PARAMETER Name
+    The name of the SQL Agent Operator.
+
+    .PARAMETER ServerName
+    The host name of the SQL Server to be configured. Default is $env:COMPUTERNAME.
+
+    .PARAMETER InstanceName
+    The name of the SQL instance to be configured.
+
+    .PARAMETER EmailAddress
+    The email address to be used for the SQL Agent Operator.
+#>
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [Parameter()]
+        [ValidateSet('Present', 'Absent')]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Ensure = 'Present',
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Name,
+
+        [Parameter()]
+        [System.String]
+        $ServerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $InstanceName,
+
+        [Parameter()]
+        [System.String]
+        $EmailAddress
+    )
+
+    Write-Verbose -Message (
+        $script:localizedData.TestSqlAgentOperator `
+            -f $Name
+    )
+
+    $getTargetResourceParameters = @{
+        Name           = $Name
+        ServerName     = $ServerName
+        InstanceName   = $InstanceName
+    }
+
+    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    $isOperatorInDesiredState = $true
+
+    switch ($Ensure)
+    {
+        'Absent'
+        {
+            if ($getTargetResourceResult.Ensure -ne 'Absent')
+            {
+                Write-Verbose -Message (
+                    $script:localizedData.SqlAgentOperatorExistsButShouldNot `
+                        -f $Name
+                )
+                $isOperatorInDesiredState = $false
+            }
+        }
+
+        'Present'
+        {
+            if ($getTargetResourceResult.EmailAddress -ne $EmailAddress -and $PSBoundParameters.ContainsKey('EmailAddress'))
+            {
+                Write-Verbose -Message (
+                    $script:localizedData.SqlAgentOperatorExistsButEmailWrong `
+                        -f $Name, $getTargetResourceResult.EmailAddress, $EmailAddress
+                )
+                $isOperatorInDesiredState = $false
+            }
+            elseif ($getTargetResourceResult.Ensure -ne 'Present')
+            {
+                Write-Verbose -Message (
+                    $script:localizedData.SqlAgentOperatorDoesNotExistButShould `
+                        -f $Name
+                )
+                $isOperatorInDesiredState = $false
+            }
+        }
+    }
+    $isOperatorInDesiredState
+}
+
+Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/MSFT_SqlAgentOperator/MSFT_SqlAgentOperator.schema.mof
+++ b/DSCResources/MSFT_SqlAgentOperator/MSFT_SqlAgentOperator.schema.mof
@@ -1,0 +1,9 @@
+[ClassVersion("1.0.0.0"), FriendlyName("SqlAgentOperator")]
+class MSFT_SqlAgentOperator : OMI_BaseResource
+{
+    [Key, Description("The name of the SQL Agent Operator.")] String Name;
+    [Write, Description("Specifies if the SQL Agent Operator should be present or absent. Default is Present."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Write, Description("The host name of the SQL Server to be configured. Default is $env:COMPUTERNAME.")] String ServerName;
+    [Key, Description("The name of the SQL instance to be configured.")] String InstanceName;
+    [Write, Description("The email address to be used for the SQL Agent Operator.")] String EmailAddress;
+};

--- a/DSCResources/MSFT_SqlAgentOperator/en-US/MSFT_SqlAgentOperator.strings.psd1
+++ b/DSCResources/MSFT_SqlAgentOperator/en-US/MSFT_SqlAgentOperator.strings.psd1
@@ -1,0 +1,18 @@
+# Localized resources for MSFT_SqlServerAgentOperator
+
+ConvertFrom-StringData @'
+    GetSqlAgents = Getting SQL Agent Operators.
+    SqlAgentPresent = SQL Agent Operator '{0}' is present.
+    SqlAgentAbsent = SQL Agent Operator '{0}' is absent.
+    UpdateOperatorSetError = Unable to update the email address for '{2}' to '{3}' on {0}\\{1}.
+    AddSqlAgentOperator = Adding SQL Agent Operator '{0}'.
+    UpdateEmailAddress = Updating email address to '{0}' for SQL Agent Operator '{1}'.
+    CreateOperatorSetError = Unable to create the SQL Agent Operator '{0}' on {1}\\{2}.
+    DeleteSqlAgentOperator = Deleting SQL Agent Operator '{0}'.
+    DropOperatorSetError = Unable to drop the SQL Agent Operator '{0}' on {1}\\{2}.
+    TestSqlAgentOperator = Checking if SQL Agent Operator '{0}' is present or absent.
+    SqlAgentOperatorExistsButShouldNot = SQL Agent Operator exists but ensure is set to Absent. The SQL Agent Operator '{0}' should be deleted.
+    SqlAgentOperatorDoesNotExistButShould  = SQL Agent Operator does not exist but Ensure is set to Present. The SQL Agent Operator '{0}' should be created.
+    SqlAgentOperatorExistsButEmailWrong  = SQL Agent Operator '{0}' exists but has the wrong email address. Email address is currently '{1}' and should be updated to '{2}'.
+    ConnectServerFailed = Unable to connect to {0}\\{1}.
+'@

--- a/DSCResources/MSFT_SqlServerEndpoint/MSFT_SqlServerEndpoint.psm1
+++ b/DSCResources/MSFT_SqlServerEndpoint/MSFT_SqlServerEndpoint.psm1
@@ -40,6 +40,7 @@ function Get-TargetResource
         EndpointName = ''
         Port         = ''
         IpAddress    = ''
+        Owner        = ''
     }
 
     $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
@@ -61,6 +62,7 @@ function Get-TargetResource
             $getTargetResourceReturnValues.EndpointName = $endpointObject.Name
             $getTargetResourceReturnValues.Port = $endpointObject.Protocol.Tcp.ListenerPort
             $getTargetResourceReturnValues.IpAddress = $endpointObject.Protocol.Tcp.ListenerIPAddress
+            $getTargetResourceReturnValues.Owner = $endpointObject.Owner
         }
         else
         {
@@ -68,6 +70,7 @@ function Get-TargetResource
             $getTargetResourceReturnValues.EndpointName = ''
             $getTargetResourceReturnValues.Port = ''
             $getTargetResourceReturnValues.IpAddress = ''
+            $getTargetResourceReturnValues.Owner = ''
         }
     }
     else
@@ -101,6 +104,9 @@ function Get-TargetResource
 
     .PARAMETER IpAddress
         The network IP address the endpoint is listening on. Defaults to '0.0.0.0' which means listen on any valid IP address.
+
+    .PARAMETER Owner
+        The owner of the endpoint. Default is the login used for the creation.
 #>
 function Set-TargetResource
 {
@@ -130,7 +136,11 @@ function Set-TargetResource
 
         [Parameter()]
         [System.String]
-        $IpAddress = '0.0.0.0'
+        $IpAddress = '0.0.0.0',
+
+        [Parameter()]
+        [System.String]
+        $Owner
     )
 
     $getTargetResourceResult = Get-TargetResource -EndpointName $EndpointName -ServerName $ServerName -InstanceName $InstanceName
@@ -147,6 +157,12 @@ function Set-TargetResource
             $endpointObject.ProtocolType = [Microsoft.SqlServer.Management.Smo.ProtocolType]::Tcp
             $endpointObject.Protocol.Tcp.ListenerPort = $Port
             $endpointObject.Protocol.Tcp.ListenerIPAddress = $IpAddress
+
+            if ($PSBoundParameters.ContainsKey('Owner'))
+            {
+                $endpointObject.Owner = $Owner
+            }
+
             $endpointObject.Payload.DatabaseMirroring.ServerMirroringRole = [Microsoft.SqlServer.Management.Smo.ServerMirroringRole]::All
             $endpointObject.Payload.DatabaseMirroring.EndpointEncryption = [Microsoft.SqlServer.Management.Smo.EndpointEncryption]::Required
             $endpointObject.Payload.DatabaseMirroring.EndpointEncryptionAlgorithm = [Microsoft.SqlServer.Management.Smo.EndpointEncryptionAlgorithm]::Aes
@@ -170,6 +186,13 @@ function Set-TargetResource
                 {
                     Write-Verbose -Message ('Updating endpoint {0} port to {1}.' -f $EndpointName, $Port)
                     $endpointObject.Protocol.Tcp.ListenerPort = $Port
+                    $endpointObject.Alter()
+                }
+
+                if ($endpointObject.Owner -ne $Owner)
+                {
+                    Write-Verbose -Message ('Updating endpoint {0} Owner to {1}.' -f $EndpointName, $Owner)
+                    $endpointObject.Owner = $Owner
                     $endpointObject.Alter()
                 }
             }
@@ -222,6 +245,9 @@ function Set-TargetResource
 
     .PARAMETER IpAddress
         The network IP address the endpoint is listening on. Defaults to '0.0.0.0' which means listen on any valid IP address.
+
+    .PARAMETER Owner
+        The owner of the endpoint. Default is the login used for the creation.
 #>
 function Test-TargetResource
 {
@@ -252,7 +278,11 @@ function Test-TargetResource
 
         [Parameter()]
         [System.String]
-        $IpAddress = '0.0.0.0'
+        $IpAddress = '0.0.0.0',
+
+        [Parameter()]
+        [System.String]
+        $Owner
     )
 
     $getTargetResourceResult = Get-TargetResource -EndpointName $EndpointName -ServerName $ServerName -InstanceName $InstanceName
@@ -262,9 +292,15 @@ function Test-TargetResource
 
         if ($getTargetResourceResult.Ensure -eq 'Present' `
                 -and (
-                $getTargetResourceResult.Port -ne $Port `
+                        $getTargetResourceResult.Port -ne $Port `
                     -or $getTargetResourceResult.IpAddress -ne $IpAddress
-            )
+                )
+        )
+        {
+            $result = $false
+        }
+        elseif ($getTargetResourceResult.Ensure -eq 'Present' -and $Owner `
+                -and $getTargetResourceResult.Owner -ne $Owner
         )
         {
             $result = $false

--- a/DSCResources/MSFT_SqlServerEndpoint/MSFT_SqlServerEndpoint.schema.mof
+++ b/DSCResources/MSFT_SqlServerEndpoint/MSFT_SqlServerEndpoint.schema.mof
@@ -7,4 +7,5 @@ class MSFT_SqlServerEndpoint : OMI_BaseResource
     [Write, Description("The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.")] String ServerName;
     [Key, Description("The name of the SQL instance to be configured.")] String InstanceName;
     [Write, Description("The network IP address the endpoint is listening on. Default the endpoint will listen on any valid IP address.")] String IpAddress;
+    [Write, Description("The owner of the endpoint. Default is the login used for the creation.")] String Owner;
 };

--- a/DSCResources/MSFT_SqlServerLogin/MSFT_SqlServerLogin.psm1
+++ b/DSCResources/MSFT_SqlServerLogin/MSFT_SqlServerLogin.psm1
@@ -227,10 +227,10 @@ function Set-TargetResource
 
                 switch ($LoginType)
                 {
-                    SqlLogin
+                    'SqlLogin'
                     {
                         # Verify the instance is in Mixed authentication mode
-                        if ( $serverObject.LoginMode -notmatch 'Mixed|Integrated' )
+                        if ( $serverObject.LoginMode -notmatch 'Mixed|Normal' )
                         {
                             throw New-TerminatingError -ErrorType IncorrectLoginMode -FormatArgs $ServerName, $InstanceName, $serverObject.LoginMode -ErrorCategory NotImplemented
                         }

--- a/DSCResources/MSFT_SqlServerMemory/MSFT_SqlServerMemory.psm1
+++ b/DSCResources/MSFT_SqlServerMemory/MSFT_SqlServerMemory.psm1
@@ -340,7 +340,7 @@ function Get-SqlDscDynamicMaxMemory
 {
     try
     {
-        $physicalMemory = ((Get-CimInstance -ClassName Win32_PhysicalMemory).Capacity | Measure-Object -Sum).Sum
+        $physicalMemory = (Get-CimInstance -ClassName Win32_ComputerSystem).TotalPhysicalMemory
         $physicalMemoryInMegaBytes = [Math]::Round($physicalMemory / 1MB)
 
         # Find how much to save for OS: 20% of total ram for under 15GB / 12.5% for over 20GB

--- a/DSCResources/MSFT_SqlServiceAccount/MSFT_SqlServiceAccount.psm1
+++ b/DSCResources/MSFT_SqlServiceAccount/MSFT_SqlServiceAccount.psm1
@@ -74,11 +74,13 @@ function Get-TargetResource
     # Replace a domain of '.' with the value for $ServerName
     $serviceAccountName = $serviceObject.ServiceAccount -ireplace '^([\.])\\(.*)$', "$ServerName\`$2"
 
+    $serviceType = ConvertTo-ResourceServiceType -ServiceType $serviceObject.Type
+
     # Return a hash table with the service information
     return @{
         ServerName         = $ServerName
         InstanceName       = $InstanceName
-        ServiceType        = $serviceObject.Type
+        ServiceType        = $serviceType
         ServiceAccountName = $serviceAccountName
     }
 }
@@ -112,7 +114,7 @@ function Get-TargetResource
 
     .EXAMPLE
         Test-TargetResource -ServerName $env:COMPUTERNAME -InstanceName MSSQLSERVER -ServiceType DatabaseEngine -ServiceAccount $account
-        Test-TargetResource -ServerName $env:COMPUTERNAME -InstanceName MSSQLSERVER -SerticeType IntegrationServices -ServiceAccount $account -VersionNumber 130
+        Test-TargetResource -ServerName $env:COMPUTERNAME -InstanceName MSSQLSERVER -ServiceType IntegrationServices -ServiceAccount $account -VersionNumber 130
 
 #>
 function Test-TargetResource
@@ -271,7 +273,7 @@ function Set-TargetResource
     .PARAMETER ServiceType
         Type of service to be managed. Must be one of the following:
         DatabaseEngine, SQLServerAgent, Search, IntegrationServices, AnalysisServices, ReportingServices, SQLServerBrowser, NotificationServices.
-    
+
     .PARAMETER VersionNumber
         Version number of IntegrationServices.
 
@@ -306,7 +308,7 @@ function Get-ServiceObject
     if (($ServiceType -eq 'IntegrationServices') -and ([String]::IsNullOrEmpty($VersionNumber)))
     {
         $errorMessage = $script:localizedData.MissingParameter -f $ServiceType
-        New-InvalidArgumentException -Message $errorMessage -ArgumentName 'VersionNumber'        
+        New-InvalidArgumentException -Message $errorMessage -ArgumentName 'VersionNumber'
     }
 
     # Load the SMO libraries
@@ -403,6 +405,88 @@ function ConvertTo-ManagedServiceType
     }
 
     return $serviceTypeValue -as [Microsoft.SqlServer.Management.Smo.Wmi.ManagedServiceType]
+}
+
+<#
+    .SYNOPSIS
+        Converts from the string value, that was returned from the type
+        Microsoft.SqlServer.Management.Smo.Wmi.ManagedServiceType, to the
+        appropriate project's standard SQL Service type string values.
+
+    .PARAMETER ServiceType
+        The string value of the Microsoft.SqlServer.Management.Smo.Wmi.ManagedServiceType.
+        Must be one of the following:
+        SqlServer, SqlAgent, Search, SqlServerIntegrationService, AnalysisServer,
+        ReportServer, SqlBrowser, NotificationServer.
+
+    .NOTES
+        If an unknown type is passed in parameter ServiceType, the same type will
+        be returned.
+
+    .EXAMPLE
+        ConvertTo-ResourceServiceType -ServiceType 'SqlServer'
+#>
+function ConvertTo-ResourceServiceType
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $ServiceType
+    )
+
+    # Map the project-specific ServiceType to a valid value from the ManagedServiceType enumeration
+    switch ($ServiceType)
+    {
+        'SqlServer'
+        {
+            $serviceTypeValue = 'DatabaseEngine'
+        }
+
+        'SqlAgent'
+        {
+            $serviceTypeValue = 'SQLServerAgent'
+        }
+
+        'Search'
+        {
+            $serviceTypeValue = 'Search'
+        }
+
+        'SqlServerIntegrationService'
+        {
+            $serviceTypeValue = 'IntegrationServices'
+        }
+
+        'AnalysisServer'
+        {
+            $serviceTypeValue = 'AnalysisServices'
+        }
+
+        'ReportServer'
+        {
+            $serviceTypeValue = 'ReportingServices'
+        }
+
+        'SqlBrowser'
+        {
+            $serviceTypeValue = 'SQLServerBrowser'
+        }
+
+        'NotificationServer'
+        {
+            $serviceTypeValue = 'NotificationServices'
+        }
+
+        default
+        {
+            $serviceTypeValue = $ServiceType
+        }
+    }
+
+    return $serviceTypeValue
 }
 
 <#

--- a/DSCResources/MSFT_SqlServiceAccount/MSFT_SqlServiceAccount.psm1
+++ b/DSCResources/MSFT_SqlServiceAccount/MSFT_SqlServiceAccount.psm1
@@ -24,8 +24,13 @@ $script:localizedData = Get-LocalizedData -ResourceName 'MSFT_SqlServiceAccount'
         ** Not used in this function **
          Credential of the service account that should be used.
 
+    .PARAMETER VersionNumber
+        ** Only used when specifying IntegrationServices **
+        Version number of IntegrationServices.
+
     .EXAMPLE
         Get-TargetResource -ServerName $env:COMPUTERNAME -InstanceName MSSQLSERVER -ServiceType DatabaseEngine -ServiceAccount $account
+        Get-TargetResource -ServerName $env:COMPUTERNAME -InstanceName MSSQLSERVER -ServiceType IntegrationServices -ServiceAccount $account -VersionNumber 130
 #>
 function Get-TargetResource
 {
@@ -48,11 +53,15 @@ function Get-TargetResource
 
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        $ServiceAccount
+        $ServiceAccount,
+
+        [Parameter()]
+        [System.String]
+        $VersionNumber
     )
 
     # Get the SMO Service object instance
-    $serviceObject = Get-ServiceObject -ServerName $ServerName -InstanceName $InstanceName -ServiceType $ServiceType
+    $serviceObject = Get-ServiceObject -ServerName $ServerName -InstanceName $InstanceName -ServiceType $ServiceType -VersionNumber $VersionNumber
 
     # If no service was found, throw an exception
     if (-not $serviceObject)
@@ -98,8 +107,12 @@ function Get-TargetResource
     .PARAMETER Force
         Forces the service account to be updated.
 
+    .PARAMETER VersionNumber
+        Version number of IntegrationServices
+
     .EXAMPLE
         Test-TargetResource -ServerName $env:COMPUTERNAME -InstanceName MSSQLSERVER -ServiceType DatabaseEngine -ServiceAccount $account
+        Test-TargetResource -ServerName $env:COMPUTERNAME -InstanceName MSSQLSERVER -SerticeType IntegrationServices -ServiceAccount $account -VersionNumber 130
 
 #>
 function Test-TargetResource
@@ -131,7 +144,11 @@ function Test-TargetResource
 
         [Parameter()]
         [System.Boolean]
-        $Force
+        $Force,
+
+        [Parameter()]
+        [System.String]
+        $VersionNumber
     )
 
     if ($Force)
@@ -141,7 +158,7 @@ function Test-TargetResource
     }
 
     # Get the current state
-    $currentState = Get-TargetResource -ServerName $ServerName -InstanceName $InstanceName -ServiceType $ServiceType -ServiceAccount $ServiceAccount
+    $currentState = Get-TargetResource -ServerName $ServerName -InstanceName $InstanceName -ServiceType $ServiceType -ServiceAccount $ServiceAccount -VersionNumber $VersionNumber
     New-VerboseMessage -Message ($script:localizedData.CurrentServiceAccount -f $currentState.ServiceAccountName, $ServerName, $InstanceName)
 
     return ($currentState.ServiceAccountName -ieq $ServiceAccount.UserName)
@@ -170,6 +187,9 @@ function Test-TargetResource
 
     .PARAMETER Force
         Forces the service account to be updated.
+
+    .PARAMETER VersionNumber
+        Version number of IntegrationServices
 
     .EXAMPLE
         Set-TargetResource -ServerName $env:COMPUTERNAME -InstanceName MSSQLSERVER -ServiceType DatabaseEngine -ServiceAccount $account
@@ -202,11 +222,15 @@ function Set-TargetResource
 
         [Parameter()]
         [System.Boolean]
-        $Force
+        $Force,
+
+        [Parameter()]
+        [System.String]
+        $VersionNumber
     )
 
     # Get the Service object
-    $serviceObject = Get-ServiceObject -ServerName $ServerName -InstanceName $InstanceName -ServiceType $ServiceType
+    $serviceObject = Get-ServiceObject -ServerName $ServerName -InstanceName $InstanceName -ServiceType $ServiceType -VersionNumber $VersionNumber
 
     # If no service was found, throw an exception
     if (-not $serviceObject)
@@ -218,7 +242,8 @@ function Set-TargetResource
     try
     {
         New-VerboseMessage -Message ($script:localizedData.UpdatingServiceAccount -f $ServiceAccount.UserName, $serviceObject.Name)
-        $serviceObject.SetServiceAccount($ServiceAccount.UserName, $ServiceAccount.GetNetworkCredential().Password)
+        $account = Get-ServiceAccount -ServiceAccount $ServiceAccount
+        $serviceObject.SetServiceAccount($account.UserName, $account.Password)
     }
     catch
     {
@@ -246,9 +271,13 @@ function Set-TargetResource
     .PARAMETER ServiceType
         Type of service to be managed. Must be one of the following:
         DatabaseEngine, SQLServerAgent, Search, IntegrationServices, AnalysisServices, ReportingServices, SQLServerBrowser, NotificationServices.
+    
+    .PARAMETER VersionNumber
+        Version number of IntegrationServices.
 
     .EXAMPLE
         Get-ServiceObject -ServerName $env:COMPUTERNAME -InstanceName MSSQLSERVER -ServiceType DatabaseEngine
+        Get-ServiceObject -ServerName $env:COMPUTERNAME -InstanceName MSSQLSERVER -ServiceType IntegrationServices -VersionNumber 130
 #>
 function Get-ServiceObject
 {
@@ -266,8 +295,19 @@ function Get-ServiceObject
         [Parameter(Mandatory = $true)]
         [ValidateSet('DatabaseEngine', 'SQLServerAgent', 'Search', 'IntegrationServices', 'AnalysisServices', 'ReportingServices', 'SQLServerBrowser', 'NotificationServices')]
         [System.String]
-        $ServiceType
+        $ServiceType,
+
+        [Parameter()]
+        [System.String]
+        $VersionNumber
     )
+
+    # Check to see if Integration services was specified, but no version specified
+    if (($ServiceType -eq 'IntegrationServices') -and ([String]::IsNullOrEmpty($VersionNumber)))
+    {
+        $errorMessage = $script:localizedData.MissingParameter -f $ServiceType
+        New-InvalidArgumentException -Message $errorMessage -ArgumentName 'VersionNumber'        
+    }
 
     # Load the SMO libraries
     Import-SQLPSModule
@@ -281,9 +321,16 @@ function Get-ServiceObject
     # Get the service name for the specified instance and type
     $serviceNameFilter = Get-SqlServiceName -InstanceName $InstanceName -ServiceType $ServiceType
 
+    # Check the service type and append version number if IntegrationServices
+    if ($ServiceType -eq 'IntegrationServices')
+    {
+        # Append version number
+        $serviceNameFilter = '{0}{1}' -f $serviceNameFilter, $VersionNumber
+    }
+
     # Get the Service object for the specified instance/type
     $serviceObject = $managedComputer.Services | Where-Object -FilterScript {
-        $_.Name -eq $serviceNameFilter
+        $_.Name -eq "$serviceNameFilter"
     }
 
     return $serviceObject
@@ -440,3 +487,4 @@ function Get-SqlServiceName
     # Build the name of the service and return it
     return ($returnValue -f $serviceNamingScheme, $InstanceName)
 }
+

--- a/DSCResources/MSFT_SqlServiceAccount/MSFT_SqlServiceAccount.schema.mof
+++ b/DSCResources/MSFT_SqlServiceAccount/MSFT_SqlServiceAccount.schema.mof
@@ -8,4 +8,5 @@ class MSFT_SqlServiceAccount : OMI_BaseResource
     [Write, Description("Determines whether the service is automatically restarted when a change to the configuration was needed.")] Boolean RestartService;
     [Write, Description("Forces the service account to be updated. Useful for password changes.")] Boolean Force;
     [Read, Description("Returns the service account username for the service.")] String ServiceAccountName;
+    [Write, Description("The version number for the service, mandatory with IntegrationServices ServiceType")] String VersionNumber;
 };

--- a/DSCResources/MSFT_SqlServiceAccount/en-US/MSFT_SqlServiceAccount.strings.psd1
+++ b/DSCResources/MSFT_SqlServiceAccount/en-US/MSFT_SqlServiceAccount.strings.psd1
@@ -10,4 +10,5 @@ ConvertFrom-StringData @'
     SetServiceAccountFailed = Unable to set the service account for {0} on {1}. Message {2}
     UnknownServiceType = Unknown or unsupported service type '{0}' specified!
     NotInstanceAware = Service type '{0}' is not instance aware.
+    MissingParameter = Missing parameter detected for '{0}'!
 '@

--- a/DSCResources/MSFT_SqlSetup/MSFT_SqlSetup.psm1
+++ b/DSCResources/MSFT_SqlSetup/MSFT_SqlSetup.psm1
@@ -190,6 +190,29 @@ function Get-TargetResource
 
         $databaseServer = Connect-SQL -ServerName $sqlHostName -InstanceName $InstanceName
 
+        # Retrieve Tempdb database files information
+        if ($sqlVersion -ge 13)
+        {
+            # Tempdb data files count
+            $tempdbPrimaryFilegroup = ($databaseServer.Databases | Where-Object {$_.Name -eq 'tempdb'}).FileGroups | Where-Object {$_.Name -eq 'PRIMARY'}
+            $SqlTempdbFileCount = $tempdbPrimaryFilegroup.Files.Count
+
+            # Tempdb data files size
+            $SqlTempdbFileSize = ($tempdbPrimaryFilegroup.Files.Size | Measure-Object -Average).Average / 1Kb
+            
+            # Tempdb data files growth
+            $SqlTempdbFileGrowth = ($tempdbPrimaryFilegroup.Files.Growth | Measure-Object -Average).Average / 1Kb
+            
+            # Tempdb log file size
+            $tempdbTempLog = ($databaseServer.Databases | Where-Object {$_.Name -eq 'tempdb'}).LogFiles | Where-Object {$_.Name -eq 'templog'}
+            $SqlTempdbLogFileSize = $tempdbTempLog.Size / 1Kb
+            
+            # Tempdb log file growth
+            $SqlTempdbLogFileGrowth = $tempdbTempLog.Growth / 1Kb
+        }
+
+
+
         $sqlCollation = $databaseServer.Collation
 
         $sqlSystemAdminAccounts = @()
@@ -501,6 +524,11 @@ function Get-TargetResource
         SQLUserDBLogDir = $sqlUserDatabaseLogDirectory
         SQLTempDBDir = $null
         SQLTempDBLogDir = $null
+        SqlTempdbFileCount = $SqlTempdbFileCount
+        SqlTempdbFileSize = $SqlTempdbFileSize
+        SqlTempdbFileGrowth = $SqlTempdbFileGrowth
+        SqlTempdbLogFileSize = $SqlTempdbLogFileSize
+        SqlTempdbLogFileGrowth = $SqlTempdbLogFileGrowth
         SQLBackupDir = $sqlBackupDirectory
         FTSvcAccountUsername = $fullTextServiceAccountUsername
         RSSvcAccountUsername = $reportingServiceAccountUsername
@@ -687,6 +715,21 @@ function Get-TargetResource
 
     .PARAMETER FailoverClusterNetworkName
         Host name to be assigned to the clustered SQL Server instance.
+
+    .PARAMETER SqlTempdbFileCount
+        Specifies the number of tempdb data files to be added by setup.
+
+    .PARAMETER SqlTempdbFileSize
+        Specifies the initial size of each tempdb data file in MB.
+
+    .PARAMETER SqlTempdbFileGrowth
+        Specifies the file growth increment of each tempdb data file in MB.
+
+    .PARAMETER SqlTempdbLogFileSize
+        Specifies the initial size of each tempdb log file in MB.
+
+    .PARAMETER SqlTempdbLogFileGrowth
+        Specifies the file growth increment of each tempdb data file in MB.
 
     .PARAMETER SetupProcessTimeout
         The timeout, in seconds, to wait for the setup process to finish. Default value is 7200 seconds (2 hours). If the setup process does not finish before this time, and error will be thrown.
@@ -910,6 +953,26 @@ function Set-TargetResource
         [Parameter()]
         [System.String]
         $FailoverClusterNetworkName,
+
+        [Parameter()]
+        [System.UInt32]
+        $SqlTempdbFileCount,
+
+        [Parameter()]
+        [System.UInt32]
+        $SqlTempdbFileSize,
+
+        [Parameter()]
+        [System.UInt32]
+        $SqlTempdbFileGrowth,
+
+        [Parameter()]
+        [System.UInt32]
+        $SqlTempdbLogFileSize,
+
+        [Parameter()]
+        [System.UInt32]
+        $SqlTempdbLogFileGrowth,
 
         [Parameter()]
         [System.UInt32]
@@ -1301,6 +1364,36 @@ function Set-TargetResource
                 'SQLTempDBLogDir',
                 'SQLBackupDir'
             )
+        }
+        
+        # tempdb : define SqlTempdbFileCount
+        if($PSBoundParameters.ContainsKey('SqlTempdbFileCount'))
+        {
+            $setupArguments += @{ SqlTempdbFileCount = $SqlTempdbFileCount }
+        }
+        
+        # tempdb : define SqlTempdbFileSize
+        if($PSBoundParameters.ContainsKey('SqlTempdbFileSize'))
+        {
+            $setupArguments += @{ SqlTempdbFileSize = $SqlTempdbFileSize }
+        }
+        
+        # tempdb : define SqlTempdbFileGrowth
+        if($PSBoundParameters.ContainsKey('SqlTempdbFileGrowth'))
+        {
+            $setupArguments += @{ SqlTempdbFileGrowth = $SqlTempdbFileGrowth }
+        }
+        
+        # tempdb : define SqlTempdbLogFileSize
+        if($PSBoundParameters.ContainsKey('SqlTempdbLogFileSize'))
+        {
+            $setupArguments += @{ SqlTempdbLogFileSize = $SqlTempdbLogFileSize }
+        }
+        
+        # tempdb : define SqlTempdbLogFileGrowth
+        if($PSBoundParameters.ContainsKey('SqlTempdbLogFileGrowth'))
+        {
+            $setupArguments += @{ SqlTempdbLogFileGrowth = $SqlTempdbLogFileGrowth }
         }
 
         if ($Action -in @('Install'))
@@ -1727,6 +1820,21 @@ function Set-TargetResource
     .PARAMETER FailoverClusterNetworkName
         Host name to be assigned to the clustered SQL Server instance.
 
+    .PARAMETER SqlTempdbFileCount
+        Specifies the number of tempdb data files to be added by setup.
+
+    .PARAMETER SqlTempdbFileSize
+        Specifies the initial size of each tempdb data file in MB.
+
+    .PARAMETER SqlTempdbFileGrowth
+        Specifies the file growth increment of each tempdb data file in MB.
+
+    .PARAMETER SqlTempdbLogFileSize
+        Specifies the initial size of each tempdb log file in MB.
+
+    .PARAMETER SqlTempdbLogFileGrowth
+        Specifies the file growth increment of each tempdb data file in MB.
+
     .PARAMETER SetupProcessTimeout
         The timeout, in seconds, to wait for the setup process to finish. Default value is 7200 seconds (2 hours). If the setup process does not finish before this time, and error will be thrown.
 #>
@@ -1940,6 +2048,26 @@ function Test-TargetResource
         [Parameter(ParameterSetName = 'ClusterInstall')]
         [System.String]
         $FailoverClusterNetworkName,
+
+        [Parameter()]
+        [System.UInt32]
+        $SqlTempdbFileCount,
+
+        [Parameter()]
+        [System.UInt32]
+        $SqlTempdbFileSize,
+
+        [Parameter()]
+        [System.UInt32]
+        $SqlTempdbFileGrowth,
+
+        [Parameter()]
+        [System.UInt32]
+        $SqlTempdbLogFileSize,
+
+        [Parameter()]
+        [System.UInt32]
+        $SqlTempdbLogFileGrowth,
 
         [Parameter()]
         [System.UInt32]

--- a/DSCResources/MSFT_SqlSetup/MSFT_SqlSetup.psm1
+++ b/DSCResources/MSFT_SqlSetup/MSFT_SqlSetup.psm1
@@ -2250,41 +2250,22 @@ function Get-ServiceAccountParameters
         $ServiceType
     )
 
+    # Get the service account properties
+    $accountParameters = Get-ServiceAccount -ServiceAccount $ServiceAccount
     $parameters = @{}
 
-    switch -Regex ($ServiceAccount.UserName.ToUpper())
-    {
-        '^(?:NT ?AUTHORITY\\)?(SYSTEM|LOCALSERVICE|LOCAL SERVICE|NETWORKSERVICE|NETWORK SERVICE)$'
-        {
-            $parameters = @{
-                "$($ServiceType)SVCACCOUNT" = "NT AUTHORITY\$($Matches[1])"
-            }
-        }
-
-        '^(?:NT SERVICE\\)(.*)$'
-        {
-            $parameters = @{
-                "$($ServiceType)SVCACCOUNT" = "NT SERVICE\$($Matches[1])"
-            }
-        }
-
-        # Testing if account is a Managed Service Account, which ends with '$'.
-        '\$$'
-        {
-            $parameters = @{
-                "$($ServiceType)SVCACCOUNT" = $ServiceAccount.UserName
-            }
-        }
-
-        # Normal local or domain service account.
-        default
-        {
-            $parameters = @{
-                "$($ServiceType)SVCACCOUNT" = $ServiceAccount.UserName
-                "$($ServiceType)SVCPASSWORD" = $ServiceAccount.GetNetworkCredential().Password
-            }
-        }
+    # Assign the service type the account
+    $parameters = @{
+        "$($ServiceType)SVCACCOUNT" = $accountParameters.UserName
     }
+
+    # Check to see if password is null
+    if (![string]::IsNullOrEmpty($accountParameters.Password))
+    {
+        # Add the password to the hashtable
+        $parameters.Add("$($ServiceType)SVCPASSWORD", $accountParameters.Password)
+    }
+
 
     return $parameters
 }

--- a/DSCResources/MSFT_SqlSetup/MSFT_SqlSetup.schema.mof
+++ b/DSCResources/MSFT_SqlSetup/MSFT_SqlSetup.schema.mof
@@ -56,5 +56,10 @@ class MSFT_SqlSetup : OMI_BaseResource
     [Write, Description("The name of the resource group to create for the clustered SQL Server instance. Default is 'SQL Server (InstanceName)'.")] String FailoverClusterGroupName;
     [Write, Description("Array of IP Addresses to be assigned to the clustered SQL Server instance.")] String FailoverClusterIPAddress[];
     [Write, Description("Host name to be assigned to the clustered SQL Server instance.")] String FailoverClusterNetworkName;
+    [Write, Description("Specifies the number of tempdb data files to be added by setup.")] UInt32 SqlTempdbFileCount;
+    [Write, Description("Specifies the initial size of each tempdb data file in MB.")] UInt32 SqlTempdbFileSize;
+    [Write, Description("Specifies the file growth increment of each tempdb data file in MB.")] UInt32 SqlTempdbFileGrowth;
+    [Write, Description("Specifies the initial size of each tempdb log file in MB.")] UInt32 SqlTempdbLogFileSize;
+    [Write, Description("Specifies the file growth increment of each tempdb data file in MB.")] UInt32 SqlTempdbLogFileGrowth;
     [Write, Description("The timeout, in seconds, to wait for the setup process to finish. Default value is 7200 seconds (2 hours). If the setup process does not finish before this time, and error will be thrown.")] UInt32 SetupProcessTimeout;
 };

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -9,6 +9,7 @@ These are the links to the examples for each individual resource.
 
 - [SqlAG](Resources/SqlAG)
 - [SqlAGDatabase](Resources/SqlAGDatabase)
+- [SqlAgentOperator](Resources/SqlAgentOperator)
 - [SqlAGListener](Resources/SqlAGListener)
 - [SqlAGReplica](Resources/SqlAGReplica)
 - [SqlAlias](Resources/SqlAlias)

--- a/Examples/Resources/SqlAgentOperator/1-AddOperator.ps1
+++ b/Examples/Resources/SqlAgentOperator/1-AddOperator.ps1
@@ -1,0 +1,21 @@
+<#
+    .EXAMPLE
+        This example shows how to ensure that the SQL Agent Operator
+        DbaTeam exists with the correct email address.
+#>
+
+Configuration Example
+{
+
+    Import-DscResource -ModuleName SqlServerDsc
+
+    node localhost {
+        SqlAgentOperator Add_DbaTeam {
+            Ensure               = 'Present'
+            Name                 = 'DbaTeam'
+            ServerName           = 'TestServer'
+            InstanceName         = 'MSSQLServer'
+            EmailAddress         = 'dbateam@company.com'
+        }
+    }
+}

--- a/Examples/Resources/SqlAgentOperator/2-RemoveOperator.ps1
+++ b/Examples/Resources/SqlAgentOperator/2-RemoveOperator.ps1
@@ -1,0 +1,20 @@
+<#
+    .EXAMPLE
+        This example shows how to ensure that the SQL Agent Operator
+        DbaTeam does not exist.
+#>
+
+Configuration Example
+{
+
+    Import-DscResource -ModuleName SqlServerDsc
+
+    node localhost {
+        SqlAgentOperator Remove_DbaTeam {
+            Ensure               = 'Absent'
+            Name                 = 'DbaTeam'
+            ServerName           = 'TestServer'
+            InstanceName         = 'MSSQLServer'
+        }
+    }
+}

--- a/Examples/Resources/SqlServerEndpoint/2-CreateEndpointWithSpecificPortIPAddressOwner.ps1
+++ b/Examples/Resources/SqlServerEndpoint/2-CreateEndpointWithSpecificPortIPAddressOwner.ps1
@@ -1,6 +1,6 @@
 <#
     .EXAMPLE
-        This example will add a Database Mirror endpoint with a specific listener port and a specific listener IP address.
+        This example will add a Database Mirror endpoint with specific listener port, listener IP address and owner.
 #>
 Configuration Example
 {
@@ -22,6 +22,7 @@ Configuration Example
             EndpointName         = 'HADR'
             Port                 = 9001
             IpAddress            = '192.168.0.20'
+            Owner                = 'sa'
 
             ServerName           = 'server1.company.local'
             InstanceName         = 'INST1'

--- a/Examples/Resources/SqlSetup/7-InstallDefaultInstanceSingleServer2016OrLater.ps1
+++ b/Examples/Resources/SqlSetup/7-InstallDefaultInstanceSingleServer2016OrLater.ps1
@@ -2,10 +2,13 @@
     .EXAMPLE
         This example shows how to install a default instance of SQL Server, and
         Analysis Services in Tabular mode, on a single server.
+        It contains configurations that apply to Sql Server 2016 or later only.
+
     .NOTES
         SQL Server setup is run using the SYSTEM account. Even if SetupCredential is provided
         it is not used to install SQL Server at this time (see issue #139).
 #>
+
 Configuration Example
 {
     [CmdletBinding()]
@@ -80,6 +83,11 @@ Configuration Example
             SourcePath             = 'C:\InstallMedia\SQL2016RTM'
             UpdateEnabled          = 'False'
             ForceReboot            = $false
+            SqlTempdbFileCount     = 4
+            SqlTempdbFileSize      = 1024
+            SqlTempdbFileGrowth    = 512
+            SqlTempdbLogFileSize   = 128
+            SqlTempdbLogFileGrowth = 64
 
             PsDscRunAsCredential = $SqlInstallCredential
 

--- a/README.md
+++ b/README.md
@@ -1041,11 +1041,13 @@ the resource [**SqlServerEndpointPermission**](#sqlserverendpointpermission).
 * **`[String]` InstanceName** _(Key)_: The name of the SQL instance to be configured.
 * **`[String]` IpAddress** _(Write)_: The network IP address the endpoint is listening
   on. Defaults to '0.0.0.0' which means listen on any valid IP address.
+* **`[String]` Owner** _(Write)_: The owner of the endpoint. Default is the
+  login used for the creation.
 
 #### Examples
 
 * [Create an endpoint with default values](/Examples/Resources/SqlServerEndpoint/1-CreateEndpointWithDefaultValues.ps1)
-* [Create an endpoint with specific port and IP address](/Examples/Resources/SqlServerEndpoint/2-CreateEndpointWithSpecificPortAndIPAddress.ps1)
+* [Create an endpoint with specific port and IP address](/Examples/Resources/SqlServerEndpoint/2-CreateEndpointWithSpecificPortIPAddressOwner.ps1)
 * [Remove an endpoint](/Examples/Resources/SqlServerEndpoint/3-RemoveEndpoint.ps1)
 
 #### Known issues

--- a/README.md
+++ b/README.md
@@ -1123,6 +1123,9 @@ No description.
 
 * Target machine must be running Windows Server 2008 R2 or later.
 * Target machine must be running SQL Server Database Engine 2008 or later.
+* When the `LoginType` `'SqlLogin'` is used, then the login authentication
+  mode must have been set to `Mixed` or `Normal`. If set to `Integrated`
+  and error will be thrown.
 
 #### Parameters
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ A full list of changes in each version can be found in the [change log](CHANGELO
   resource to ensure an availability group is present or absent.
 * [**SqlAGDatabase**](#sqlagdatabase)
   to manage the database membership in Availability Groups.
+* [**SqlAgentOperator**](#sqlagentoperator)
+  resource to manage SQL Agent Operators.
 * [**SqlAGListener**](#sqlaglistener)
   Create or remove an availability group listener.
 * [**SqlAGReplica**](#sqlagreplica)
@@ -306,6 +308,36 @@ group.
 #### Known issues
 
 All issues are not listed here, see [here for all open issues](https://github.com/PowerShell/SqlServerDsc/issues?q=is%3Aissue+is%3Aopen+in%3Atitle+SqlAGDatabase).
+
+### SqlAgentOperator
+
+This resource is used to add/remove SQL Agent Operators. You can also update
+the operators email address.
+
+#### Requirements
+
+* Target machine must be running Windows Server 2008 R2 or later.
+* Target machine must be running SQL Server Database Engine 2008 or later.
+
+#### Parameters
+
+* **`[String]` Name** _(Key)_: The name of the SQL Agent Operator.
+* **`[String]` Ensure** _(Write)_: Specifies if the SQL Agent Operator should
+  be present or absent. Default is Present. { *Present* | Absent }
+* **`[String]` ServerName** _(Key)_: The host name of the SQL Server to be
+  configured. Default is $env:COMPUTERNAME.
+* **`[String]` InstanceName** _(Key)_: The name of the SQL instance to be configured.
+* **`[String]` EmailAddress** _(Write)_: The email address to be used for
+  the SQL Agent Operator.
+
+#### Examples
+
+* [Add a SQL Agent Operator](/Examples/Resources/SqlAgentOperator/1-AddOperator.ps1)
+* [Remove a SQL Agent Operator](/Examples/Resources/SqlAgentOperator/2-RemoveOperator.ps1)
+
+#### Known issues
+
+All issues are not listed here, see [here for all open issues](https://github.com/PowerShell/SqlServerDsc/issues?q=is%3Aissue+is%3Aopen+in%3Atitle+SqlAgentOperator).
 
 ### SqlAGListener
 
@@ -1534,7 +1566,7 @@ Manage the service account for SQL Server services.
   each consecutive run.
 * **`[String]` VersionNumber** (Write): The version number of the SQL Server,
   mandatory for when IntegrationServices is used as **ServiceType**.
-  Eg. 130 for SQL 2016.  
+  Eg. 130 for SQL 2016.
 
 #### Read-Only Properties from Get-TargetResource
 

--- a/README.md
+++ b/README.md
@@ -1574,6 +1574,13 @@ Installs SQL Server on the target node.
   * Additional parameters need when installing Analysis Services.
     * ASSysAdminAccounts
     * AsSvcAccount
+* The parameters below can only be used when installing SQL Server 2016 or
+  later:
+  * SqlTempdbFileCount
+  * SqlTempdbFileSize
+  * SqlTempdbFileGrowth
+  * SqlTempdbLogFileSize
+  * SqlTempdbLogFileGrowth
 
 > **Note:** It is not possible to add or remove features to a SQL Server failover
 cluster. This is a limitation of SQL Server. See article
@@ -1706,6 +1713,16 @@ need a '*SVCPASSWORD' argument in the setup arguments.
   this setup parameter.
 * **`[String]` FailoverClusterNetworkName** _(Write)_: Host name to be assigned to
   the clustered SQL Server instance.
+* **`[UInt32]` SqlTempdbFileCount** _(Write)_: Specifies the number of tempdb
+  data files to be added by setup.
+* **`[UInt32]` SqlTempdbFileSize** _(Write)_: Specifies the initial size of
+  each tempdb data file in MB.
+* **`[UInt32]` SqlTempdbFileGrowth** _(Write)_: Specifies the file growth
+  increment of each tempdb data file in MB.
+* **`[UInt32]` SqlTempdbLogFileSize** _(Write)_: Specifies the initial size
+  of each tempdb log file in MB.
+* **`[UInt32]` SqlTempdbLogFileGrowth** _(Write)_: Specifies the file growth
+  increment of each tempdb data file in MB.
 * **`[UInt32]` SetupProcessTimeout** _(Write)_: The timeout, in seconds, to wait
   for the setup process to finish. Default value is 7200 seconds (2 hours). If
   the setup process does not finish before this time, and error will be thrown.
@@ -1732,6 +1749,7 @@ need a '*SVCPASSWORD' argument in the setup arguments.
 * [Install a named instance as the first node in SQL Server Failover Cluster](/Examples/Resources/SqlSetup/4-InstallNamedInstanceInFailoverClusterFirstNode.ps1)
 * [Install a named instance as the second node in SQL Server Failover Cluster](/Examples/Resources/SqlSetup/5-InstallNamedInstanceInFailoverClusterSecondNode.ps1)
 * [Install a named instance with the Agent Service set to Disabled](/Examples/Resources/SqlSetup/6-InstallNamedInstanceSingleServerWithAgtSvcStartupTypeDisabled.ps1)
+* [Install a default instance on a single server (Sql Server 2016 or Later)](/Examples/Resources/SqlSetup/7-InstallDefaultInstanceSingleServer2016OrLater.ps1)
 
 #### Known issues
 

--- a/README.md
+++ b/README.md
@@ -1527,6 +1527,9 @@ Manage the service account for SQL Server services.
 * **`[Boolean]` Force** (Write): Forces the service account to be updated.
   Useful for password changes. This will cause `Set-TargetResource` to be run on
   each consecutive run.
+* **`[String]` VersionNumber** (Write): The version number of the SQL Server,
+  mandatory for when IntegrationServices is used as **ServiceType**.
+  Eg. 130 for SQL 2016.  
 
 #### Read-Only Properties from Get-TargetResource
 

--- a/Tests/Integration/MSFT_SqlAgentOperator.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlAgentOperator.Integration.Tests.ps1
@@ -2,21 +2,16 @@
 [Microsoft.DscResourceKit.IntegrationTest(OrderNumber = 2)]
 param()
 
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
+if (Test-SkipContinuousIntegrationTask -Type 'Integration')
+{
+    return
+}
+
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceFriendlyName = 'SqlAgentOperator'
 $script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
-
-if (-not $env:APPVEYOR -eq $true)
-{
-    Write-Warning -Message ('Integration test for {0} will be skipped unless $env:APPVEYOR equals $true' -f $script:DSCResourceName)
-    return
-}
-
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
-{
-    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
-    return
-}
 
 #region HEADER
 # Integration Test Template Version: 1.1.2

--- a/Tests/Integration/MSFT_SqlAgentOperator.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlAgentOperator.Integration.Tests.ps1
@@ -9,51 +9,43 @@ if (Test-SkipContinuousIntegrationTask -Type 'Integration')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceFriendlyName = 'SqlAgentOperator'
-$script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceFriendlyName = 'SqlAgentOperator'
+$script:dscResourceName = "MSFT_$($script:dscResourceFriendlyName)"
 
-#region HEADER
-# Integration Test Template Version: 1.1.2
-[System.String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+##region HEADER
+# Integration Test Template Version: 1.3.2
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DscResource.Tests'))
 }
 
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Integration
-
 #endregion
 
-$mockSqlInstallAccountPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
-$mockSqlInstallAccountUserName = "$env:COMPUTERNAME\SqlInstall"
-$mockSqlInstallCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlInstallAccountUserName, $mockSqlInstallAccountPassword
-
+# Using try/finally to always cleanup.
 try
 {
-    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
+    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dscResourceName).config.ps1"
     . $configFile
 
-    $mockName = $ConfigurationData.AllNodes.Name
-    $mockEmailAddress = $ConfigurationData.AllNodes.EmailAddress
-
-    Describe "$($script:DSCResourceName)_Integration" {
+    Describe "$($script:dscResourceName)_Integration" {
         BeforeAll {
-            $resourceId = "[$($script:DSCResourceFriendlyName)]Integration_Test"
+            $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
         }
 
-        $configurationName = "$($script:DSCResourceName)_Add_Config"
+        $configurationName = "$($script:dscResourceName)_Add_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlInstallCredential = $mockSqlInstallCredential
                         OutputPath           = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData    = $ConfigurationData
@@ -82,24 +74,26 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
                 $resourceCurrentState.Ensure | Should -Be 'Present'
-                $resourceCurrentState.Name | Should -Be $mockName
-                $resourceCurrentState.EmailAddress | Should -Be $mockEmailAddress
+                $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.Name
+                $resourceCurrentState.EmailAddress | Should -Be $ConfigurationData.AllNodes.EmailAddress
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
             }
         }
 
-        $configurationName = "$($script:DSCResourceName)_Remove_Config"
+        $configurationName = "$($script:dscResourceName)_Remove_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlInstallCredential = $mockSqlInstallCredential
                         OutputPath           = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData    = $ConfigurationData
@@ -128,14 +122,17 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
                 $resourceCurrentState.Ensure | Should -Be 'Absent'
                 $resourceCurrentState.Name | Should -BeNullOrEmpty
                 $resourceCurrentState.EmailAddress | Should -BeNullOrEmpty
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
             }
         }
     }

--- a/Tests/Integration/MSFT_SqlAgentOperator.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlAgentOperator.Integration.Tests.ps1
@@ -1,0 +1,155 @@
+# This is used to make sure the integration test run in the correct order.
+[Microsoft.DscResourceKit.IntegrationTest(OrderNumber = 2)]
+param()
+
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceFriendlyName = 'SqlAgentOperator'
+$script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
+
+if (-not $env:APPVEYOR -eq $true)
+{
+    Write-Warning -Message ('Integration test for {0} will be skipped unless $env:APPVEYOR equals $true' -f $script:DSCResourceName)
+    return
+}
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
+{
+    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
+    return
+}
+
+#region HEADER
+# Integration Test Template Version: 1.1.2
+[System.String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))
+}
+
+Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Integration
+
+#endregion
+
+$mockSqlInstallAccountPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
+$mockSqlInstallAccountUserName = "$env:COMPUTERNAME\SqlInstall"
+$mockSqlInstallCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlInstallAccountUserName, $mockSqlInstallAccountPassword
+
+try
+{
+    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
+    . $configFile
+
+    $mockName = $ConfigurationData.AllNodes.Name
+    $mockEmailAddress = $ConfigurationData.AllNodes.EmailAddress
+
+    Describe "$($script:DSCResourceName)_Integration" {
+        BeforeAll {
+            $resourceId = "[$($script:DSCResourceFriendlyName)]Integration_Test"
+        }
+
+        $configurationName = "$($script:DSCResourceName)_Add_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        SqlInstallCredential = $mockSqlInstallCredential
+                        OutputPath           = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData    = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName
+                } | Where-Object -FilterScript {
+                    $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.Ensure | Should -Be 'Present'
+                $resourceCurrentState.Name | Should -Be $mockName
+                $resourceCurrentState.EmailAddress | Should -Be $mockEmailAddress
+            }
+        }
+
+        $configurationName = "$($script:DSCResourceName)_Remove_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        SqlInstallCredential = $mockSqlInstallCredential
+                        OutputPath           = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData    = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName
+                } | Where-Object -FilterScript {
+                    $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.Ensure | Should -Be 'Absent'
+                $resourceCurrentState.Name | Should -BeNullOrEmpty
+                $resourceCurrentState.EmailAddress | Should -BeNullOrEmpty
+            }
+        }
+    }
+}
+finally
+{
+    #region FOOTER
+
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+
+    #endregion
+}

--- a/Tests/Integration/MSFT_SqlAgentOperator.config.ps1
+++ b/Tests/Integration/MSFT_SqlAgentOperator.config.ps1
@@ -1,0 +1,68 @@
+$ConfigurationData = @{
+    AllNodes = @(
+        @{
+            NodeName        = 'localhost'
+            ServerName      = $env:COMPUTERNAME
+            InstanceName    = 'DSCSQL2016'
+
+            Name            = 'MyOperator'
+            EmailAddress    = 'MyEmail@company.local'
+
+            CertificateFile = $env:DscPublicCertificatePath
+        }
+    )
+}
+
+Configuration MSFT_SqlAgentOperator_Add_Config
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SqlInstallCredential
+    )
+
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node localhost {
+        SqlAgentOperator 'Integration_Test'
+        {
+            Ensure               = 'Present'
+            ServerName           = $Node.ServerName
+            InstanceName         = $Node.InstanceName
+            Name                 = $Node.Name
+            EmailAddress         = $Node.EmailAddress
+
+            PsDscRunAsCredential = $SqlInstallCredential
+        }
+    }
+}
+
+Configuration MSFT_SqlAgentOperator_Remove_Config
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SqlInstallCredential
+    )
+
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node localhost {
+        SqlAgentOperator 'Integration_Test'
+        {
+            Ensure               = 'Absent'
+            ServerName           = $Node.ServerName
+            InstanceName         = $Node.InstanceName
+            Name                 = $Node.Name
+            EmailAddress         = $Node.EmailAddress
+
+            PsDscRunAsCredential = $SqlInstallCredential
+        }
+    }
+}
+
+

--- a/Tests/Integration/MSFT_SqlAlwaysOnService.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlAlwaysOnService.Integration.Tests.ps1
@@ -12,6 +12,12 @@ if (-not $env:APPVEYOR -eq $true)
     return
 }
 
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
+{
+    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
+    return
+}
+
 #region HEADER
 # Integration Test Template Version: 1.1.2
 [System.String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
@@ -28,8 +34,6 @@ $TestEnvironment = Initialize-TestEnvironment `
     -TestType Integration
 
 #endregion
-
-$script:integrationErrorMessagePrefix = 'INTEGRATION ERROR MESSAGE:'
 
 $testRootFolderPath = Split-Path -Path $PSScriptRoot -Parent
 Import-Module -Name (Join-Path -Path $testRootFolderPath -ChildPath (Join-Path -Path 'TestHelpers' -ChildPath 'CommonTestHelper.psm1')) -Force
@@ -82,15 +86,7 @@ try
                         ErrorAction = 'Stop'
                     }
 
-                    try
-                    {
-                        Start-DscConfiguration @startDscConfigurationParameters
-                    }
-                    catch
-                    {
-                        Write-Verbose -Message ('{0} {1}' -f $script:integrationErrorMessagePrefix, $_) -Verbose
-                        throw $_
-                    }
+                    Start-DscConfiguration @startDscConfigurationParameters
                 } | Should -Not -Throw
             }
         }
@@ -118,15 +114,7 @@ try
                         ErrorAction = 'Stop'
                     }
 
-                    try
-                    {
-                        Start-DscConfiguration @startDscConfigurationParameters
-                    }
-                    catch
-                    {
-                        Write-Verbose -Message ('{0} {1}' -f $script:integrationErrorMessagePrefix, $_) -Verbose
-                        throw $_
-                    }
+                    Start-DscConfiguration @startDscConfigurationParameters
                 } | Should -Not -Throw
             }
 
@@ -170,15 +158,7 @@ try
                         ErrorAction = 'Stop'
                     }
 
-                    try
-                    {
-                        Start-DscConfiguration @startDscConfigurationParameters
-                    }
-                    catch
-                    {
-                        Write-Verbose -Message ('{0} {1}' -f $script:integrationErrorMessagePrefix, $_) -Verbose
-                        throw $_
-                    }
+                    Start-DscConfiguration @startDscConfigurationParameters
                 } | Should -Not -Throw
             }
 
@@ -221,15 +201,7 @@ try
                         ErrorAction = 'Stop'
                     }
 
-                    try
-                    {
-                        Start-DscConfiguration @startDscConfigurationParameters
-                    }
-                    catch
-                    {
-                        Write-Verbose -Message ('{0} {1}' -f $script:integrationErrorMessagePrefix, $_) -Verbose
-                        throw $_
-                    }
+                    Start-DscConfiguration @startDscConfigurationParameters
                 } | Should -Not -Throw
             }
         }

--- a/Tests/Integration/MSFT_SqlAlwaysOnService.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlAlwaysOnService.Integration.Tests.ps1
@@ -2,21 +2,16 @@
 [Microsoft.DscResourceKit.IntegrationTest(OrderNumber = 2)]
 param()
 
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
+if (Test-SkipContinuousIntegrationTask -Type 'Integration')
+{
+    return
+}
+
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceFriendlyName = 'SqlAlwaysOnService'
 $script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
-
-if (-not $env:APPVEYOR -eq $true)
-{
-    Write-Warning -Message ('Integration test for {0} will be skipped unless $env:APPVEYOR equals $true' -f $script:DSCResourceName)
-    return
-}
-
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
-{
-    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
-    return
-}
 
 #region HEADER
 # Integration Test Template Version: 1.1.2

--- a/Tests/Integration/MSFT_SqlAlwaysOnService.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlAlwaysOnService.Integration.Tests.ps1
@@ -9,37 +9,30 @@ if (Test-SkipContinuousIntegrationTask -Type 'Integration')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceFriendlyName = 'SqlAlwaysOnService'
-$script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceFriendlyName = 'SqlAlwaysOnService'
+$script:dscResourceName = "MSFT_$($script:dscResourceFriendlyName)"
 
 #region HEADER
-# Integration Test Template Version: 1.1.2
-[System.String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+# Integration Test Template Version: 1.3.2
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DscResource.Tests'))
 }
 
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Integration
-
 #endregion
 
-$testRootFolderPath = Split-Path -Path $PSScriptRoot -Parent
-Import-Module -Name (Join-Path -Path $testRootFolderPath -ChildPath (Join-Path -Path 'TestHelpers' -ChildPath 'CommonTestHelper.psm1')) -Force
-
-$mockSqlInstallAccountPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
-$mockSqlInstallAccountUserName = "$env:COMPUTERNAME\SqlInstall"
-$mockSqlInstallCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlInstallAccountUserName, $mockSqlInstallAccountPassword
-
+# Using try/finally to always cleanup.
 try
 {
-    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
+    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dscResourceName).config.ps1"
     . $configFile
 
     # These sets variables used for verification from the dot-sourced $ConfigurationData variable.
@@ -54,12 +47,12 @@ try
     #>
     New-IntegrationLoopbackAdapter -AdapterName $mockLoopbackAdapterName
 
-    Describe "$($script:DSCResourceName)_Integration" {
+    Describe "$($script:dscResourceName)_Integration" {
         BeforeAll {
-            $resourceId = "[$($script:DSCResourceFriendlyName)]Integration_Test"
+            $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
         }
 
-        $configurationName = "$($script:DSCResourceName)_CreateDependencies_Config"
+        $configurationName = "$($script:dscResourceName)_CreateDependencies_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
@@ -86,13 +79,12 @@ try
             }
         }
 
-        $configurationName = "$($script:DSCResourceName)_EnableAlwaysOn_Config"
+        $configurationName = "$($script:dscResourceName)_EnableAlwaysOn_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlInstallCredential = $mockSqlInstallCredential
                         OutputPath = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData = $ConfigurationData
@@ -121,22 +113,24 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
                 $resourceCurrentState.IsHadrEnabled | Should -Be $true
             }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
+            }
         }
 
-        $configurationName = "$($script:DSCResourceName)_DisableAlwaysOn_Config"
+        $configurationName = "$($script:dscResourceName)_DisableAlwaysOn_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlInstallCredential = $mockSqlInstallCredential
                         OutputPath = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData = $ConfigurationData
@@ -165,16 +159,19 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
                 $resourceCurrentState.IsHadrEnabled | Should -Be $false
             }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
+            }
         }
 
-        $configurationName = "$($script:DSCResourceName)_CleanupDependencies_Config"
+        $configurationName = "$($script:dscResourceName)_CleanupDependencies_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
@@ -205,8 +202,6 @@ try
 finally
 {
     #region FOOTER
-
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
-
     #endregion
 }

--- a/Tests/Integration/MSFT_SqlDatabaseDefaultLocation.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlDatabaseDefaultLocation.Integration.Tests.ps1
@@ -2,21 +2,16 @@
 [Microsoft.DscResourceKit.IntegrationTest(OrderNumber = 2)]
 param()
 
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
+if (Test-SkipContinuousIntegrationTask -Type 'Integration')
+{
+    return
+}
+
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceFriendlyName = 'SqlDatabaseDefaultLocation'
 $script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
-
-if (-not $env:APPVEYOR -eq $true)
-{
-    Write-Warning -Message ('Integration test for {0} will be skipped unless $env:APPVEYOR equals $true' -f $script:DSCResourceName)
-    return
-}
-
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
-{
-    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
-    return
-}
 
 #region HEADER
 # Integration Test Template Version: 1.1.2

--- a/Tests/Integration/MSFT_SqlDatabaseDefaultLocation.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlDatabaseDefaultLocation.Integration.Tests.ps1
@@ -12,6 +12,12 @@ if (-not $env:APPVEYOR -eq $true)
     return
 }
 
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
+{
+    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
+    return
+}
+
 #region HEADER
 # Integration Test Template Version: 1.1.2
 [System.String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)

--- a/Tests/Integration/MSFT_SqlDatabaseDefaultLocation.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlDatabaseDefaultLocation.Integration.Tests.ps1
@@ -9,49 +9,44 @@ if (Test-SkipContinuousIntegrationTask -Type 'Integration')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceFriendlyName = 'SqlDatabaseDefaultLocation'
-$script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceFriendlyName = 'SqlDatabaseDefaultLocation'
+$script:dscResourceName = "MSFT_$($script:dscResourceFriendlyName)"
 
 #region HEADER
-# Integration Test Template Version: 1.1.2
-[System.String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+# Integration Test Template Version: 1.3.2
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DscResource.Tests'))
 }
 
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Integration
-
 #endregion
 
-$mockSqlInstallAccountPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
-$mockSqlInstallAccountUserName = "$env:COMPUTERNAME\SqlInstall"
-$mockSqlInstallCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlInstallAccountUserName, $mockSqlInstallAccountPassword
-
+# Using try/finally to always cleanup.
 try
 {
-    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
+    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dscResourceName).config.ps1"
     . $configFile
 
-    Describe "$($script:DSCResourceName)_Integration" {
+    Describe "$($script:dscResourceName)_Integration" {
         BeforeAll {
-            $resourceId = "[$($script:DSCResourceFriendlyName)]Integration_Test"
+            $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
         }
 
-        $configurationName = "$($script:DSCResourceName)_Data_Config"
+        $configurationName = "$($script:dscResourceName)_Data_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlInstallCredential = $mockSqlInstallCredential
-                        OutputPath = $TestDrive
+                        OutputPath        = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData = $ConfigurationData
                     }
@@ -59,12 +54,12 @@ try
                     & $configurationName @configurationParameters
 
                     $startDscConfigurationParameters = @{
-                        Path = $TestDrive
+                        Path         = $TestDrive
                         ComputerName = 'localhost'
-                        Wait = $true
-                        Verbose = $true
-                        Force = $true
-                        ErrorAction = 'Stop'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
                     }
 
                     Start-DscConfiguration @startDscConfigurationParameters
@@ -79,24 +74,26 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
                 $resourceCurrentState.Type | Should -Be 'Data'
                 ( Join-Path -Path $resourceCurrentState.Path -ChildPath '' ) | Should -Be ( Join-Path -Path $ConfigurationData.AllNodes.DataFilePath -ChildPath '' )
             }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
+            }
         }
 
-        $configurationName = "$($script:DSCResourceName)_Log_Config"
+        $configurationName = "$($script:dscResourceName)_Log_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlInstallCredential = $mockSqlInstallCredential
-                        OutputPath = $TestDrive
+                        OutputPath        = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData = $ConfigurationData
                     }
@@ -104,12 +101,12 @@ try
                     & $configurationName @configurationParameters
 
                     $startDscConfigurationParameters = @{
-                        Path = $TestDrive
+                        Path         = $TestDrive
                         ComputerName = 'localhost'
-                        Wait = $true
-                        Verbose = $true
-                        Force = $true
-                        ErrorAction = 'Stop'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
                     }
 
                     Start-DscConfiguration @startDscConfigurationParameters
@@ -124,24 +121,26 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
                 $resourceCurrentState.Type | Should -Be 'Log'
                 ( Join-Path -Path $resourceCurrentState.Path -ChildPath '' ) | Should -Be ( Join-Path -Path $ConfigurationData.AllNodes.LogFilePath -ChildPath '' )
             }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
+            }
         }
 
-        $configurationName = "$($script:DSCResourceName)_Backup_Config"
+        $configurationName = "$($script:dscResourceName)_Backup_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlInstallCredential = $mockSqlInstallCredential
-                        OutputPath = $TestDrive
+                        OutputPath        = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData = $ConfigurationData
                     }
@@ -149,12 +148,12 @@ try
                     & $configurationName @configurationParameters
 
                     $startDscConfigurationParameters = @{
-                        Path = $TestDrive
+                        Path         = $TestDrive
                         ComputerName = 'localhost'
-                        Wait = $true
-                        Verbose = $true
-                        Force = $true
-                        ErrorAction = 'Stop'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
                     }
 
                     Start-DscConfiguration @startDscConfigurationParameters
@@ -169,13 +168,16 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
                 $resourceCurrentState.Type | Should -Be 'Backup'
                 ( Join-Path -Path $resourceCurrentState.Path -ChildPath '' ) | Should -Be ( Join-Path -Path $ConfigurationData.AllNodes.BackupFilePath -ChildPath '' )
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
             }
         }
     }
@@ -183,8 +185,6 @@ try
 finally
 {
     #region FOOTER
-
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
-
     #endregion
 }

--- a/Tests/Integration/MSFT_SqlRS.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlRS.Integration.Tests.ps1
@@ -2,21 +2,16 @@
 [Microsoft.DscResourceKit.IntegrationTest(OrderNumber = 2)]
 param()
 
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
+if (Test-SkipContinuousIntegrationTask -Type 'Integration')
+{
+    return
+}
+
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceFriendlyName = 'SqlRS'
 $script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
-
-if (-not $env:APPVEYOR -eq $true)
-{
-    Write-Warning -Message ('Integration test for {0} will be skipped unless $env:APPVEYOR equals $true' -f $script:DSCResourceName)
-    return
-}
-
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
-{
-    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
-    return
-}
 
 #region HEADER
 # Integration Test Template Version: 1.1.2

--- a/Tests/Integration/MSFT_SqlRS.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlRS.Integration.Tests.ps1
@@ -12,6 +12,12 @@ if (-not $env:APPVEYOR -eq $true)
     return
 }
 
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
+{
+    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
+    return
+}
+
 #region HEADER
 # Integration Test Template Version: 1.1.2
 [System.String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
@@ -27,7 +33,6 @@ $TestEnvironment = Initialize-TestEnvironment `
     -DSCResourceName $script:DSCResourceName `
     -TestType Integration
 
-$script:integrationErrorMessagePrefix = 'INTEGRATION ERROR MESSAGE:'
 #endregion
 
 $mockSqlInstallAccountPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
@@ -76,15 +81,7 @@ try
                         ErrorAction  = 'Stop'
                     }
 
-                    try
-                    {
-                        Start-DscConfiguration @startDscConfigurationParameters
-                    }
-                    catch
-                    {
-                        Write-Verbose -Message ('{0} {1}' -f $integrationErrorMessagePrefix, $_) -Verbose
-                        throw $_
-                    }
+                    Start-DscConfiguration @startDscConfigurationParameters
                 } | Should -Not -Throw
             }
         }
@@ -112,15 +109,7 @@ try
                         ErrorAction  = 'Stop'
                     }
 
-                    try
-                    {
-                        Start-DscConfiguration @startDscConfigurationParameters
-                    }
-                    catch
-                    {
-                        Write-Verbose -Message ('{0} {1}' -f $integrationErrorMessagePrefix, $_) -Verbose
-                        throw $_
-                    }
+                    Start-DscConfiguration @startDscConfigurationParameters
                 } | Should -Not -Throw
             }
 
@@ -212,15 +201,7 @@ try
                         ErrorAction  = 'Stop'
                     }
 
-                    try
-                    {
-                        Start-DscConfiguration @startDscConfigurationParameters
-                    }
-                    catch
-                    {
-                        Write-Verbose -Message ('{0} {1}' -f $integrationErrorMessagePrefix, $_) -Verbose
-                        throw $_
-                    }
+                    Start-DscConfiguration @startDscConfigurationParameters
                 } | Should -Not -Throw
             }
 
@@ -276,15 +257,7 @@ try
                         ErrorAction  = 'Stop'
                     }
 
-                    try
-                    {
-                        Start-DscConfiguration @startDscConfigurationParameters
-                    }
-                    catch
-                    {
-                        Write-Verbose -Message ('{0} {1}' -f $integrationErrorMessagePrefix, $_) -Verbose
-                        throw $_
-                    }
+                    Start-DscConfiguration @startDscConfigurationParameters
                 } | Should -Not -Throw
             }
 
@@ -349,15 +322,7 @@ try
                         ErrorAction  = 'Stop'
                     }
 
-                    try
-                    {
-                        Start-DscConfiguration @startDscConfigurationParameters
-                    }
-                    catch
-                    {
-                        Write-Verbose -Message ('{0} {1}' -f $integrationErrorMessagePrefix, $_) -Verbose
-                        throw $_
-                    }
+                    Start-DscConfiguration @startDscConfigurationParameters
                 } | Should -Not -Throw
             }
         }

--- a/Tests/Integration/MSFT_SqlRS.config.ps1
+++ b/Tests/Integration/MSFT_SqlRS.config.ps1
@@ -1,51 +1,66 @@
-# Get a spare drive letter
-$mockLastDrive = ((Get-Volume).DriveLetter | Sort-Object | Select-Object -Last 1)
-$mockIsoMediaDriveLetter = [char](([int][char]$mockLastDrive) + 1)
+#region HEADER
+# Integration Test Config Template Version: 1.2.0
+#endregion
 
-$ConfigurationData = @{
-    AllNodes = @(
-        @{
-            NodeName             = 'localhost'
+$configFile = [System.IO.Path]::ChangeExtension($MyInvocation.MyCommand.Path, 'json')
+if (Test-Path -Path $configFile)
+{
+    <#
+        Allows reading the configuration data from a JSON file,
+        for real testing scenarios outside of the CI.
+    #>
+    $ConfigurationData = Get-Content -Path $configFile | ConvertFrom-Json
+}
+else
+{
+    # Get a spare drive letter
+    $mockLastDrive = ((Get-Volume).DriveLetter | Sort-Object | Select-Object -Last 1)
+    $mockIsoMediaDriveLetter = [char](([int][char]$mockLastDrive) + 1)
 
-            InstanceName         = 'DSCRS2016'
-            Features             = 'RS'
-            InstallSharedDir     = 'C:\Program Files\Microsoft SQL Server'
-            InstallSharedWOWDir  = 'C:\Program Files (x86)\Microsoft SQL Server'
-            UpdateEnabled        = 'False'
-            SuppressReboot       = $true # Make sure we don't reboot during testing.
-            ForceReboot          = $false
+    $ConfigurationData = @{
+        AllNodes = @(
+            @{
+                NodeName             = 'localhost'
 
-            ImagePath            = "$env:TEMP\SQL2016.iso"
-            DriveLetter          = $mockIsoMediaDriveLetter
+                RunAs_UserName       = "$env:COMPUTERNAME\SqlInstall"
+                RunAs_Password       = 'P@ssw0rd1'
+                Service_UserName     = "$env:COMPUTERNAME\svc-Reporting"
+                Service_Password     = 'yig-C^Equ3'
 
-            DatabaseServerName   = $env:COMPUTERNAME
-            DatabaseInstanceName = 'DSCSQL2016'
+                InstanceName         = 'DSCRS2016'
+                Features             = 'RS'
+                InstallSharedDir     = 'C:\Program Files\Microsoft SQL Server'
+                InstallSharedWOWDir  = 'C:\Program Files (x86)\Microsoft SQL Server'
+                UpdateEnabled        = 'False'
+                SuppressReboot       = $true # Make sure we don't reboot during testing.
+                ForceReboot          = $false
 
-            CertificateFile      = $env:DscPublicCertificatePath
-        }
-    )
+                ImagePath            = "$env:TEMP\SQL2016.iso"
+                DriveLetter          = $mockIsoMediaDriveLetter
+
+                DatabaseServerName   = $env:COMPUTERNAME
+                DatabaseInstanceName = 'DSCSQL2016'
+
+                CertificateFile      = $env:DscPublicCertificatePath
+            }
+        )
+    }
 }
 
+<#
+    .SYNOPSIS
+        Add dependencies for configuring Reporting Services. Mounts the ISO,
+        create the service account, make sure .NET Framework 4.5 is installed,
+        and installs the Reporting Services,
+#>
 Configuration MSFT_SqlRS_CreateDependencies_Config
 {
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $SqlInstallCredential,
-
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $ReportingServicesServiceCredential
-    )
-
     Import-DscResource -ModuleName 'PSDscResources'
     Import-DscResource -ModuleName 'StorageDsc'
     Import-DscResource -ModuleName 'SqlServerDsc'
 
-    node localhost {
+    node $AllNodes.NodeName
+    {
         MountImage 'MountIsoMedia'
         {
             ImagePath   = $Node.ImagePath
@@ -63,8 +78,10 @@ Configuration MSFT_SqlRS_CreateDependencies_Config
         User 'CreateReportingServicesServiceAccount'
         {
             Ensure   = 'Present'
-            UserName = Split-Path -Path $ReportingServicesServiceCredential.UserName -Leaf
-            Password = $ReportingServicesServiceCredential
+            UserName = Split-Path -Path $Node.Service_UserName -Leaf
+            Password = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Service_UserName, (ConvertTo-SecureString -String $Node.Service_Password -AsPlainText -Force))
         }
 
         WindowsFeature 'NetFramework45'
@@ -79,12 +96,14 @@ Configuration MSFT_SqlRS_CreateDependencies_Config
             Features              = $Node.Features
             SourcePath            = "$($Node.DriveLetter):\"
             BrowserSvcStartupType = 'Automatic'
-            RSSvcAccount          = $ReportingServicesServiceCredential
             InstallSharedDir      = $Node.InstallSharedDir
             InstallSharedWOWDir   = $Node.InstallSharedWOWDir
             UpdateEnabled         = $Node.UpdateEnabled
             SuppressReboot        = $Node.SuppressReboot
             ForceReboot           = $Node.ForceReboot
+            RSSvcAccount          = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Service_UserName, (ConvertTo-SecureString -String $Node.Service_Password -AsPlainText -Force))
 
             DependsOn             = @(
                 '[WaitForVolume]WaitForMountOfIsoMedia'
@@ -92,24 +111,25 @@ Configuration MSFT_SqlRS_CreateDependencies_Config
                 '[WindowsFeature]NetFramework45'
             )
 
-            PsDscRunAsCredential  = $SqlInstallCredential
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @(
+                    $Node.RunAs_UserName, (ConvertTo-SecureString -String $Node.RunAs_Password -AsPlainText -Force))
+
         }
     }
 }
 
+<#
+    .SYNOPSIS
+        Configures the Reporting Services.
+#>
 Configuration MSFT_SqlRS_InstallReportingServices_Config
 {
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $SqlInstallCredential
-    )
-
     Import-DscResource -ModuleName 'SqlServerDsc'
 
-    node localhost {
+    node $AllNodes.NodeName
+    {
         SqlRS 'Integration_Test'
         {
             # Instance name for the Reporting Services.
@@ -122,24 +142,24 @@ Configuration MSFT_SqlRS_InstallReportingServices_Config
             DatabaseServerName   = $Node.DatabaseServerName
             DatabaseInstanceName = $Node.DatabaseInstanceName
 
-            PsDscRunAsCredential = $SqlInstallCredential
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @(
+                    $Node.RunAs_UserName, (ConvertTo-SecureString -String $Node.RunAs_Password -AsPlainText -Force))
         }
     }
 }
 
+<#
+    .SYNOPSIS
+        Enables SSL on the Reporting Services.
+#>
 Configuration MSFT_SqlRS_InstallReportingServices_ConfigureSsl_Config
 {
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $SqlInstallCredential
-    )
-
     Import-DscResource -ModuleName 'SqlServerDsc'
 
-    node localhost {
+    node $AllNodes.NodeName
+    {
         SqlRS 'Integration_Test'
         {
             # Instance name for the Reporting Services.
@@ -153,24 +173,24 @@ Configuration MSFT_SqlRS_InstallReportingServices_ConfigureSsl_Config
             DatabaseServerName   = $Node.DatabaseServerName
             DatabaseInstanceName = $Node.DatabaseInstanceName
 
-            PsDscRunAsCredential = $SqlInstallCredential
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @(
+                    $Node.RunAs_UserName, (ConvertTo-SecureString -String $Node.RunAs_Password -AsPlainText -Force))
         }
     }
 }
 
+<#
+    .SYNOPSIS
+        Disables SSL on the Reporting Services.
+#>
 Configuration MSFT_SqlRS_InstallReportingServices_RestoreToNoSsl_Config
 {
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $SqlInstallCredential
-    )
-
     Import-DscResource -ModuleName 'SqlServerDsc'
 
-    node localhost {
+    node $AllNodes.NodeName
+    {
         SqlRS 'Integration_Test'
         {
             # Instance name for the Reporting Services.
@@ -184,16 +204,23 @@ Configuration MSFT_SqlRS_InstallReportingServices_RestoreToNoSsl_Config
             DatabaseServerName   = $Node.DatabaseServerName
             DatabaseInstanceName = $Node.DatabaseInstanceName
 
-            PsDscRunAsCredential = $SqlInstallCredential
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @(
+                    $Node.RunAs_UserName, (ConvertTo-SecureString -String $Node.RunAs_Password -AsPlainText -Force))
         }
     }
 }
 
+<#
+    .SYNOPSIS
+        Stops the Reporting Services instance to save resource on the build worker.
+#>
 Configuration MSFT_SqlRS_StopReportingServicesInstance_Config
 {
     Import-DscResource -ModuleName 'PSDscResources'
 
-    node localhost
+    node $AllNodes.NodeName
     {
         Service ('StopReportingServicesInstance{0}' -f $Node.InstanceName)
         {

--- a/Tests/Integration/MSFT_SqlScript.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlScript.Integration.Tests.ps1
@@ -17,6 +17,12 @@ if (-not $env:APPVEYOR -eq $true)
     return
 }
 
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
+{
+    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
+    return
+}
+
 #region HEADER
 # Integration Test Template Version: 1.1.2
 [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)

--- a/Tests/Integration/MSFT_SqlScript.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlScript.Integration.Tests.ps1
@@ -7,21 +7,16 @@
 [Microsoft.DscResourceKit.IntegrationTest(OrderNumber = 4)]
 param()
 
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
+if (Test-SkipContinuousIntegrationTask -Type 'Integration')
+{
+    return
+}
+
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceFriendlyName = 'SqlScript'
 $script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
-
-if (-not $env:APPVEYOR -eq $true)
-{
-    Write-Warning -Message ('Integration test for {0} will be skipped unless $env:APPVEYOR equals $true' -f $script:DSCResourceName)
-    return
-}
-
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
-{
-    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
-    return
-}
 
 #region HEADER
 # Integration Test Template Version: 1.1.2

--- a/Tests/Integration/MSFT_SqlScriptQuery.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlScriptQuery.Integration.Tests.ps1
@@ -17,6 +17,12 @@ if (-not $env:APPVEYOR -eq $true)
     return
 }
 
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
+{
+    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
+    return
+}
+
 #region HEADER
 # Integration Test Template Version: 1.1.2
 [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)

--- a/Tests/Integration/MSFT_SqlScriptQuery.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlScriptQuery.Integration.Tests.ps1
@@ -7,21 +7,16 @@
 [Microsoft.DscResourceKit.IntegrationTest(OrderNumber = 5)]
 param()
 
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
+if (Test-SkipContinuousIntegrationTask -Type 'Integration')
+{
+    return
+}
+
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceFriendlyName = 'SqlScriptQuery'
 $script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
-
-if (-not $env:APPVEYOR -eq $true)
-{
-    Write-Warning -Message ('Integration test for {0} will be skipped unless $env:APPVEYOR equals $true' -f $script:DSCResourceName)
-    return
-}
-
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
-{
-    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
-    return
-}
 
 #region HEADER
 # Integration Test Template Version: 1.1.2

--- a/Tests/Integration/MSFT_SqlScriptQuery.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlScriptQuery.Integration.Tests.ps1
@@ -14,57 +14,43 @@ if (Test-SkipContinuousIntegrationTask -Type 'Integration')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceFriendlyName = 'SqlScriptQuery'
-$script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceFriendlyName = 'SqlScriptQuery'
+$script:dscResourceName = "MSFT_$($script:dscResourceFriendlyName)"
 
 #region HEADER
-# Integration Test Template Version: 1.1.2
+# Integration Test Template Version: 1.3.2
 [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DscResource.Tests'))
 }
 
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Integration
-
 #endregion
 
-$mockSqlAdminAccountPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
-$mockSqlAdminAccountUserName = "$env:COMPUTERNAME\SqlAdmin"
-$mockSqlAdminCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlAdminAccountUserName, $mockSqlAdminAccountPassword
-
-$mockUserAccountPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
-$mockUserCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'DscAdmin1', $mockUserAccountPassword
-
+# Using try/finally to always cleanup.
 try
 {
-    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
+    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dscResourceName).config.ps1"
     . $configFile
 
-    $mockGetQuery      = $ConfigurationData.AllNodes.GetQuery
-    $mockTestQuery     = $ConfigurationData.AllNodes.TestQuery
-    $mockSetQuery      = $ConfigurationData.AllNodes.SetQuery
-    $mockDatabase1Name = $ConfigurationData.AllNodes.Database1Name
-    $mockDatabase2Name = $ConfigurationData.AllNodes.Database2Name
-
-    Describe "$($script:DSCResourceName)_Integration" {
+    Describe "$($script:dscResourceName)_Integration" {
         BeforeAll {
-            $resourceId = "[$($script:DSCResourceFriendlyName)]Integration_Test"
+            $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
         }
 
-        $configurationName = "$($script:DSCResourceName)_RunSqlScriptQueryAsWindowsUser_Config"
+        $configurationName = "$($script:dscResourceName)_RunSqlScriptQueryAsWindowsUser_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlAdministratorCredential = $mockSqlAdminCredential
                         OutputPath                 = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData          = $ConfigurationData
@@ -93,9 +79,8 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
                 <#
@@ -126,7 +111,6 @@ try
 
                 try
                 {
-
                     $resultObject = $regularExpressionMatch | ConvertFrom-Json
                 }
                 catch
@@ -136,20 +120,23 @@ try
                     throw $_
                 }
 
-                $resultObject.Name | Should -Be $mockDatabase1Name
-                $resourceCurrentState.GetQuery | Should -Be $mockGetQuery
-                $resourceCurrentState.TestQuery | Should -Be $mockTestQuery
-                $resourceCurrentState.SetQuery | Should -Be $mockSetQuery
+                $resultObject.Name | Should -Be $ConfigurationData.AllNodes.Database1Name
+                $resourceCurrentState.GetQuery | Should -Be $ConfigurationData.AllNodes.GetQuery
+                $resourceCurrentState.TestQuery | Should -Be $ConfigurationData.AllNodes.TestQuery
+                $resourceCurrentState.SetQuery | Should -Be $ConfigurationData.AllNodes.SetQuery
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
             }
         }
 
-        $configurationName = "$($script:DSCResourceName)_RunSqlScriptQueryAsSqlUser_Config"
+        $configurationName = "$($script:dscResourceName)_RunSqlScriptQueryAsSqlUser_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        UserCredential    = $mockUserCredential
                         OutputPath        = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData = $ConfigurationData
@@ -178,15 +165,18 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
-                $resourceCurrentState.GetResult | Should -Match $mockDatabase2Name
-                $resourceCurrentState.GetQuery | Should -Be $mockGetQuery
-                $resourceCurrentState.TestQuery | Should -Be $mockTestQuery
-                $resourceCurrentState.SetQuery | Should -Be $mockSetQuery
+                $resourceCurrentState.GetResult | Should -Match $ConfigurationData.AllNodes.Database2Name
+                $resourceCurrentState.GetQuery | Should -Be $ConfigurationData.AllNodes.GetQuery
+                $resourceCurrentState.TestQuery | Should -Be $ConfigurationData.AllNodes.TestQuery
+                $resourceCurrentState.SetQuery | Should -Be $ConfigurationData.AllNodes.SetQuery
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
             }
         }
     }
@@ -194,8 +184,6 @@ try
 finally
 {
     #region FOOTER
-
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
-
     #endregion
 }

--- a/Tests/Integration/MSFT_SqlServerDatabaseMail.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlServerDatabaseMail.Integration.Tests.ps1
@@ -12,6 +12,12 @@ if (-not $env:APPVEYOR -eq $true)
     return
 }
 
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
+{
+    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
+    return
+}
+
 #region HEADER
 # Integration Test Template Version: 1.1.2
 [System.String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)

--- a/Tests/Integration/MSFT_SqlServerDatabaseMail.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlServerDatabaseMail.Integration.Tests.ps1
@@ -2,21 +2,16 @@
 [Microsoft.DscResourceKit.IntegrationTest(OrderNumber = 2)]
 param()
 
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
+if (Test-SkipContinuousIntegrationTask -Type 'Integration')
+{
+    return
+}
+
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceFriendlyName = 'SqlServerDatabaseMail'
 $script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
-
-if (-not $env:APPVEYOR -eq $true)
-{
-    Write-Warning -Message ('Integration test for {0} will be skipped unless $env:APPVEYOR equals $true' -f $script:DSCResourceName)
-    return
-}
-
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
-{
-    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
-    return
-}
 
 #region HEADER
 # Integration Test Template Version: 1.1.2

--- a/Tests/Integration/MSFT_SqlServerEndPoint.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlServerEndPoint.Integration.Tests.ps1
@@ -1,0 +1,159 @@
+# This is used to make sure the integration test run in the correct order.
+[Microsoft.DscResourceKit.IntegrationTest(OrderNumber = 2)]
+param()
+
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceFriendlyName = 'SqlServerEndpoint'
+$script:dcsResourceName = "MSFT_$($script:dscResourceFriendlyName)"
+
+if (-not $env:APPVEYOR -eq $true)
+{
+    Write-Warning -Message ('Integration test for {0} will be skipped unless $env:APPVEYOR equals $true' -f $script:DSCResourceName)
+    return
+}
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
+{
+    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
+    return
+}
+
+#region HEADER
+# Integration Test Template Version: 1.3.1
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DscResource.Tests'))
+}
+
+Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dcsResourceName `
+    -TestType Integration
+#endregion
+
+$mockSqlInstallAccountPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
+$mockSqlInstallAccountUserName = "$env:COMPUTERNAME\SqlInstall"
+$mockSqlInstallCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlInstallAccountUserName, $mockSqlInstallAccountPassword
+
+# Using try/finally to always cleanup.
+try
+{
+    #region Integration Tests
+    $configurationFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dcsResourceName).config.ps1"
+    . $configurationFile
+
+    $mockEndpointName = $ConfigurationData.AllNodes.EndpointName
+    $mockPort = $ConfigurationData.AllNodes.Port
+    $mockIpAddress = $ConfigurationData.AllNodes.IpAddress
+    $mockOwner = $ConfigurationData.AllNodes.Owner
+
+    Describe "$($script:dcsResourceName)_Integration" {
+
+        $configurationName = "$($script:dcsResourceName)_Add_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath           = $TestDrive
+                        ConfigurationData    = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq "[$($script:dscResourceFriendlyName)]Integration_Test"
+                }
+
+                $resourceCurrentState.Ensure | Should -Be 'Present'
+                $resourceCurrentState.EndpointName | Should -Be $mockEndpointName
+                $resourceCurrentState.Port | Should -Be $mockPort
+                $resourceCurrentState.IpAddress | Should -Be $mockIpAddress
+                $resourceCurrentState.Owner | Should -Be $mockOwner
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
+            }
+        }
+
+        $configurationName = "$($script:dcsResourceName)_Remove_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath           = $TestDrive
+                        ConfigurationData    = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq "[$($script:dscResourceFriendlyName)]Integration_Test"
+                }
+
+                $resourceCurrentState.Ensure | Should -Be 'Absent'
+                $resourceCurrentState.EndpointName | Should -BeNullOrEmpty
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
+            }
+        }
+
+    }
+    #endregion
+
+}
+finally
+{
+    #region FOOTER
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+    #endregion
+}

--- a/Tests/Integration/MSFT_SqlServerEndPoint.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlServerEndPoint.Integration.Tests.ps1
@@ -11,10 +11,10 @@ if (Test-SkipContinuousIntegrationTask -Type 'Integration')
 
 $script:dscModuleName = 'SqlServerDsc'
 $script:dscResourceFriendlyName = 'SqlServerEndpoint'
-$script:dcsResourceName = "MSFT_$($script:dscResourceFriendlyName)"
+$script:dscResourceName = "MSFT_$($script:dscResourceFriendlyName)"
 
 #region HEADER
-# Integration Test Template Version: 1.3.1
+# Integration Test Template Version: 1.3.2
 [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
@@ -25,29 +25,23 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $script:dscModuleName `
-    -DSCResourceName $script:dcsResourceName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Integration
 #endregion
-
-$mockSqlInstallAccountPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
-$mockSqlInstallAccountUserName = "$env:COMPUTERNAME\SqlInstall"
-$mockSqlInstallCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlInstallAccountUserName, $mockSqlInstallAccountPassword
 
 # Using try/finally to always cleanup.
 try
 {
     #region Integration Tests
-    $configurationFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dcsResourceName).config.ps1"
+    $configurationFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dscResourceName).config.ps1"
     . $configurationFile
 
-    $mockEndpointName = $ConfigurationData.AllNodes.EndpointName
-    $mockPort = $ConfigurationData.AllNodes.Port
-    $mockIpAddress = $ConfigurationData.AllNodes.IpAddress
-    $mockOwner = $ConfigurationData.AllNodes.Owner
+    Describe "$($script:dscResourceName)_Integration" {
+        BeforeAll {
+            $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
+        }
 
-    Describe "$($script:dcsResourceName)_Integration" {
-
-        $configurationName = "$($script:dcsResourceName)_Add_Config"
+        $configurationName = "$($script:dscResourceName)_Add_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
@@ -81,14 +75,14 @@ try
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
                     $_.ConfigurationName -eq $configurationName `
-                    -and $_.ResourceId -eq "[$($script:dscResourceFriendlyName)]Integration_Test"
+                    -and $_.ResourceId -eq $resourceId
                 }
 
                 $resourceCurrentState.Ensure | Should -Be 'Present'
-                $resourceCurrentState.EndpointName | Should -Be $mockEndpointName
-                $resourceCurrentState.Port | Should -Be $mockPort
-                $resourceCurrentState.IpAddress | Should -Be $mockIpAddress
-                $resourceCurrentState.Owner | Should -Be $mockOwner
+                $resourceCurrentState.EndpointName | Should -Be $ConfigurationData.AllNodes.EndpointName
+                $resourceCurrentState.Port | Should -Be $ConfigurationData.AllNodes.Port
+                $resourceCurrentState.IpAddress | Should -Be $ConfigurationData.AllNodes.IpAddress
+                $resourceCurrentState.Owner | Should -Be $ConfigurationData.AllNodes.Owner
             }
 
             It 'Should return $true when Test-DscConfiguration is run' {
@@ -96,7 +90,7 @@ try
             }
         }
 
-        $configurationName = "$($script:dcsResourceName)_Remove_Config"
+        $configurationName = "$($script:dscResourceName)_Remove_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
@@ -130,7 +124,7 @@ try
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
                     $_.ConfigurationName -eq $configurationName `
-                    -and $_.ResourceId -eq "[$($script:dscResourceFriendlyName)]Integration_Test"
+                    -and $_.ResourceId -eq $resourceId
                 }
 
                 $resourceCurrentState.Ensure | Should -Be 'Absent'
@@ -141,10 +135,8 @@ try
                 Test-DscConfiguration -Verbose | Should -Be $true
             }
         }
-
     }
     #endregion
-
 }
 finally
 {

--- a/Tests/Integration/MSFT_SqlServerEndPoint.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlServerEndPoint.Integration.Tests.ps1
@@ -2,21 +2,16 @@
 [Microsoft.DscResourceKit.IntegrationTest(OrderNumber = 2)]
 param()
 
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
+if (Test-SkipContinuousIntegrationTask -Type 'Integration')
+{
+    return
+}
+
 $script:dscModuleName = 'SqlServerDsc'
 $script:dscResourceFriendlyName = 'SqlServerEndpoint'
 $script:dcsResourceName = "MSFT_$($script:dscResourceFriendlyName)"
-
-if (-not $env:APPVEYOR -eq $true)
-{
-    Write-Warning -Message ('Integration test for {0} will be skipped unless $env:APPVEYOR equals $true' -f $script:DSCResourceName)
-    return
-}
-
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
-{
-    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
-    return
-}
 
 #region HEADER
 # Integration Test Template Version: 1.3.1

--- a/Tests/Integration/MSFT_SqlServerEndPoint.config.ps1
+++ b/Tests/Integration/MSFT_SqlServerEndPoint.config.ps1
@@ -1,0 +1,70 @@
+#region HEADER
+# Integration Test Config Template Version: 1.2.0
+#endregion
+
+
+$ConfigurationData = @{
+    AllNodes = @(
+        @{
+            NodeName             = 'localhost'
+            ServerName           = $env:COMPUTERNAME
+            InstanceName         = 'DSCSQL2016'
+
+            EndpointName         = 'HADR'
+            Port                 = 5023
+            IpAddress            = '0.0.0.0'
+            Owner                = 'sa'
+
+            CertificateFile      = $env:DscPublicCertificatePath
+        }
+    )
+}
+
+<#
+    .SYNOPSIS
+        Configuration to ensure present and specify all the parameters
+#>
+Configuration MSFT_SqlServerEndpoint_Add_Config
+{
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node localhost
+    {
+        SqlServerEndpoint Integration_Test
+        {
+            Ensure               = 'Present'
+
+            EndpointName         = $Node.EndpointName
+            Port                 = $Node.Port
+            IpAddress            = $Node.IpAddress
+            Owner                = $Node.Owner
+
+            ServerName           = $Node.ServerName
+            InstanceName         = $Node.InstanceName
+        }
+    }
+}
+
+<#
+    .SYNOPSIS
+        Configuration to ensure Absent and specify all the parameters
+#>
+Configuration MSFT_SqlServerEndpoint_Remove_Config
+{
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node localhost
+    {
+        SqlServerEndpoint Integration_Test
+        {
+            Ensure               = 'Absent'
+
+            EndpointName         = $Node.EndpointName
+
+            ServerName           = $Node.ServerName
+            InstanceName         = $Node.InstanceName
+        }
+    }
+}
+
+

--- a/Tests/Integration/MSFT_SqlServerLogin.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlServerLogin.Integration.Tests.ps1
@@ -9,56 +9,38 @@ if (Test-SkipContinuousIntegrationTask -Type 'Integration')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceFriendlyName = 'SqlServerLogin'
-$script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceFriendlyName = 'SqlServerLogin'
+$script:dscResourceName = "MSFT_$($script:dscResourceFriendlyName)"
 
 #region HEADER
-# Integration Test Template Version: 1.1.2
-[System.String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+# Integration Test Template Version: 1.3.2
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DscResource.Tests'))
 }
 
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Integration
-
 #endregion
 
-$mockSqlAdminAccountPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
-$mockSqlAdminAccountUserName = "$env:COMPUTERNAME\SqlAdmin"
-$mockSqlAdminCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlAdminAccountUserName, $mockSqlAdminAccountPassword
-
-$mockUserAccountPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
-$mockUserCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'OnlyPasswordIsUsed', $mockUserAccountPassword
-
+# Using try/finally to always cleanup.
 try
 {
-    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
+    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dscResourceName).config.ps1"
     . $configFile
 
-    $mockDscUser1Name = $ConfigurationData.AllNodes.DscUser1Name
-    $mockDscUser1Type = $ConfigurationData.AllNodes.DscUser1Type
-    $mockDscUser2Name = $ConfigurationData.AllNodes.DscUser2Name
-    $mockDscUser2Type = $ConfigurationData.AllNodes.DscUser2Type
-    $mockDscUser3Name = $ConfigurationData.AllNodes.DscUser3Name
-    $mockDscUser3Type = $ConfigurationData.AllNodes.DscUser3Type
-    $mockDscUser4Name = $ConfigurationData.AllNodes.DscUser4Name
-    $mockDscUser4Type = $ConfigurationData.AllNodes.DscUser4Type
-    $mockDscSqlUsers1Name = $ConfigurationData.AllNodes.DscSqlUsers1Name
-    $mockDscSqlUsers1Type = $ConfigurationData.AllNodes.DscSqlUsers1Type
-
-    Describe "$($script:DSCResourceName)_Integration" {
+     Describe "$($script:dscResourceName)_Integration" {
         BeforeAll {
-            $resourceId = "[$($script:DSCResourceFriendlyName)]Integration_Test"
+            $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
         }
 
-        $configurationName = "$($script:DSCResourceName)_CreateDependencies_Config"
+        $configurationName = "$($script:dscResourceName)_CreateDependencies_Config"
 
         <#
             This will install dependencies using other resource modules, and is
@@ -69,7 +51,6 @@ try
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        UserCredential    = $mockUserCredential
                         OutputPath        = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData = $ConfigurationData
@@ -91,13 +72,12 @@ try
             }
         }
 
-        $configurationName = "$($script:DSCResourceName)_AddLoginDscUser1_Config"
+        $configurationName = "$($script:dscResourceName)_AddLoginDscUser1_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlAdministratorCredential = $mockSqlAdminCredential
                         OutputPath                 = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData          = $ConfigurationData
@@ -126,25 +106,27 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
                 $resourceCurrentState.Ensure | Should -Be 'Present'
-                $resourceCurrentState.Name | Should -Be $mockDscUser1Name
-                $resourceCurrentState.LoginType | Should -Be $mockDscUser1Type
+                $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.DscUser1Name
+                $resourceCurrentState.LoginType | Should -Be $ConfigurationData.AllNodes.DscUser1Type
                 $resourceCurrentState.Disabled | Should -Be $false
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
             }
         }
 
-        $configurationName = "$($script:DSCResourceName)_AddLoginDscUser2_Config"
+        $configurationName = "$($script:dscResourceName)_AddLoginDscUser2_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlAdministratorCredential = $mockSqlAdminCredential
                         OutputPath                 = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData          = $ConfigurationData
@@ -173,25 +155,27 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
                 $resourceCurrentState.Ensure | Should -Be 'Present'
-                $resourceCurrentState.Name | Should -Be $mockDscUser2Name
-                $resourceCurrentState.LoginType | Should -Be $mockDscUser2Type
+                $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.DscUser2Name
+                $resourceCurrentState.LoginType | Should -Be $ConfigurationData.AllNodes.DscUser2Type
                 $resourceCurrentState.Disabled | Should -Be $false
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
             }
         }
 
-        $configurationName = "$($script:DSCResourceName)_AddLoginDscUser3_Disabled_Config"
+        $configurationName = "$($script:dscResourceName)_AddLoginDscUser3_Disabled_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlAdministratorCredential = $mockSqlAdminCredential
                         OutputPath                 = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData          = $ConfigurationData
@@ -220,26 +204,27 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
                 $resourceCurrentState.Ensure | Should -Be 'Present'
-                $resourceCurrentState.Name | Should -Be $mockDscUser3Name
-                $resourceCurrentState.LoginType | Should -Be $mockDscUser3Type
+                $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.DscUser3Name
+                $resourceCurrentState.LoginType | Should -Be $ConfigurationData.AllNodes.DscUser3Type
                 $resourceCurrentState.Disabled | Should -Be $true
             }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
+            }
         }
 
-        $configurationName = "$($script:DSCResourceName)_AddLoginDscUser4_Config"
+        $configurationName = "$($script:dscResourceName)_AddLoginDscUser4_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlAdministratorCredential = $mockSqlAdminCredential
-                        UserCredential             = $mockUserCredential
                         OutputPath                 = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData          = $ConfigurationData
@@ -268,25 +253,27 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
                 $resourceCurrentState.Ensure | Should -Be 'Present'
-                $resourceCurrentState.Name | Should -Be $mockDscUser4Name
-                $resourceCurrentState.LoginType | Should -Be $mockDscUser4Type
+                $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.DscUser4Name
+                $resourceCurrentState.LoginType | Should -Be $ConfigurationData.AllNodes.DscUser4Type
                 $resourceCurrentState.Disabled | Should -Be $false
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
             }
         }
 
-        $configurationName = "$($script:DSCResourceName)_AddLoginDscSqlUsers1_Config"
+        $configurationName = "$($script:dscResourceName)_AddLoginDscSqlUsers1_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlAdministratorCredential = $mockSqlAdminCredential
                         OutputPath                 = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData          = $ConfigurationData
@@ -315,25 +302,27 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
                 $resourceCurrentState.Ensure | Should -Be 'Present'
-                $resourceCurrentState.Name | Should -Be $mockDscSqlUsers1Name
-                $resourceCurrentState.LoginType | Should -Be $mockDscSqlUsers1Type
+                $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.DscSqlUsers1Name
+                $resourceCurrentState.LoginType | Should -Be $ConfigurationData.AllNodes.DscSqlUsers1Type
                 $resourceCurrentState.Disabled | Should -Be $false
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
             }
         }
 
-        $configurationName = "$($script:DSCResourceName)_RemoveLoginDscUser3_Config"
+        $configurationName = "$($script:dscResourceName)_RemoveLoginDscUser3_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlAdministratorCredential = $mockSqlAdminCredential
                         OutputPath                 = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData          = $ConfigurationData
@@ -362,14 +351,17 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
                 $resourceCurrentState.Ensure | Should -Be 'Absent'
-                $resourceCurrentState.Name | Should -Be $mockDscUser3Name
+                $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.DscUser3Name
                 $resourceCurrentState.LoginType | Should -BeNullOrEmpty
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
             }
         }
     }
@@ -377,8 +369,6 @@ try
 finally
 {
     #region FOOTER
-
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
-
     #endregion
 }

--- a/Tests/Integration/MSFT_SqlServerLogin.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlServerLogin.Integration.Tests.ps1
@@ -12,6 +12,12 @@ if (-not $env:APPVEYOR -eq $true)
     return
 }
 
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
+{
+    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
+    return
+}
+
 #region HEADER
 # Integration Test Template Version: 1.1.2
 [System.String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)

--- a/Tests/Integration/MSFT_SqlServerLogin.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlServerLogin.Integration.Tests.ps1
@@ -2,21 +2,16 @@
 [Microsoft.DscResourceKit.IntegrationTest(OrderNumber = 2)]
 param()
 
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
+if (Test-SkipContinuousIntegrationTask -Type 'Integration')
+{
+    return
+}
+
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceFriendlyName = 'SqlServerLogin'
 $script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
-
-if (-not $env:APPVEYOR -eq $true)
-{
-    Write-Warning -Message ('Integration test for {0} will be skipped unless $env:APPVEYOR equals $true' -f $script:DSCResourceName)
-    return
-}
-
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
-{
-    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
-    return
-}
 
 #region HEADER
 # Integration Test Template Version: 1.1.2

--- a/Tests/Integration/MSFT_SqlServerLogin.config.ps1
+++ b/Tests/Integration/MSFT_SqlServerLogin.config.ps1
@@ -1,62 +1,88 @@
-$ConfigurationData = @{
-    AllNodes = @(
-        @{
-            NodeName         = 'localhost'
-            ServerName       = $env:COMPUTERNAME
-            InstanceName     = 'DSCSQL2016'
+#region HEADER
+# Integration Test Config Template Version: 1.2.0
+#endregion
 
-            DscUser1Name     = ('{0}\{1}' -f $env:COMPUTERNAME, 'DscUser1')
-            DscUser1Type     = 'WindowsUser'
+$configFile = [System.IO.Path]::ChangeExtension($MyInvocation.MyCommand.Path, 'json')
+if (Test-Path -Path $configFile)
+{
+    <#
+        Allows reading the configuration data from a JSON file,
+        for real testing scenarios outside of the CI.
+    #>
+    $ConfigurationData = Get-Content -Path $configFile | ConvertFrom-Json
+}
+else
+{
+    $ConfigurationData = @{
+        AllNodes = @(
+            @{
+                NodeName         = 'localhost'
 
-            DscUser2Name     = ('{0}\{1}' -f $env:COMPUTERNAME, 'DscUser2')
-            DscUser2Type     = 'WindowsUser'
+                Admin_UserName   = "$env:COMPUTERNAME\SqlAdmin"
+                Admin_Password   = 'P@ssw0rd1'
 
-            DscUser3Name     = ('{0}\{1}' -f $env:COMPUTERNAME, 'DscUser3')
-            DscUser3Type     = 'WindowsUser'
+                ServerName       = $env:COMPUTERNAME
+                InstanceName     = 'DSCSQL2016'
 
-            DscUser4Name     = 'DscUser4'
-            DscUser4Type     = 'SqlLogin'
+                DscUser1Name     = ('{0}\{1}' -f $env:COMPUTERNAME, 'DscUser1')
+                DscUser1Type     = 'WindowsUser'
 
-            DscSqlUsers1Name = ('{0}\{1}' -f $env:COMPUTERNAME, 'DscSqlUsers1')
-            DscSqlUsers1Type = 'WindowsGroup'
+                DscUser2Name     = ('{0}\{1}' -f $env:COMPUTERNAME, 'DscUser2')
+                DscUser2Type     = 'WindowsUser'
 
-            CertificateFile  = $env:DscPublicCertificatePath
-        }
-    )
+                DscUser3Name     = ('{0}\{1}' -f $env:COMPUTERNAME, 'DscUser3')
+                DscUser3Type     = 'WindowsUser'
+
+                DscUser4Name     = 'DscUser4'
+                DscUser4Type     = 'SqlLogin'
+
+                DscSqlUsers1Name = ('{0}\{1}' -f $env:COMPUTERNAME, 'DscSqlUsers1')
+                DscSqlUsers1Type = 'WindowsGroup'
+
+                CertificateFile  = $env:DscPublicCertificatePath
+            }
+        )
+    }
 }
 
+<#
+    .SYNOPSIS
+        Creates the logins that are dependencies.
+#>
 Configuration MSFT_SqlServerLogin_CreateDependencies_Config
 {
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $UserCredential
-    )
-
     Import-DscResource -ModuleName 'PSDscResources'
 
-    node localhost {
+    node $AllNodes.NodeName
+    {
         User 'CreateDscUser1'
         {
             Ensure   = 'Present'
             UserName = Split-Path -Path $Node.DscUser1Name -Leaf
-            Password = $UserCredential
+            # Only the password will be used of this credential object.
+            Password = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Admin_UserName, (ConvertTo-SecureString -String $Node.Admin_Password -AsPlainText -Force))
         }
 
         User 'CreateDscUser2'
         {
             Ensure   = 'Present'
             UserName = Split-Path -Path $Node.DscUser2Name -Leaf
-            Password = $UserCredential
+            # Only the password will be used of this credential object.
+            Password = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Admin_UserName, (ConvertTo-SecureString -String $Node.Admin_Password -AsPlainText -Force))
         }
 
         User 'CreateDscUser3'
         {
             Ensure   = 'Present'
             UserName = Split-Path -Path $Node.DscUser3Name -Leaf
-            Password = $UserCredential
+            # Only the password will be used of this credential object.
+            Password = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Admin_UserName, (ConvertTo-SecureString -String $Node.Admin_Password -AsPlainText -Force))
         }
 
         Group 'CreateDscSqlUsers1'
@@ -76,19 +102,16 @@ Configuration MSFT_SqlServerLogin_CreateDependencies_Config
     }
 }
 
+<#
+    .SYNOPSIS
+        Adds a Windows User login.
+#>
 Configuration MSFT_SqlServerLogin_AddLoginDscUser1_Config
 {
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $SqlAdministratorCredential
-    )
-
     Import-DscResource -ModuleName 'SqlServerDsc'
 
-    node localhost {
+    node $AllNodes.NodeName
+    {
         SqlServerLogin 'Integration_Test'
         {
             Ensure               = 'Present'
@@ -98,24 +121,23 @@ Configuration MSFT_SqlServerLogin_AddLoginDscUser1_Config
             ServerName           = $Node.ServerName
             InstanceName         = $Node.InstanceName
 
-            PsDscRunAsCredential = $SqlAdministratorCredential
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Admin_UserName, (ConvertTo-SecureString -String $Node.Admin_Password -AsPlainText -Force))
         }
     }
 }
 
+<#
+    .SYNOPSIS
+        Adds a second Windows User login.
+#>
 Configuration MSFT_SqlServerLogin_AddLoginDscUser2_Config
 {
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $SqlAdministratorCredential
-    )
-
     Import-DscResource -ModuleName 'SqlServerDsc'
 
-    node localhost {
+    node $AllNodes.NodeName
+    {
         SqlServerLogin 'Integration_Test'
         {
             Ensure               = 'Present'
@@ -125,24 +147,23 @@ Configuration MSFT_SqlServerLogin_AddLoginDscUser2_Config
             ServerName           = $Node.ServerName
             InstanceName         = $Node.InstanceName
 
-            PsDscRunAsCredential = $SqlAdministratorCredential
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Admin_UserName, (ConvertTo-SecureString -String $Node.Admin_Password -AsPlainText -Force))
         }
     }
 }
 
+<#
+    .SYNOPSIS
+        Adds a third Windows User login, and creates it as disabled.
+#>
 Configuration MSFT_SqlServerLogin_AddLoginDscUser3_Disabled_Config
 {
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $SqlAdministratorCredential
-    )
-
     Import-DscResource -ModuleName 'SqlServerDsc'
 
-    node localhost {
+    node $AllNodes.NodeName
+    {
         SqlServerLogin 'Integration_Test'
         {
             Ensure               = 'Present'
@@ -153,60 +174,55 @@ Configuration MSFT_SqlServerLogin_AddLoginDscUser3_Disabled_Config
             ServerName           = $Node.ServerName
             InstanceName         = $Node.InstanceName
 
-            PsDscRunAsCredential = $SqlAdministratorCredential
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Admin_UserName, (ConvertTo-SecureString -String $Node.Admin_Password -AsPlainText -Force))
         }
     }
 }
 
+<#
+    .SYNOPSIS
+        Adds a SQL login.
+#>
 Configuration MSFT_SqlServerLogin_AddLoginDscUser4_Config
 {
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $SqlAdministratorCredential,
-
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $UserCredential
-    )
-
     Import-DscResource -ModuleName 'SqlServerDsc'
 
-    node localhost {
+    node $AllNodes.NodeName
+    {
         SqlServerLogin 'Integration_Test'
         {
             Ensure                         = 'Present'
             Name                           = $Node.DscUser4Name
             LoginType                      = $Node.DscUser4Type
-            LoginCredential                = $UserCredential
             LoginMustChangePassword        = $false
             LoginPasswordExpirationEnabled = $true
             LoginPasswordPolicyEnforced    = $true
+            LoginCredential                = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Admin_UserName, (ConvertTo-SecureString -String $Node.Admin_Password -AsPlainText -Force))
 
             ServerName                     = $Node.ServerName
             InstanceName                   = $Node.InstanceName
 
-            PsDscRunAsCredential           = $SqlAdministratorCredential
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Admin_UserName, (ConvertTo-SecureString -String $Node.Admin_Password -AsPlainText -Force))
         }
     }
 }
 
+<#
+    .SYNOPSIS
+        Adds a Windows Group login.
+#>
 Configuration MSFT_SqlServerLogin_AddLoginDscSqlUsers1_Config
 {
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $SqlAdministratorCredential
-    )
-
     Import-DscResource -ModuleName 'SqlServerDsc'
 
-    node localhost {
+    node $AllNodes.NodeName
+    {
         SqlServerLogin 'Integration_Test'
         {
             Ensure               = 'Present'
@@ -216,24 +232,23 @@ Configuration MSFT_SqlServerLogin_AddLoginDscSqlUsers1_Config
             ServerName           = $Node.ServerName
             InstanceName         = $Node.InstanceName
 
-            PsDscRunAsCredential = $SqlAdministratorCredential
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Admin_UserName, (ConvertTo-SecureString -String $Node.Admin_Password -AsPlainText -Force))
         }
     }
 }
 
+<#
+    .SYNOPSIS
+        Removes the third Windows User login that was created.
+#>
 Configuration MSFT_SqlServerLogin_RemoveLoginDscUser3_Config
 {
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $SqlAdministratorCredential
-    )
-
     Import-DscResource -ModuleName 'SqlServerDsc'
 
-    node localhost {
+    node $AllNodes.NodeName
+    {
         SqlServerLogin 'Integration_Test'
         {
             Ensure               = 'Absent'
@@ -243,9 +258,9 @@ Configuration MSFT_SqlServerLogin_RemoveLoginDscUser3_Config
             ServerName           = $Node.ServerName
             InstanceName         = $Node.InstanceName
 
-            PsDscRunAsCredential = $SqlAdministratorCredential
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Admin_UserName, (ConvertTo-SecureString -String $Node.Admin_Password -AsPlainText -Force))
         }
     }
 }
-
-

--- a/Tests/Integration/MSFT_SqlServerNetwork.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlServerNetwork.Integration.Tests.ps1
@@ -2,21 +2,16 @@
 [Microsoft.DscResourceKit.IntegrationTest(OrderNumber = 2)]
 param()
 
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
+if (Test-SkipContinuousIntegrationTask -Type 'Integration')
+{
+    return
+}
+
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceFriendlyName = 'SqlServerNetwork'
 $script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
-
-if (-not $env:APPVEYOR -eq $true)
-{
-    Write-Warning -Message ('Integration test for {0} will be skipped unless $env:APPVEYOR equals $true' -f $script:DSCResourceName)
-    return
-}
-
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
-{
-    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
-    return
-}
 
 #region HEADER
 # Integration Test Template Version: 1.1.2

--- a/Tests/Integration/MSFT_SqlServerNetwork.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlServerNetwork.Integration.Tests.ps1
@@ -12,6 +12,12 @@ if (-not $env:APPVEYOR -eq $true)
     return
 }
 
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
+{
+    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
+    return
+}
+
 #region HEADER
 # Integration Test Template Version: 1.1.2
 [System.String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)

--- a/Tests/Integration/MSFT_SqlServerNetwork.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlServerNetwork.Integration.Tests.ps1
@@ -9,53 +9,47 @@ if (Test-SkipContinuousIntegrationTask -Type 'Integration')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceFriendlyName = 'SqlServerNetwork'
-$script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceFriendlyName = 'SqlServerNetwork'
+$script:dscResourceName = "MSFT_$($script:dscResourceFriendlyName)"
 
 #region HEADER
-# Integration Test Template Version: 1.1.2
-[System.String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+# Integration Test Template Version: 1.3.2
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DscResource.Tests'))
 }
 
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Integration
-
 #endregion
 
 $mockSqlInstallAccountPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
 $mockSqlInstallAccountUserName = "$env:COMPUTERNAME\SqlInstall"
 $mockSqlInstallCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlInstallAccountUserName, $mockSqlInstallAccountPassword
 
+# Using try/finally to always cleanup.
 try
 {
-    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
+    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dscResourceName).config.ps1"
     . $configFile
 
-    $mockProtocolName = $ConfigurationData.AllNodes.ProtocolName
-    $mockEnabled = $ConfigurationData.AllNodes.Enabled
-    $mockDisabled = $ConfigurationData.AllNodes.Disabled
-    $mockTcpDynamicPort = $ConfigurationData.AllNodes.TcpDynamicPort
-
-    Describe "$($script:DSCResourceName)_Integration" {
+    Describe "$($script:dscResourceName)_Integration" {
         BeforeAll {
-            $resourceId = "[$($script:DSCResourceFriendlyName)]Integration_Test"
+            $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
         }
 
-        $configurationName = "$($script:DSCResourceName)_SetDisabled_Config"
+        $configurationName = "$($script:dscResourceName)_SetDisabled_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlInstallCredential = $mockSqlInstallCredential
                         OutputPath           = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData    = $ConfigurationData
@@ -84,24 +78,27 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
-                $resourceCurrentState.IsEnabled | Should -Be $mockDisabled
-                $resourceCurrentState.ProtocolName | Should -Be $mockProtocolName
-                $resourceCurrentState.TcpDynamicPort | Should -Be $mockTcpDynamicPort
+
+                $resourceCurrentState.IsEnabled | Should -Be $ConfigurationData.AllNodes.Disabled
+                $resourceCurrentState.ProtocolName | Should -Be $ConfigurationData.AllNodes.ProtocolName
+                $resourceCurrentState.TcpDynamicPort | Should -Be $ConfigurationData.AllNodes.TcpDynamicPort
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
             }
         }
 
-        $configurationName = "$($script:DSCResourceName)_SetEnabled_Config"
+        $configurationName = "$($script:dscResourceName)_SetEnabled_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlInstallCredential = $mockSqlInstallCredential
                         OutputPath           = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData    = $ConfigurationData
@@ -130,14 +127,18 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
-                $resourceCurrentState.IsEnabled | Should -Be $mockEnabled
-                $resourceCurrentState.ProtocolName | Should -Be $mockProtocolName
-                $resourceCurrentState.TcpDynamicPort | Should -Be $mockTcpDynamicPort
+
+                $resourceCurrentState.IsEnabled | Should -Be $ConfigurationData.AllNodes.Enabled
+                $resourceCurrentState.ProtocolName | Should -Be $ConfigurationData.AllNodes.ProtocolName
+                $resourceCurrentState.TcpDynamicPort | Should -Be $ConfigurationData.AllNodes.TcpDynamicPort
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
             }
         }
     }
@@ -145,8 +146,6 @@ try
 finally
 {
     #region FOOTER
-
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
-
     #endregion
 }

--- a/Tests/Integration/MSFT_SqlServerNetwork.config.ps1
+++ b/Tests/Integration/MSFT_SqlServerNetwork.config.ps1
@@ -1,34 +1,51 @@
-$ConfigurationData = @{
-    AllNodes = @(
-        @{
-            NodeName        = 'localhost'
-            ServerName      = $env:COMPUTERNAME
-            InstanceName    = 'DSCSQL2016'
+#region HEADER
+# Integration Test Config Template Version: 1.2.0
+#endregion
 
-            ProtocolName    = 'Tcp'
-            Enabled         = $true
-            Disabled        = $false
-            TcpDynamicPort  = $true
-            RestartService  = $true
+$configFile = [System.IO.Path]::ChangeExtension($MyInvocation.MyCommand.Path, 'json')
+if (Test-Path -Path $configFile)
+{
+    <#
+        Allows reading the configuration data from a JSON file,
+        for real testing scenarios outside of the CI.
+    #>
+    $ConfigurationData = Get-Content -Path $configFile | ConvertFrom-Json
+}
+else
+{
+    $ConfigurationData = @{
+        AllNodes = @(
+            @{
+                NodeName        = 'localhost'
 
-            CertificateFile = $env:DscPublicCertificatePath
-        }
-    )
+                UserName        = "$env:COMPUTERNAME\SqlInstall"
+                Password        = 'P@ssw0rd1'
+
+                ServerName      = $env:COMPUTERNAME
+                InstanceName    = 'DSCSQL2016'
+
+                ProtocolName    = 'Tcp'
+                Enabled         = $true
+                Disabled        = $false
+                TcpDynamicPort  = $true
+                RestartService  = $true
+
+                CertificateFile = $env:DscPublicCertificatePath
+            }
+        )
+    }
 }
 
+<#
+    .SYNOPSIS
+        Disable network protocol.
+#>
 Configuration MSFT_SqlServerNetwork_SetDisabled_Config
 {
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $SqlInstallCredential
-    )
-
     Import-DscResource -ModuleName 'SqlServerDsc'
 
-    node localhost {
+    node $AllNodes.NodeName
+    {
         SqlServerNetwork 'Integration_Test'
         {
             ServerName           = $Node.ServerName
@@ -37,24 +54,23 @@ Configuration MSFT_SqlServerNetwork_SetDisabled_Config
             IsEnabled            = $Node.Disabled
             TcpDynamicPort       = $Node.TcpDynamicPort
 
-            PsDscRunAsCredential = $SqlInstallCredential
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Username, (ConvertTo-SecureString -String $Node.Password -AsPlainText -Force))
         }
     }
 }
 
+<#
+    .SYNOPSIS
+        Enable network protocol.
+#>
 Configuration MSFT_SqlServerNetwork_SetEnabled_Config
 {
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $SqlInstallCredential
-    )
-
     Import-DscResource -ModuleName 'SqlServerDsc'
 
-    node localhost {
+    node $AllNodes.NodeName
+    {
         SqlServerNetwork 'Integration_Test'
         {
             ServerName           = $Node.ServerName
@@ -63,7 +79,9 @@ Configuration MSFT_SqlServerNetwork_SetEnabled_Config
             IsEnabled            = $Node.Enabled
             TcpDynamicPort       = $Node.TcpDynamicPort
 
-            PsDscRunAsCredential = $SqlInstallCredential
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Username, (ConvertTo-SecureString -String $Node.Password -AsPlainText -Force))
         }
     }
 }

--- a/Tests/Integration/MSFT_SqlServerRole.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlServerRole.Integration.Tests.ps1
@@ -2,21 +2,16 @@
 [Microsoft.DscResourceKit.IntegrationTest(OrderNumber = 3)]
 param()
 
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
+if (Test-SkipContinuousIntegrationTask -Type 'Integration')
+{
+    return
+}
+
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceFriendlyName = 'SqlServerRole'
 $script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
-
-if (-not $env:APPVEYOR -eq $true)
-{
-    Write-Warning -Message ('Integration test for {0} will be skipped unless $env:APPVEYOR equals $true' -f $script:DSCResourceName)
-    return
-}
-
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
-{
-    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
-    return
-}
 
 #region HEADER
 # Integration Test Template Version: 1.1.2

--- a/Tests/Integration/MSFT_SqlServerRole.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlServerRole.Integration.Tests.ps1
@@ -12,6 +12,12 @@ if (-not $env:APPVEYOR -eq $true)
     return
 }
 
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
+{
+    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
+    return
+}
+
 #region HEADER
 # Integration Test Template Version: 1.1.2
 [System.String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)

--- a/Tests/Integration/MSFT_SqlServerRole.config.ps1
+++ b/Tests/Integration/MSFT_SqlServerRole.config.ps1
@@ -1,21 +1,41 @@
-$ConfigurationData = @{
-    AllNodes = @(
-        @{
-            NodeName        = 'localhost'
-            ServerName      = $env:COMPUTERNAME
-            InstanceName    = 'DSCSQL2016'
+#region HEADER
+# Integration Test Config Template Version: 1.2.0
+#endregion
 
-            Role1Name       = 'DscServerRole1'
-            Role2Name       = 'DscServerRole2'
-            Role3Name       = 'DscServerRole3'
+$configFile = [System.IO.Path]::ChangeExtension($MyInvocation.MyCommand.Path, 'json')
+if (Test-Path -Path $configFile)
+{
+    <#
+        Allows reading the configuration data from a JSON file,
+        for real testing scenarios outside of the CI.
+    #>
+    $ConfigurationData = Get-Content -Path $configFile | ConvertFrom-Json
+}
+else
+{
+    $ConfigurationData = @{
+        AllNodes = @(
+            @{
+                NodeName        = 'localhost'
 
-            User1Name       = '{0}\{1}' -f $env:COMPUTERNAME, 'DscUser1'
-            User2Name       = '{0}\{1}' -f $env:COMPUTERNAME, 'DscUser2'
-            User4Name       = 'DscUser4'
+                UserName        = "$env:COMPUTERNAME\SqlAdmin"
+                Password        = 'P@ssw0rd1'
 
-            CertificateFile = $env:DscPublicCertificatePath
-        }
-    )
+                ServerName      = $env:COMPUTERNAME
+                InstanceName    = 'DSCSQL2016'
+
+                Role1Name       = 'DscServerRole1'
+                Role2Name       = 'DscServerRole2'
+                Role3Name       = 'DscServerRole3'
+
+                User1Name       = '{0}\{1}' -f $env:COMPUTERNAME, 'DscUser1'
+                User2Name       = '{0}\{1}' -f $env:COMPUTERNAME, 'DscUser2'
+                User4Name       = 'DscUser4'
+
+                CertificateFile = $env:DscPublicCertificatePath
+            }
+        )
+    }
 }
 
 <#
@@ -24,17 +44,10 @@ $ConfigurationData = @{
 #>
 Configuration MSFT_SqlServerRole_AddRole1_Config
 {
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $SqlAdministratorCredential
-    )
-
     Import-DscResource -ModuleName 'SqlServerDsc'
 
-    node localhost {
+    node $AllNodes.NodeName
+    {
         SqlServerRole 'Integration_Test'
         {
             Ensure               = 'Present'
@@ -45,7 +58,9 @@ Configuration MSFT_SqlServerRole_AddRole1_Config
                 $Node.User4Name
             )
 
-            PsDscRunAsCredential = $SqlAdministratorCredential
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Username, (ConvertTo-SecureString -String $Node.Password -AsPlainText -Force))
         }
     }
 }
@@ -56,17 +71,10 @@ Configuration MSFT_SqlServerRole_AddRole1_Config
 #>
 Configuration MSFT_SqlServerRole_AddRole2_Config
 {
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $SqlAdministratorCredential
-    )
-
     Import-DscResource -ModuleName 'SqlServerDsc'
 
-    node localhost {
+    node $AllNodes.NodeName
+    {
         SqlServerRole 'Integration_Test'
         {
             Ensure               = 'Present'
@@ -74,7 +82,9 @@ Configuration MSFT_SqlServerRole_AddRole2_Config
             ServerName           = $Node.ServerName
             InstanceName         = $Node.InstanceName
 
-            PsDscRunAsCredential = $SqlAdministratorCredential
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Username, (ConvertTo-SecureString -String $Node.Password -AsPlainText -Force))
         }
     }
 }
@@ -85,17 +95,10 @@ Configuration MSFT_SqlServerRole_AddRole2_Config
 #>
 Configuration MSFT_SqlServerRole_AddRole3_Config
 {
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $SqlAdministratorCredential
-    )
-
     Import-DscResource -ModuleName 'SqlServerDsc'
 
-    node localhost {
+    node $AllNodes.NodeName
+    {
         SqlServerRole 'Integration_Test'
         {
             Ensure               = 'Present'
@@ -107,7 +110,9 @@ Configuration MSFT_SqlServerRole_AddRole3_Config
                 $Node.User2Name
             )
 
-            PsDscRunAsCredential = $SqlAdministratorCredential
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Username, (ConvertTo-SecureString -String $Node.Password -AsPlainText -Force))
         }
     }
 }
@@ -121,17 +126,10 @@ Configuration MSFT_SqlServerRole_AddRole3_Config
 #>
 Configuration MSFT_SqlServerRole_Role1_ChangeMembers_Config
 {
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $SqlAdministratorCredential
-    )
-
     Import-DscResource -ModuleName 'SqlServerDsc'
 
-    node localhost {
+    node $AllNodes.NodeName
+    {
         SqlServerRole 'Integration_Test'
         {
             Ensure               = 'Present'
@@ -143,7 +141,9 @@ Configuration MSFT_SqlServerRole_Role1_ChangeMembers_Config
                 $Node.User2Name
             )
 
-            PsDscRunAsCredential = $SqlAdministratorCredential
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Username, (ConvertTo-SecureString -String $Node.Password -AsPlainText -Force))
         }
     }
 }
@@ -154,17 +154,10 @@ Configuration MSFT_SqlServerRole_Role1_ChangeMembers_Config
 #>
 Configuration MSFT_SqlServerRole_Role2_AddMembers_Config
 {
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $SqlAdministratorCredential
-    )
-
     Import-DscResource -ModuleName 'SqlServerDsc'
 
-    node localhost {
+    node $AllNodes.NodeName
+    {
         SqlServerRole 'Integration_Test'
         {
             Ensure               = 'Present'
@@ -177,7 +170,9 @@ Configuration MSFT_SqlServerRole_Role2_AddMembers_Config
                 $Node.User4Name
             )
 
-            PsDscRunAsCredential = $SqlAdministratorCredential
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Username, (ConvertTo-SecureString -String $Node.Password -AsPlainText -Force))
         }
     }
 }
@@ -188,17 +183,10 @@ Configuration MSFT_SqlServerRole_Role2_AddMembers_Config
 #>
 Configuration MSFT_SqlServerRole_Role2_RemoveMembers_Config
 {
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $SqlAdministratorCredential
-    )
-
     Import-DscResource -ModuleName 'SqlServerDsc'
 
-    node localhost {
+    node $AllNodes.NodeName
+    {
         SqlServerRole 'Integration_Test'
         {
             Ensure               = 'Present'
@@ -210,25 +198,23 @@ Configuration MSFT_SqlServerRole_Role2_RemoveMembers_Config
                 $Node.User2Name
             )
 
-            PsDscRunAsCredential = $SqlAdministratorCredential
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Username, (ConvertTo-SecureString -String $Node.Password -AsPlainText -Force))
         }
     }
 }
 
-
+<#
+    .SYNOPSIS
+        Removes an existing group.
+#>
 Configuration MSFT_SqlServerRole_RemoveRole3_Config
 {
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $SqlAdministratorCredential
-    )
-
     Import-DscResource -ModuleName 'SqlServerDsc'
 
-    node localhost {
+    node $AllNodes.NodeName
+    {
         SqlServerRole 'Integration_Test'
         {
             Ensure               = 'Absent'
@@ -236,7 +222,9 @@ Configuration MSFT_SqlServerRole_RemoveRole3_Config
             ServerName           = $Node.ServerName
             InstanceName         = $Node.InstanceName
 
-            PsDscRunAsCredential = $SqlAdministratorCredential
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Username, (ConvertTo-SecureString -String $Node.Password -AsPlainText -Force))
         }
     }
 }

--- a/Tests/Integration/MSFT_SqlServerSecureConnection.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlServerSecureConnection.Integration.Tests.ps1
@@ -17,6 +17,12 @@ if (-not $env:APPVEYOR -eq $true)
     return
 }
 
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
+{
+    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
+    return
+}
+
 #region HEADER
 # Integration Test Template Version: 1.1.2
 [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)

--- a/Tests/Integration/MSFT_SqlServerSecureConnection.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlServerSecureConnection.Integration.Tests.ps1
@@ -7,21 +7,16 @@
 [Microsoft.DscResourceKit.IntegrationTest(OrderNumber = 5)]
 param()
 
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
+if (Test-SkipContinuousIntegrationTask -Type 'Integration')
+{
+    return
+}
+
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceFriendlyName = 'SqlServerSecureConnection'
 $script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
-
-if (-not $env:APPVEYOR -eq $true)
-{
-    Write-Warning -Message ('Integration test for {0} will be skipped unless $env:APPVEYOR equals $true' -f $script:DSCResourceName)
-    return
-}
-
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
-{
-    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
-    return
-}
 
 #region HEADER
 # Integration Test Template Version: 1.1.2

--- a/Tests/Integration/MSFT_SqlServerSecureConnection.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlServerSecureConnection.Integration.Tests.ps1
@@ -14,53 +14,56 @@ if (Test-SkipContinuousIntegrationTask -Type 'Integration')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceFriendlyName = 'SqlServerSecureConnection'
-$script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceFriendlyName = 'SqlServerSecureConnection'
+$script:dscResourceName = "MSFT_$($script:dscResourceFriendlyName)"
 
 #region HEADER
-# Integration Test Template Version: 1.1.2
+# Integration Test Template Version: 1.3.2
 [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DscResource.Tests'))
 }
 
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Integration
+#endregion
 
 $testRootFolderPath = Split-Path -Path $PSScriptRoot -Parent
 Import-Module -Name (Join-Path -Path $testRootFolderPath -ChildPath (Join-Path -Path 'TestHelpers' -ChildPath 'CommonTestHelper.psm1')) -Force
 
-#endregion
-
-$mockSqlServicePrimaryAccountUserName = "$env:COMPUTERNAME\svc-SqlPrimary"
-
+<#
+    This will create a new self signed certificate an write the path to the new
+    certificate in the environment variable 'SqlPrivateCertificatePath', and its
+    thumbprint to the environment variable 'SqlCertificateThumbprint'
+#>
 $null = New-SQLSelfSignedCertificate
 $mockSqlPrivateKeyPassword = ConvertTo-SecureString -String '1234' -AsPlainText -Force
 Import-PfxCertificate -FilePath $env:SqlPrivateCertificatePath -Password $mockSqlPrivateKeyPassword -Exportable -CertStoreLocation 'Cert:\LocalMachine\Root'
 Import-PfxCertificate -FilePath $env:SqlPrivateCertificatePath -Password $mockSqlPrivateKeyPassword -Exportable -CertStoreLocation 'Cert:\LocalMachine\My'
+
+# Using try/finally to always cleanup.
 try
 {
-    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
+    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dscResourceName).config.ps1"
     . $configFile
 
-    Describe "$($script:DSCResourceName)_Integration" {
+    Describe "$($script:dscResourceName)_Integration" {
         BeforeAll {
-            $resourceId = "[$($script:DSCResourceFriendlyName)]Integration_Test"
+            $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
         }
 
-        $configurationName = "$($script:DSCResourceName)_AddSecureConnection_Config"
+        $configurationName = "$($script:dscResourceName)_AddSecureConnection_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlServicePrimaryUserName = $mockSqlServicePrimaryAccountUserName
                         OutputPath                 = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData          = $ConfigurationData
@@ -89,23 +92,24 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
-
                 $resourceCurrentState.Thumbprint | Should -Be $env:SqlCertificateThumbprint
                 $resourceCurrentState.ForceEncryption | Should -Be $true
             }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
+            }
         }
 
-        $configurationName = "$($script:DSCResourceName)_RemoveSecureConnection_Config"
+        $configurationName = "$($script:dscResourceName)_RemoveSecureConnection_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlServicePrimaryUserName = $mockSqlServicePrimaryAccountUserName
                         OutputPath        = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData = $ConfigurationData
@@ -134,13 +138,16 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
                 $resultObject.Thumbprint | Should -BeNullOrEmpty
                 $resourceCurrentState.ForceEncryption | Should -Be $false
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
             }
         }
     }
@@ -148,8 +155,6 @@ try
 finally
 {
     #region FOOTER
-
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
-
     #endregion
 }

--- a/Tests/Integration/MSFT_SqlServerSecureConnection.config.ps1
+++ b/Tests/Integration/MSFT_SqlServerSecureConnection.config.ps1
@@ -1,62 +1,73 @@
-$ConfigurationData = @{
-    AllNodes = @(
-        @{
-            NodeName        = 'localhost'
-            ServerName      = $env:COMPUTERNAME
-            InstanceName    = 'DSCSQL2016'
+#region HEADER
+# Integration Test Config Template Version: 1.2.0
+#endregion
 
-            Thumbprint      = $env:SqlCertificateThumbprint
+$configFile = [System.IO.Path]::ChangeExtension($MyInvocation.MyCommand.Path, 'json')
+if (Test-Path -Path $configFile)
+{
+    <#
+        Allows reading the configuration data from a JSON file,
+        for real testing scenarios outside of the CI.
+    #>
+    $ConfigurationData = Get-Content -Path $configFile | ConvertFrom-Json
+}
+else
+{
+    $ConfigurationData = @{
+        AllNodes = @(
+            @{
+                NodeName        = 'localhost'
 
-            CertificateFile = $env:DscPublicCertificatePath
-        }
-    )
+                ServiceAccount  = "$env:COMPUTERNAME\svc-SqlPrimary"
+
+                ServerName      = $env:COMPUTERNAME
+                InstanceName    = 'DSCSQL2016'
+
+                Thumbprint      = $env:SqlCertificateThumbprint
+
+                CertificateFile = $env:DscPublicCertificatePath
+            }
+        )
+    }
 }
 
+<#
+    .SYNOPSIS
+        Enable a secure connection, adding a correct certificate.
+#>
 Configuration MSFT_SqlServerSecureConnection_AddSecureConnection_Config
 {
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $SqlServicePrimaryUserName
-    )
-
     Import-DscResource -ModuleName 'SqlServerDsc'
 
-    node localhost
+    node $AllNodes.NodeName
     {
         SqlServerSecureConnection 'Integration_Test'
         {
             InstanceName = $Node.InstanceName
             Ensure = 'Present'
             Thumbprint = $Node.Thumbprint
-            ServiceAccount = $SqlServicePrimaryUserName
+            ServiceAccount = $Node.ServiceAccount
             ForceEncryption = $true
         }
     }
 }
 
+<#
+    .SYNOPSIS
+        Remove the secure connection.
+#>
 Configuration MSFT_SqlServerSecureConnection_RemoveSecureConnection_Config
 {
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [String]
-        $SqlServicePrimaryUserName
-    )
-
     Import-DscResource -ModuleName 'SqlServerDsc'
 
-    node localhost
+    node $AllNodes.NodeName
     {
         SqlServerSecureConnection 'Integration_Test'
         {
             InstanceName = $Node.InstanceName
             Ensure = 'Absent'
             Thumbprint = ''
-            ServiceAccount = $SqlServicePrimaryUserName
+            ServiceAccount = $Node.ServiceAccount
         }
     }
 }

--- a/Tests/Integration/MSFT_SqlServiceAccount.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlServiceAccount.Integration.Tests.ps1
@@ -2,21 +2,16 @@
 [Microsoft.DscResourceKit.IntegrationTest(OrderNumber = 2)]
 param()
 
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
+if (Test-SkipContinuousIntegrationTask -Type 'Integration')
+{
+    return
+}
+
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceFriendlyName = 'SqlServiceAccount'
 $script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
-
-if (-not $env:APPVEYOR -eq $true)
-{
-    Write-Warning -Message ('Integration test for {0} will be skipped unless $env:APPVEYOR equals $true' -f $script:DSCResourceName)
-    return
-}
-
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
-{
-    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
-    return
-}
 
 #region HEADER
 # Integration Test Template Version: 1.1.2

--- a/Tests/Integration/MSFT_SqlServiceAccount.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlServiceAccount.Integration.Tests.ps1
@@ -9,51 +9,30 @@ if (Test-SkipContinuousIntegrationTask -Type 'Integration')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceFriendlyName = 'SqlServiceAccount'
-$script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceFriendlyName = 'SqlServiceAccount'
+$script:dscResourceName = "MSFT_$($script:dscResourceFriendlyName)"
 
 #region HEADER
-# Integration Test Template Version: 1.1.2
-[System.String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+# Integration Test Template Version: 1.3.2
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DscResource.Tests'))
 }
 
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Integration
-
 #endregion
 
-$mockSqlInstallAccountPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
-$mockSqlInstallAccountUserName = "$env:COMPUTERNAME\SqlInstall"
-$mockSqlInstallCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlInstallAccountUserName, $mockSqlInstallAccountPassword
-
-$mockSqlServicePrimaryAccountPassword = ConvertTo-SecureString -String 'yig-C^Equ3' -AsPlainText -Force
-$mockSqlServicePrimaryAccountUserName = "$env:COMPUTERNAME\svc-SqlPrimary"
-$mockSqlServicePrimaryCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlServicePrimaryAccountUserName, $mockSqlServicePrimaryAccountPassword
-
-$mockSqlAgentServicePrimaryAccountPassword = ConvertTo-SecureString -String 'yig-C^Equ3' -AsPlainText -Force
-$mockSqlAgentServicePrimaryAccountUserName = "$env:COMPUTERNAME\svc-SqlAgentPri"
-$mockSqlAgentServicePrimaryCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlAgentServicePrimaryAccountUserName, $mockSqlAgentServicePrimaryAccountPassword
-
-$mockSqlServiceSecondaryAccountPassword = ConvertTo-SecureString -String 'yig-C^Equ3' -AsPlainText -Force
-$mockSqlServiceSecondaryAccountUserName = "$env:COMPUTERNAME\svc-SqlSecondary"
-$mockSqlServiceSecondaryCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlServiceSecondaryAccountUserName, $mockSqlServiceSecondaryAccountPassword
-
-$mockSqlAgentServiceSecondaryAccountPassword = ConvertTo-SecureString -String 'yig-C^Equ3' -AsPlainText -Force
-$mockSqlAgentServiceSecondaryAccountUserName = "$env:COMPUTERNAME\svc-SqlAgentSec"
-$mockSqlAgentServiceSecondaryCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlAgentServiceSecondaryAccountUserName, $mockSqlAgentServiceSecondaryAccountPassword
-
-$moc
+# Using try/finally to always cleanup.
 try
 {
-    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
+    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dscResourceName).config.ps1"
     . $configFile
 
     <#
@@ -65,12 +44,12 @@ try
     $mockServiceTypeDatabaseEngine = 'SqlServer'
     $mockServiceTypeSqlServerAgent = 'SqlAgent'
 
-    Describe "$($script:DSCResourceName)_Integration" {
+    Describe "$($script:dscResourceName)_Integration" {
         BeforeAll {
-            $resourceId = "[$($script:DSCResourceFriendlyName)]Integration_Test"
+            $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
         }
 
-        $configurationName = "$($script:DSCResourceName)_CreateDependencies_Config"
+        $configurationName = "$($script:dscResourceName)_CreateDependencies_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
@@ -97,13 +76,12 @@ try
             }
         }
 
-        $configurationName = "$($script:DSCResourceName)_DatabaseEngine_DefaultInstance_Config"
+        $configurationName = "$($script:dscResourceName)_DatabaseEngine_DefaultInstance_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlServiceSecondaryCredential = $mockSqlServiceSecondaryCredential
                         OutputPath                    = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData             = $ConfigurationData
@@ -132,24 +110,25 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
-                $resourceCurrentState.ServiceType | Should -Be $mockServiceTypeDatabaseEngine
-                $resourceCurrentState.ServiceAccountName | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $mockSqlServiceSecondaryAccountUserName -Leaf))
+                $resourceCurrentState.ServiceType | Should -Be $ConfigurationData.AllNodes.ServiceTypeDatabaseEngine
+                $resourceCurrentState.ServiceAccountName | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $ConfigurationData.AllNodes.SqlSecondary_UserName -Leaf))
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
             }
         }
 
-        $configurationName = "$($script:DSCResourceName)_SqlServerAgent_DefaultInstance_Config"
+        $configurationName = "$($script:dscResourceName)_SqlServerAgent_DefaultInstance_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlInstallCredential               = $mockSqlInstallCredential
-                        SqlAgentServiceSecondaryCredential = $mockSqlAgentServiceSecondaryCredential
                         OutputPath                         = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData                  = $ConfigurationData
@@ -178,23 +157,25 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
-                $resourceCurrentState.ServiceType | Should -Be $mockServiceTypeSqlServerAgent
-                $resourceCurrentState.ServiceAccountName | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $mockSqlAgentServiceSecondaryAccountUserName -Leaf))
+                $resourceCurrentState.ServiceType | Should -Be $ConfigurationData.AllNodes.ServiceTypeSqlServerAgent
+                $resourceCurrentState.ServiceAccountName | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $ConfigurationData.AllNodes.SqlAgentSecondary_UserName -Leaf))
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
             }
         }
 
-        $configurationName = "$($script:DSCResourceName)_DatabaseEngine_DefaultInstance_Restore_Config"
+        $configurationName = "$($script:dscResourceName)_DatabaseEngine_DefaultInstance_Restore_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlServicePrimaryCredential = $mockSqlServicePrimaryCredential
                         OutputPath                    = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData             = $ConfigurationData
@@ -223,24 +204,25 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
-                $resourceCurrentState.ServiceType | Should -Be $mockServiceTypeDatabaseEngine
-                $resourceCurrentState.ServiceAccountName | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $mockSqlServicePrimaryAccountUserName -Leaf))
+                $resourceCurrentState.ServiceType | Should -Be $ConfigurationData.AllNodes.ServiceTypeDatabaseEngine
+                $resourceCurrentState.ServiceAccountName | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $ConfigurationData.AllNodes.SqlPrimary_UserName -Leaf))
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
             }
         }
 
-        $configurationName = "$($script:DSCResourceName)_SqlServerAgent_DefaultInstance_Restore_Config"
+        $configurationName = "$($script:dscResourceName)_SqlServerAgent_DefaultInstance_Restore_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlInstallCredential             = $mockSqlInstallCredential
-                        SqlAgentServicePrimaryCredential = $mockSqlAgentServicePrimaryCredential
                         OutputPath                       = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData                = $ConfigurationData
@@ -269,17 +251,20 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
-                $resourceCurrentState.ServiceType | Should -Be $mockServiceTypeSqlServerAgent
-                $resourceCurrentState.ServiceAccountName | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $mockSqlAgentServicePrimaryAccountUserName -Leaf))
+                $resourceCurrentState.ServiceType | Should -Be $ConfigurationData.AllNodes.ServiceTypeSqlServerAgent
+                $resourceCurrentState.ServiceAccountName | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $ConfigurationData.AllNodes.SqlAgentPrimary_UserName -Leaf))
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
             }
         }
 
-        $configurationName = "$($script:DSCResourceName)_StopSqlServerDefaultInstance_Config"
+        $configurationName = "$($script:dscResourceName)_StopSqlServerDefaultInstance_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
@@ -306,13 +291,12 @@ try
             }
         }
 
-        $configurationName = "$($script:DSCResourceName)_DatabaseEngine_NamedInstance_Config"
+        $configurationName = "$($script:dscResourceName)_DatabaseEngine_NamedInstance_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlServiceSecondaryCredential = $mockSqlServiceSecondaryCredential
                         OutputPath                    = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData             = $ConfigurationData
@@ -334,31 +318,32 @@ try
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
             }
 
             It 'Should have set the resource and all the parameters should match' {
-                $currentConfiguration = Get-DscConfiguration
-
-                $resourceCurrentState = $currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
-                $resourceCurrentState.ServiceType | Should -Be $mockServiceTypeDatabaseEngine
-                $resourceCurrentState.ServiceAccountName | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $mockSqlServiceSecondaryAccountUserName -Leaf))
+                $resourceCurrentState.ServiceType | Should -Be $ConfigurationData.AllNodes.ServiceTypeDatabaseEngine
+                $resourceCurrentState.ServiceAccountName | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $ConfigurationData.AllNodes.SqlSecondary_UserName -Leaf))
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
             }
         }
 
-        $configurationName = "$($script:DSCResourceName)_SqlServerAgent_NamedInstance_Config"
+        $configurationName = "$($script:dscResourceName)_SqlServerAgent_NamedInstance_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlInstallCredential               = $mockSqlInstallCredential
-                        SqlAgentServiceSecondaryCredential = $mockSqlAgentServiceSecondaryCredential
                         OutputPath                         = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData                  = $ConfigurationData
@@ -387,23 +372,25 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
-                $resourceCurrentState.ServiceType | Should -Be $mockServiceTypeSqlServerAgent
-                $resourceCurrentState.ServiceAccountName | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $mockSqlAgentServiceSecondaryAccountUserName -Leaf))
+                $resourceCurrentState.ServiceType | Should -Be $ConfigurationData.AllNodes.ServiceTypeSqlServerAgent
+                $resourceCurrentState.ServiceAccountName | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $ConfigurationData.AllNodes.SqlAgentSecondary_UserName -Leaf))
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
             }
         }
 
-        $configurationName = "$($script:DSCResourceName)_DatabaseEngine_NamedInstance_Restore_Config"
+        $configurationName = "$($script:dscResourceName)_DatabaseEngine_NamedInstance_Restore_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlServicePrimaryCredential = $mockSqlServicePrimaryCredential
                         OutputPath                    = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData             = $ConfigurationData
@@ -432,24 +419,25 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
-                $resourceCurrentState.ServiceType | Should -Be $mockServiceTypeDatabaseEngine
-                $resourceCurrentState.ServiceAccountName | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $mockSqlServicePrimaryAccountUserName -Leaf))
+                $resourceCurrentState.ServiceType | Should -Be $ConfigurationData.AllNodes.ServiceTypeDatabaseEngine
+                $resourceCurrentState.ServiceAccountName | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $ConfigurationData.AllNodes.SqlPrimary_UserName -Leaf))
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
             }
         }
 
-        $configurationName = "$($script:DSCResourceName)_SqlServerAgent_NamedInstance_Restore_Config"
+        $configurationName = "$($script:dscResourceName)_SqlServerAgent_NamedInstance_Restore_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlInstallCredential             = $mockSqlInstallCredential
-                        SqlAgentServicePrimaryCredential = $mockSqlAgentServicePrimaryCredential
                         OutputPath                       = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData                = $ConfigurationData
@@ -478,13 +466,16 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
-                $resourceCurrentState.ServiceType | Should -Be $mockServiceTypeSqlServerAgent
-                $resourceCurrentState.ServiceAccountName | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $mockSqlAgentServicePrimaryAccountUserName -Leaf))
+                $resourceCurrentState.ServiceType | Should -Be $ConfigurationData.AllNodes.ServiceTypeSqlServerAgent
+                $resourceCurrentState.ServiceAccountName | Should -Be ('{0}\{1}' -f $env:COMPUTERNAME, (Split-Path -Path $ConfigurationData.AllNodes.SqlAgentPrimary_UserName -Leaf))
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
             }
         }
     }
@@ -492,8 +483,6 @@ try
 finally
 {
     #region FOOTER
-
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
-
     #endregion
 }

--- a/Tests/Integration/MSFT_SqlServiceAccount.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlServiceAccount.Integration.Tests.ps1
@@ -12,6 +12,12 @@ if (-not $env:APPVEYOR -eq $true)
     return
 }
 
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
+{
+    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
+    return
+}
+
 #region HEADER
 # Integration Test Template Version: 1.1.2
 [System.String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
@@ -27,7 +33,6 @@ $TestEnvironment = Initialize-TestEnvironment `
     -DSCResourceName $script:DSCResourceName `
     -TestType Integration
 
-$script:integrationErrorMessagePrefix = 'INTEGRATION ERROR MESSAGE:'
 #endregion
 
 $mockSqlInstallAccountPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
@@ -92,15 +97,7 @@ try
                         ErrorAction  = 'Stop'
                     }
 
-                    try
-                    {
-                        Start-DscConfiguration @startDscConfigurationParameters
-                    }
-                    catch
-                    {
-                        Write-Verbose -Message ('{0} {1}' -f $integrationErrorMessagePrefix, $_) -Verbose
-                        throw $_
-                    }
+                    Start-DscConfiguration @startDscConfigurationParameters
                 } | Should -Not -Throw
             }
         }
@@ -128,15 +125,7 @@ try
                         ErrorAction  = 'Stop'
                     }
 
-                    try
-                    {
-                        Start-DscConfiguration @startDscConfigurationParameters
-                    }
-                    catch
-                    {
-                        Write-Verbose -Message ('{0} {1}' -f $integrationErrorMessagePrefix, $_) -Verbose
-                        throw $_
-                    }
+                    Start-DscConfiguration @startDscConfigurationParameters
                 } | Should -Not -Throw
             }
 
@@ -182,15 +171,7 @@ try
                         ErrorAction  = 'Stop'
                     }
 
-                    try
-                    {
-                        Start-DscConfiguration @startDscConfigurationParameters
-                    }
-                    catch
-                    {
-                        Write-Verbose -Message ('{0} {1}' -f $integrationErrorMessagePrefix, $_) -Verbose
-                        throw $_
-                    }
+                    Start-DscConfiguration @startDscConfigurationParameters
                 } | Should -Not -Throw
             }
 
@@ -235,15 +216,7 @@ try
                         ErrorAction  = 'Stop'
                     }
 
-                    try
-                    {
-                        Start-DscConfiguration @startDscConfigurationParameters
-                    }
-                    catch
-                    {
-                        Write-Verbose -Message ('{0} {1}' -f $integrationErrorMessagePrefix, $_) -Verbose
-                        throw $_
-                    }
+                    Start-DscConfiguration @startDscConfigurationParameters
                 } | Should -Not -Throw
             }
 
@@ -289,15 +262,7 @@ try
                         ErrorAction  = 'Stop'
                     }
 
-                    try
-                    {
-                        Start-DscConfiguration @startDscConfigurationParameters
-                    }
-                    catch
-                    {
-                        Write-Verbose -Message ('{0} {1}' -f $integrationErrorMessagePrefix, $_) -Verbose
-                        throw $_
-                    }
+                    Start-DscConfiguration @startDscConfigurationParameters
                 } | Should -Not -Throw
             }
 
@@ -341,15 +306,7 @@ try
                         ErrorAction  = 'Stop'
                     }
 
-                    try
-                    {
-                        Start-DscConfiguration @startDscConfigurationParameters
-                    }
-                    catch
-                    {
-                        Write-Verbose -Message ('{0} {1}' -f $integrationErrorMessagePrefix, $_) -Verbose
-                        throw $_
-                    }
+                    Start-DscConfiguration @startDscConfigurationParameters
                 } | Should -Not -Throw
             }
         }
@@ -377,15 +334,7 @@ try
                         ErrorAction  = 'Stop'
                     }
 
-                    try
-                    {
-                        Start-DscConfiguration @startDscConfigurationParameters
-                    }
-                    catch
-                    {
-                        Write-Verbose -Message ('{0} {1}' -f $integrationErrorMessagePrefix, $_) -Verbose
-                        throw $_
-                    }
+                    Start-DscConfiguration @startDscConfigurationParameters
                 } | Should -Not -Throw
             }
 
@@ -431,15 +380,7 @@ try
                         ErrorAction  = 'Stop'
                     }
 
-                    try
-                    {
-                        Start-DscConfiguration @startDscConfigurationParameters
-                    }
-                    catch
-                    {
-                        Write-Verbose -Message ('{0} {1}' -f $integrationErrorMessagePrefix, $_) -Verbose
-                        throw $_
-                    }
+                    Start-DscConfiguration @startDscConfigurationParameters
                 } | Should -Not -Throw
             }
 
@@ -484,15 +425,7 @@ try
                         ErrorAction  = 'Stop'
                     }
 
-                    try
-                    {
-                        Start-DscConfiguration @startDscConfigurationParameters
-                    }
-                    catch
-                    {
-                        Write-Verbose -Message ('{0} {1}' -f $integrationErrorMessagePrefix, $_) -Verbose
-                        throw $_
-                    }
+                    Start-DscConfiguration @startDscConfigurationParameters
                 } | Should -Not -Throw
             }
 
@@ -538,15 +471,7 @@ try
                         ErrorAction  = 'Stop'
                     }
 
-                    try
-                    {
-                        Start-DscConfiguration @startDscConfigurationParameters
-                    }
-                    catch
-                    {
-                        Write-Verbose -Message ('{0} {1}' -f $integrationErrorMessagePrefix, $_) -Verbose
-                        throw $_
-                    }
+                    Start-DscConfiguration @startDscConfigurationParameters
                 } | Should -Not -Throw
             }
 

--- a/Tests/Integration/MSFT_SqlSetup.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlSetup.Integration.Tests.ps1
@@ -9,23 +9,23 @@ if (Test-SkipContinuousIntegrationTask -Type 'Integration')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceFriendlyName = 'SqlSetup'
-$script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceFriendlyName = 'SqlSetup'
+$script:dscResourceName = "MSFT_$($script:dscResourceFriendlyName)"
 
 #region HEADER
-# Integration Test Template Version: 1.1.2
-[System.String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+# Integration Test Template Version: 1.3.2
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DscResource.Tests'))
 }
 
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Integration
 #endregion
 
@@ -64,7 +64,6 @@ function Show-SqlBootstrapLog
     Write-Verbose -Message $('-' * 80) -Verbose
 }
 
-
 <#
     Workaround for issue #774. In the appveyor.yml file the folder
     C:\Program Files (x86)\Microsoft SQL Server\**\Tools\PowerShell\Modules
@@ -80,54 +79,31 @@ $sqlModulePath | ForEach-Object -Process {
     Rename-Item $_ -NewName $newFolderName -Force
 }
 
+# Using try/finally to always cleanup.
 try
 {
-    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
+    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dscResourceName).config.ps1"
     . $configFile
-
-    # These sets variables used for verification from the dot-sourced $ConfigurationData variable.
-    $mockDatabaseEngineNamedInstanceName       = $ConfigurationData.AllNodes.DatabaseEngineNamedInstanceName
-    $mockDatabaseEngineNamedInstanceFeatures   = $ConfigurationData.AllNodes.DatabaseEngineNamedInstanceFeatures
-    $mockDatabaseEngineDefaultInstanceName     = $ConfigurationData.AllNodes.DatabaseEngineDefaultInstanceName
-    $mockDatabaseEngineDefaultInstanceFeatures = $ConfigurationData.AllNodes.DatabaseEngineDefaultInstanceFeatures
-    $mockAnalysisServicesTabularInstanceName   = $ConfigurationData.AllNodes.AnalysisServicesTabularInstanceName
-    $mockAnalysisServicesTabularFeatures       = $ConfigurationData.AllNodes.AnalysisServicesTabularFeatures
-    $mockAnalysisServicesTabularServerMode     = $ConfigurationData.AllNodes.AnalysisServicesTabularServerMode
-    $mockAnalysisServicesMultiServerMode       = $ConfigurationData.AllNodes.AnalysisServicesMultiServerMode
-    $mockCollation                             = $ConfigurationData.AllNodes.Collation
-    $mockInstallSharedDir                      = $ConfigurationData.AllNodes.InstallSharedDir
-    $mockInstallSharedWOWDir                   = $ConfigurationData.AllNodes.InstallSharedWOWDir
-    $mockUpdateEnable                          = $ConfigurationData.AllNodes.UpdateEnabled
-    $mockSuppressReboot                        = $ConfigurationData.AllNodes.SuppressReboot
-    $mockForceReboot                           = $ConfigurationData.AllNodes.ForceReboot
-    $mockIsoMediaFilePath                      = $ConfigurationData.AllNodes.ImagePath
-    $mockIsoMediaDriveLetter                   = $ConfigurationData.AllNodes.DriveLetter
-    $mockSqlTempdbFileCount                    = $ConfigurationData.AllNodes.SqlTempdbFileCount
-    $mockSqlTempdbFileSize                     = $ConfigurationData.AllNodes.SqlTempdbFileSize
-    $mockSqlTempdbFileGrowth                   = $ConfigurationData.AllNodes.SqlTempdbFileGrowth
-    $mockSqlTempdbLogFileSize                  = $ConfigurationData.AllNodes.SqlTempdbLogFileSize
-    $mockSqlTempdbLogFileGrowth                = $ConfigurationData.AllNodes.SqlTempdbLogFileGrowth
 
     $mockSourceMediaUrl = 'https://download.microsoft.com/download/9/0/7/907AD35F-9F9C-43A5-9789-52470555DB90/ENU/SQLServer2016SP1-FullSlipstream-x64-ENU.iso'
 
     # Download SQL Server media
-    if (-not (Test-Path -Path $mockIsoMediaFilePath))
+    if (-not (Test-Path -Path $ConfigurationData.AllNodes.ImagePath))
     {
-
         # By switching to 'SilentlyContinue' should theoretically increase the download speed.
         $previousProgressPreference = $ProgressPreference
         $ProgressPreference = 'SilentlyContinue'
 
         Write-Verbose -Message "Start downloading the SQL Server media at $(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')" -Verbose
 
-        Invoke-WebRequest -Uri $mockSourceMediaUrl -OutFile $mockIsoMediaFilePath
+        Invoke-WebRequest -Uri $mockSourceMediaUrl -OutFile $ConfigurationData.AllNodes.ImagePath
 
-        Write-Verbose -Message ('SQL Server media file has SHA1 hash ''{0}''' -f (Get-FileHash -Path $mockIsoMediaFilePath -Algorithm 'SHA1').Hash) -Verbose
+        Write-Verbose -Message ('SQL Server media file has SHA1 hash ''{0}''' -f (Get-FileHash -Path $ConfigurationData.AllNodes.ImagePath -Algorithm 'SHA1').Hash) -Verbose
 
         $ProgressPreference = $previousProgressPreference
 
         # Double check that the SQL media was downloaded.
-        if (-not (Test-Path -Path $mockIsoMediaFilePath))
+        if (-not (Test-Path -Path $ConfigurationData.AllNodes.ImagePath))
         {
             Write-Warning -Message ('SQL media could not be downloaded, can not run the integration test.')
             return
@@ -142,47 +118,17 @@ try
         Write-Verbose -Message 'SQL Server media is already downloaded' -Verbose
     }
 
-    $mockSqlInstallAccountPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
-    $mockSqlInstallAccountUserName = "$env:COMPUTERNAME\SqlInstall"
-    $mockSqlInstallCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlInstallAccountUserName, $mockSqlInstallAccountPassword
-
-    $mockSqlAdminAccountPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
-    $mockSqlAdminAccountUserName = "$env:COMPUTERNAME\SqlAdmin"
-    $mockSqlAdminCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlAdminAccountUserName, $mockSqlAdminAccountPassword
-
-    $mockSqlServicePrimaryAccountPassword = ConvertTo-SecureString -String 'yig-C^Equ3' -AsPlainText -Force
-    $mockSqlServicePrimaryAccountUserName = "$env:COMPUTERNAME\svc-SqlPrimary"
-    $mockSqlServicePrimaryCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlServicePrimaryAccountUserName, $mockSqlServicePrimaryAccountPassword
-
-    $mockSqlAgentServicePrimaryAccountPassword = ConvertTo-SecureString -String 'yig-C^Equ3' -AsPlainText -Force
-    $mockSqlAgentServicePrimaryAccountUserName = "$env:COMPUTERNAME\svc-SqlAgentPri"
-    $mockSqlAgentServicePrimaryCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlAgentServicePrimaryAccountUserName, $mockSqlAgentServicePrimaryAccountPassword
-
-    $mockSqlServiceSecondaryAccountPassword = ConvertTo-SecureString -String 'yig-C^Equ3' -AsPlainText -Force
-    $mockSqlServiceSecondaryAccountUserName = "$env:COMPUTERNAME\svc-SqlSecondary"
-    $mockSqlServiceSecondaryCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlServiceSecondaryAccountUserName, $mockSqlServiceSecondaryAccountPassword
-
-    $mockSqlAgentServiceSecondaryAccountPassword = ConvertTo-SecureString -String 'yig-C^Equ3' -AsPlainText -Force
-    $mockSqlAgentServiceSecondaryAccountUserName = "$env:COMPUTERNAME\svc-SqlAgentSec"
-    $mockSqlAgentServiceSecondaryCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlAgentServiceSecondaryAccountUserName, $mockSqlAgentServiceSecondaryAccountPassword
-
-    Describe "$($script:DSCResourceName)_Integration" {
+    Describe "$($script:dscResourceName)_Integration" {
         BeforeAll {
-            $resourceId = "[$($script:DSCResourceFriendlyName)]Integration_Test"
+            $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
         }
 
-        $configurationName = "$($script:DSCResourceName)_CreateDependencies_Config"
+        $configurationName = "$($script:dscResourceName)_CreateDependencies_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlInstallCredential               = $mockSqlInstallCredential
-                        SqlAdministratorCredential         = $mockSqlAdminCredential
-                        SqlServicePrimaryCredential        = $mockSqlServicePrimaryCredential
-                        SqlAgentServicePrimaryCredential   = $mockSqlAgentServicePrimaryCredential
-                        SqlServiceSecondaryCredential      = $mockSqlServiceSecondaryCredential
-                        SqlAgentServiceSecondaryCredential = $mockSqlAgentServiceSecondaryCredential
                         OutputPath                         = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData                  = $ConfigurationData
@@ -204,16 +150,12 @@ try
             }
         }
 
-        $configurationName = "$($script:DSCResourceName)_InstallDatabaseEngineNamedInstanceAsSystem_Config"
+        $configurationName = "$($script:dscResourceName)_InstallDatabaseEngineNamedInstanceAsSystem_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlInstallCredential             = $mockSqlInstallCredential
-                        SqlAdministratorCredential       = $mockSqlAdminCredential
-                        SqlServicePrimaryCredential      = $mockSqlServicePrimaryCredential
-                        SqlAgentServicePrimaryCredential = $mockSqlAgentServicePrimaryCredential
                         OutputPath                       = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData                = $ConfigurationData
@@ -248,44 +190,43 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
                 $resourceCurrentState.Action                     | Should -BeNullOrEmpty
                 $resourceCurrentState.AgtSvcAccount              | Should -BeNullOrEmpty
-                $resourceCurrentState.AgtSvcAccountUsername      | Should -Be ('.\{0}' -f (Split-Path -Path $mockSqlAgentServicePrimaryAccountUserName -Leaf))
+                $resourceCurrentState.AgtSvcAccountUsername      | Should -Be ('.\{0}' -f (Split-Path -Path $ConfigurationData.AllNodes.SqlAgentServicePrimaryAccountUserName -Leaf))
                 $resourceCurrentState.AgtSvcStartupType          | Should -Be 'Automatic'
-                $resourceCurrentState.ASServerMode               | Should -Be $mockAnalysisServicesMultiServerMode
-                $resourceCurrentState.ASBackupDir                | Should -Be (Join-Path -Path $mockInstallSharedDir -ChildPath "MSAS13.$mockDatabaseEngineNamedInstanceName\OLAP\Backup")
-                $resourceCurrentState.ASCollation                | Should -Be $mockCollation
-                $resourceCurrentState.ASConfigDir                | Should -Be (Join-Path -Path $mockInstallSharedDir -ChildPath "MSAS13.$mockDatabaseEngineNamedInstanceName\OLAP\Config")
-                $resourceCurrentState.ASDataDir                  | Should -Be (Join-Path -Path $mockInstallSharedDir -ChildPath "MSAS13.$mockDatabaseEngineNamedInstanceName\OLAP\Data")
-                $resourceCurrentState.ASLogDir                   | Should -Be (Join-Path -Path $mockInstallSharedDir -ChildPath "MSAS13.$mockDatabaseEngineNamedInstanceName\OLAP\Log")
-                $resourceCurrentState.ASTempDir                  | Should -Be (Join-Path -Path $mockInstallSharedDir -ChildPath "MSAS13.$mockDatabaseEngineNamedInstanceName\OLAP\Temp")
+                $resourceCurrentState.ASServerMode               | Should -Be $ConfigurationData.AllNodes.AnalysisServicesMultiServerMode
+                $resourceCurrentState.ASBackupDir                | Should -Be (Join-Path -Path $ConfigurationData.AllNodes.InstallSharedDir -ChildPath "MSAS13.$($ConfigurationData.AllNodes.DatabaseEngineNamedInstanceName)\OLAP\Backup")
+                $resourceCurrentState.ASCollation                | Should -Be $ConfigurationData.AllNodes.Collation
+                $resourceCurrentState.ASConfigDir                | Should -Be (Join-Path -Path $ConfigurationData.AllNodes.InstallSharedDir -ChildPath "MSAS13.$($ConfigurationData.AllNodes.DatabaseEngineNamedInstanceName)\OLAP\Config")
+                $resourceCurrentState.ASDataDir                  | Should -Be (Join-Path -Path $ConfigurationData.AllNodes.InstallSharedDir -ChildPath "MSAS13.$($ConfigurationData.AllNodes.DatabaseEngineNamedInstanceName)\OLAP\Data")
+                $resourceCurrentState.ASLogDir                   | Should -Be (Join-Path -Path $ConfigurationData.AllNodes.InstallSharedDir -ChildPath "MSAS13.$($ConfigurationData.AllNodes.DatabaseEngineNamedInstanceName)\OLAP\Log")
+                $resourceCurrentState.ASTempDir                  | Should -Be (Join-Path -Path $ConfigurationData.AllNodes.InstallSharedDir -ChildPath "MSAS13.$($ConfigurationData.AllNodes.DatabaseEngineNamedInstanceName)\OLAP\Temp")
                 $resourceCurrentState.ASSvcAccount               | Should -BeNullOrEmpty
-                $resourceCurrentState.ASSvcAccountUsername       | Should -Be ('.\{0}' -f (Split-Path -Path $mockSqlServicePrimaryAccountUserName -Leaf))
+                $resourceCurrentState.ASSvcAccountUsername       | Should -Be ('.\{0}' -f (Split-Path -Path $ConfigurationData.AllNodes.SqlServicePrimaryAccountUserName -Leaf))
                 $resourceCurrentState.AsSvcStartupType           | Should -Be 'Automatic'
                 $resourceCurrentState.ASSysAdminAccounts         | Should -Be @(
-                    $mockSqlAdminAccountUserName,
-                    "NT SERVICE\SSASTELEMETRY`$$mockDatabaseEngineNamedInstanceName"
+                    $ConfigurationData.AllNodes.SqlAdministratorAccountUserName,
+                    "NT SERVICE\SSASTELEMETRY`$$($ConfigurationData.AllNodes.DatabaseEngineNamedInstanceName)"
                 )
                 $resourceCurrentState.BrowserSvcStartupType      | Should -BeNullOrEmpty
                 $resourceCurrentState.ErrorReporting             | Should -BeNullOrEmpty
                 $resourceCurrentState.FailoverClusterGroupName   | Should -BeNullOrEmpty
                 $resourceCurrentState.FailoverClusterIPAddress   | Should -BeNullOrEmpty
                 $resourceCurrentState.FailoverClusterNetworkName | Should -BeNullOrEmpty
-                $resourceCurrentState.Features                   | Should -Be $mockDatabaseEngineNamedInstanceFeatures
+                $resourceCurrentState.Features                   | Should -Be $ConfigurationData.AllNodes.DatabaseEngineNamedInstanceFeatures
                 $resourceCurrentState.ForceReboot                | Should -BeNullOrEmpty
                 $resourceCurrentState.FTSvcAccount               | Should -BeNullOrEmpty
                 $resourceCurrentState.FTSvcAccountUsername       | Should -BeNullOrEmpty
-                $resourceCurrentState.InstallSharedDir           | Should -Be $mockInstallSharedDir
-                $resourceCurrentState.InstallSharedWOWDir        | Should -Be $mockInstallSharedWOWDir
-                $resourceCurrentState.InstallSQLDataDir          | Should -Be (Join-Path -Path $mockInstallSharedDir -ChildPath "MSSQL13.$mockDatabaseEngineNamedInstanceName\MSSQL")
-                $resourceCurrentState.InstanceDir                | Should -Be $mockInstallSharedDir
-                $resourceCurrentState.InstanceID                 | Should -Be $mockDatabaseEngineNamedInstanceName
-                $resourceCurrentState.InstanceName               | Should -Be $mockDatabaseEngineNamedInstanceName
+                $resourceCurrentState.InstallSharedDir           | Should -Be $ConfigurationData.AllNodes.InstallSharedDir
+                $resourceCurrentState.InstallSharedWOWDir        | Should -Be $ConfigurationData.AllNodes.InstallSharedWOWDir
+                $resourceCurrentState.InstallSQLDataDir          | Should -Be (Join-Path -Path $ConfigurationData.AllNodes.InstallSharedDir -ChildPath "MSSQL13.$($ConfigurationData.AllNodes.DatabaseEngineNamedInstanceName)\MSSQL")
+                $resourceCurrentState.InstanceDir                | Should -Be $ConfigurationData.AllNodes.InstallSharedDir
+                $resourceCurrentState.InstanceID                 | Should -Be $ConfigurationData.AllNodes.DatabaseEngineNamedInstanceName
+                $resourceCurrentState.InstanceName               | Should -Be $ConfigurationData.AllNodes.DatabaseEngineNamedInstanceName
                 $resourceCurrentState.ISSvcAccount               | Should -BeNullOrEmpty
                 $resourceCurrentState.ISSvcAccountUsername       | Should -BeNullOrEmpty
                 $resourceCurrentState.ProductKey                 | Should -BeNullOrEmpty
@@ -295,39 +236,42 @@ try
                 $resourceCurrentState.SecurityMode               | Should -Be 'SQL'
                 $resourceCurrentState.SetupProcessTimeout        | Should -BeNullOrEmpty
                 $resourceCurrentState.SourceCredential           | Should -BeNullOrEmpty
-                $resourceCurrentState.SourcePath                 | Should -Be "$($mockIsoMediaDriveLetter):\"
-                $resourceCurrentState.SQLBackupDir               | Should -Be (Join-Path -Path $mockInstallSharedDir -ChildPath "MSSQL13.$mockDatabaseEngineNamedInstanceName\MSSQL\Backup")
-                $resourceCurrentState.SQLCollation               | Should -Be $mockCollation
+                $resourceCurrentState.SourcePath                 | Should -Be "$($ConfigurationData.AllNodes.DriveLetter):\"
+                $resourceCurrentState.SQLBackupDir               | Should -Be (Join-Path -Path $ConfigurationData.AllNodes.InstallSharedDir -ChildPath "MSSQL13.$($ConfigurationData.AllNodes.DatabaseEngineNamedInstanceName)\MSSQL\Backup")
+                $resourceCurrentState.SQLCollation               | Should -Be $ConfigurationData.AllNodes.Collation
                 $resourceCurrentState.SQLSvcAccount              | Should -BeNullOrEmpty
-                $resourceCurrentState.SQLSvcAccountUsername      | Should -Be ('.\{0}' -f (Split-Path -Path $mockSqlServicePrimaryAccountUserName -Leaf))
+                $resourceCurrentState.SQLSvcAccountUsername      | Should -Be ('.\{0}' -f (Split-Path -Path $ConfigurationData.AllNodes.SqlServicePrimaryAccountUserName -Leaf))
                 $resourceCurrentState.SqlSvcStartupType          | Should -Be 'Automatic'
                 $resourceCurrentState.SQLSysAdminAccounts        | Should -Be @(
-                    $mockSqlAdminAccountUserName,
-                    $mockSqlInstallAccountUserName,
-                    "NT SERVICE\MSSQL`$$mockDatabaseEngineNamedInstanceName",
-                    "NT SERVICE\SQLAgent`$$mockDatabaseEngineNamedInstanceName",
+                    $ConfigurationData.AllNodes.SqlAdministratorAccountUserName,
+                    $ConfigurationData.AllNodes.SqlInstallAccountUserName,
+                    "NT SERVICE\MSSQL`$$($ConfigurationData.AllNodes.DatabaseEngineNamedInstanceName)",
+                    "NT SERVICE\SQLAgent`$$($ConfigurationData.AllNodes.DatabaseEngineNamedInstanceName)",
                     'NT SERVICE\SQLWriter',
                     'NT SERVICE\Winmgmt',
                     'sa'
                 )
                 $resourceCurrentState.SQLTempDBDir               | Should -BeNullOrEmpty
-                $resourceCurrentState.SqlTempdbFileCount         | Should -Be $mockSqlTempdbFileCount
-                $resourceCurrentState.SqlTempdbFileSize          | Should -Be $mockSqlTempdbFileSize
-                $resourceCurrentState.SqlTempdbFileGrowth        | Should -Be $mockSqlTempdbFileGrowth
+                $resourceCurrentState.SqlTempdbFileCount         | Should -Be $ConfigurationData.AllNodes.SqlTempdbFileCount
+                $resourceCurrentState.SqlTempdbFileSize          | Should -Be $ConfigurationData.AllNodes.SqlTempdbFileSize
+                $resourceCurrentState.SqlTempdbFileGrowth        | Should -Be $ConfigurationData.AllNodes.SqlTempdbFileGrowth
                 $resourceCurrentState.SQLTempDBLogDir            | Should -BeNullOrEmpty
-                $resourceCurrentState.SqlTempdbLogFileSize       | Should -Be $mockSqlTempdbLogFileSize
-                $resourceCurrentState.SqlTempdbLogFileGrowth     | Should -Be $mockSqlTempdbLogFileGrowth
-                $resourceCurrentState.SQLUserDBDir               | Should -Be (Join-Path -Path $mockInstallSharedDir -ChildPath "MSSQL13.$mockDatabaseEngineNamedInstanceName\MSSQL\DATA\")
-                $resourceCurrentState.SQLUserDBLogDir            | Should -Be (Join-Path -Path $mockInstallSharedDir -ChildPath "MSSQL13.$mockDatabaseEngineNamedInstanceName\MSSQL\DATA\")
+                $resourceCurrentState.SqlTempdbLogFileSize       | Should -Be $ConfigurationData.AllNodes.SqlTempdbLogFileSize
+                $resourceCurrentState.SqlTempdbLogFileGrowth     | Should -Be $ConfigurationData.AllNodes.SqlTempdbLogFileGrowth
+                $resourceCurrentState.SQLUserDBDir               | Should -Be (Join-Path -Path $ConfigurationData.AllNodes.InstallSharedDir -ChildPath "MSSQL13.$($ConfigurationData.AllNodes.DatabaseEngineNamedInstanceName)\MSSQL\DATA\")
+                $resourceCurrentState.SQLUserDBLogDir            | Should -Be (Join-Path -Path $ConfigurationData.AllNodes.InstallSharedDir -ChildPath "MSSQL13.$($ConfigurationData.AllNodes.DatabaseEngineNamedInstanceName)\MSSQL\DATA\")
                 $resourceCurrentState.SQMReporting               | Should -BeNullOrEmpty
                 $resourceCurrentState.SuppressReboot             | Should -BeNullOrEmpty
                 $resourceCurrentState.UpdateEnabled              | Should -BeNullOrEmpty
                 $resourceCurrentState.UpdateSource               | Should -BeNullOrEmpty
+            }
 
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
             }
         }
 
-        $configurationName = "$($script:DSCResourceName)_StopServicesInstance_Config"
+        $configurationName = "$($script:dscResourceName)_StopServicesInstance_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
@@ -354,16 +298,12 @@ try
             }
         }
 
-        $configurationName = "$($script:DSCResourceName)_InstallDatabaseEngineDefaultInstanceAsUser_Config"
+        $configurationName = "$($script:dscResourceName)_InstallDatabaseEngineDefaultInstanceAsUser_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlInstallCredential             = $mockSqlInstallCredential
-                        SqlAdministratorCredential       = $mockSqlAdminCredential
-                        SqlServicePrimaryCredential      = $mockSqlServicePrimaryCredential
-                        SqlAgentServicePrimaryCredential = $mockSqlAgentServicePrimaryCredential
                         OutputPath                       = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData                = $ConfigurationData
@@ -398,14 +338,13 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
                 $resourceCurrentState.Action                     | Should -BeNullOrEmpty
                 $resourceCurrentState.AgtSvcAccount              | Should -BeNullOrEmpty
-                $resourceCurrentState.AgtSvcAccountUsername      | Should -Be ('.\{0}' -f (Split-Path -Path $mockSqlAgentServicePrimaryAccountUserName -Leaf))
+                $resourceCurrentState.AgtSvcAccountUsername      | Should -Be ('.\{0}' -f (Split-Path -Path $ConfigurationData.AllNodes.SqlAgentServicePrimaryAccountUserName -Leaf))
                 $resourceCurrentState.ASServerMode               | Should -BeNullOrEmpty
                 $resourceCurrentState.ASBackupDir                | Should -BeNullOrEmpty
                 $resourceCurrentState.ASCollation                | Should -BeNullOrEmpty
@@ -421,16 +360,16 @@ try
                 $resourceCurrentState.FailoverClusterGroupName   | Should -BeNullOrEmpty
                 $resourceCurrentState.FailoverClusterIPAddress   | Should -BeNullOrEmpty
                 $resourceCurrentState.FailoverClusterNetworkName | Should -BeNullOrEmpty
-                $resourceCurrentState.Features                   | Should -Be $mockDatabaseEngineDefaultInstanceFeatures
+                $resourceCurrentState.Features                   | Should -Be $ConfigurationData.AllNodes.DatabaseEngineDefaultInstanceFeatures
                 $resourceCurrentState.ForceReboot                | Should -BeNullOrEmpty
                 $resourceCurrentState.FTSvcAccount               | Should -BeNullOrEmpty
                 $resourceCurrentState.FTSvcAccountUsername       | Should -BeNullOrEmpty
-                $resourceCurrentState.InstallSharedDir           | Should -Be $mockInstallSharedDir
-                $resourceCurrentState.InstallSharedWOWDir        | Should -Be $mockInstallSharedWOWDir
-                $resourceCurrentState.InstallSQLDataDir          | Should -Be (Join-Path -Path $mockInstallSharedDir -ChildPath "MSSQL13.$mockDatabaseEngineDefaultInstanceName\MSSQL")
-                $resourceCurrentState.InstanceDir                | Should -Be $mockInstallSharedDir
-                $resourceCurrentState.InstanceID                 | Should -Be $mockDatabaseEngineDefaultInstanceName
-                $resourceCurrentState.InstanceName               | Should -Be $mockDatabaseEngineDefaultInstanceName
+                $resourceCurrentState.InstallSharedDir           | Should -Be $ConfigurationData.AllNodes.InstallSharedDir
+                $resourceCurrentState.InstallSharedWOWDir        | Should -Be $ConfigurationData.AllNodes.InstallSharedWOWDir
+                $resourceCurrentState.InstallSQLDataDir          | Should -Be (Join-Path -Path $ConfigurationData.AllNodes.InstallSharedDir -ChildPath "MSSQL13.$($ConfigurationData.AllNodes.DatabaseEngineDefaultInstanceName)\MSSQL")
+                $resourceCurrentState.InstanceDir                | Should -Be $ConfigurationData.AllNodes.InstallSharedDir
+                $resourceCurrentState.InstanceID                 | Should -Be $ConfigurationData.AllNodes.DatabaseEngineDefaultInstanceName
+                $resourceCurrentState.InstanceName               | Should -Be $ConfigurationData.AllNodes.DatabaseEngineDefaultInstanceName
                 $resourceCurrentState.ISSvcAccount               | Should -BeNullOrEmpty
                 $resourceCurrentState.ISSvcAccountUsername       | Should -BeNullOrEmpty
                 $resourceCurrentState.ProductKey                 | Should -BeNullOrEmpty
@@ -440,15 +379,15 @@ try
                 $resourceCurrentState.SecurityMode               | Should -Be 'Windows'
                 $resourceCurrentState.SetupProcessTimeout        | Should -BeNullOrEmpty
                 $resourceCurrentState.SourceCredential           | Should -BeNullOrEmpty
-                $resourceCurrentState.SourcePath                 | Should -Be "$($mockIsoMediaDriveLetter):\"
-                $resourceCurrentState.SQLBackupDir               | Should -Be (Join-Path -Path $mockInstallSharedDir -ChildPath "MSSQL13.$mockDatabaseEngineDefaultInstanceName\MSSQL\Backup")
-                $resourceCurrentState.SQLCollation               | Should -Be $mockCollation
+                $resourceCurrentState.SourcePath                 | Should -Be "$($ConfigurationData.AllNodes.DriveLetter):\"
+                $resourceCurrentState.SQLBackupDir               | Should -Be (Join-Path -Path $ConfigurationData.AllNodes.InstallSharedDir -ChildPath "MSSQL13.$($ConfigurationData.AllNodes.DatabaseEngineDefaultInstanceName)\MSSQL\Backup")
+                $resourceCurrentState.SQLCollation               | Should -Be $ConfigurationData.AllNodes.Collation
                 $resourceCurrentState.SQLSvcAccount              | Should -BeNullOrEmpty
-                $resourceCurrentState.SQLSvcAccountUsername      | Should -Be ('.\{0}' -f (Split-Path -Path $mockSqlServicePrimaryAccountUserName -Leaf))
+                $resourceCurrentState.SQLSvcAccountUsername      | Should -Be ('.\{0}' -f (Split-Path -Path $ConfigurationData.AllNodes.SqlServicePrimaryAccountUserName -Leaf))
                 $resourceCurrentState.SQLSysAdminAccounts        | Should -Be @(
-                    $mockSqlAdminAccountUserName,
-                    $mockSqlInstallAccountUserName,
-                    "NT SERVICE\$mockDatabaseEngineDefaultInstanceName",
+                    $ConfigurationData.AllNodes.SqlAdministratorAccountUserName,
+                    $ConfigurationData.AllNodes.SqlInstallAccountUserName,
+                    "NT SERVICE\$($ConfigurationData.AllNodes.DatabaseEngineDefaultInstanceName)",
                     "NT SERVICE\SQLSERVERAGENT",
                     'NT SERVICE\SQLWriter',
                     'NT SERVICE\Winmgmt',
@@ -456,17 +395,20 @@ try
                 )
                 $resourceCurrentState.SQLTempDBDir               | Should -BeNullOrEmpty
                 $resourceCurrentState.SQLTempDBLogDir            | Should -BeNullOrEmpty
-                $resourceCurrentState.SQLUserDBDir               | Should -Be (Join-Path -Path $mockInstallSharedDir -ChildPath "MSSQL13.$mockDatabaseEngineDefaultInstanceName\MSSQL\DATA\")
-                $resourceCurrentState.SQLUserDBLogDir            | Should -Be (Join-Path -Path $mockInstallSharedDir -ChildPath "MSSQL13.$mockDatabaseEngineDefaultInstanceName\MSSQL\DATA\")
+                $resourceCurrentState.SQLUserDBDir               | Should -Be (Join-Path -Path $ConfigurationData.AllNodes.InstallSharedDir -ChildPath "MSSQL13.$($ConfigurationData.AllNodes.DatabaseEngineDefaultInstanceName)\MSSQL\DATA\")
+                $resourceCurrentState.SQLUserDBLogDir            | Should -Be (Join-Path -Path $ConfigurationData.AllNodes.InstallSharedDir -ChildPath "MSSQL13.$($ConfigurationData.AllNodes.DatabaseEngineDefaultInstanceName)\MSSQL\DATA\")
                 $resourceCurrentState.SQMReporting               | Should -BeNullOrEmpty
                 $resourceCurrentState.SuppressReboot             | Should -BeNullOrEmpty
                 $resourceCurrentState.UpdateEnabled              | Should -BeNullOrEmpty
                 $resourceCurrentState.UpdateSource               | Should -BeNullOrEmpty
+            }
 
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
             }
         }
 
-        $configurationName = "$($script:DSCResourceName)_StopSqlServerDefaultInstance_Config"
+        $configurationName = "$($script:dscResourceName)_StopSqlServerDefaultInstance_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
@@ -493,15 +435,12 @@ try
             }
         }
 
-        $configurationName = "$($script:DSCResourceName)_InstallTabularAnalysisServicesAsSystem_Config"
+        $configurationName = "$($script:dscResourceName)_InstallTabularAnalysisServicesAsSystem_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     $configurationParameters = @{
-                        SqlInstallCredential        = $mockSqlInstallCredential
-                        SqlAdministratorCredential  = $mockSqlAdminCredential
-                        SqlServicePrimaryCredential = $mockSqlServicePrimaryCredential
                         OutputPath                  = $TestDrive
                         # The variable $ConfigurationData was dot-sourced above.
                         ConfigurationData           = $ConfigurationData
@@ -536,42 +475,41 @@ try
 
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName
-                } | Where-Object -FilterScript {
-                    $_.ResourceId -eq $resourceId
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
                 }
 
                 $resourceCurrentState.Action                     | Should -BeNullOrEmpty
                 $resourceCurrentState.AgtSvcAccount              | Should -BeNullOrEmpty
                 $resourceCurrentState.AgtSvcAccountUsername      | Should -BeNullOrEmpty
-                $resourceCurrentState.ASServerMode               | Should -Be $mockAnalysisServicesTabularServerMode
-                $resourceCurrentState.ASBackupDir                | Should -Be (Join-Path -Path $mockInstallSharedDir -ChildPath "MSAS13.$mockAnalysisServicesTabularInstanceName\OLAP\Backup")
-                $resourceCurrentState.ASCollation                | Should -Be $mockCollation
-                $resourceCurrentState.ASConfigDir                | Should -Be (Join-Path -Path $mockInstallSharedDir -ChildPath "MSAS13.$mockAnalysisServicesTabularInstanceName\OLAP\Config")
-                $resourceCurrentState.ASDataDir                  | Should -Be (Join-Path -Path $mockInstallSharedDir -ChildPath "MSAS13.$mockAnalysisServicesTabularInstanceName\OLAP\Data")
-                $resourceCurrentState.ASLogDir                   | Should -Be (Join-Path -Path $mockInstallSharedDir -ChildPath "MSAS13.$mockAnalysisServicesTabularInstanceName\OLAP\Log")
-                $resourceCurrentState.ASTempDir                  | Should -Be (Join-Path -Path $mockInstallSharedDir -ChildPath "MSAS13.$mockAnalysisServicesTabularInstanceName\OLAP\Temp")
+                $resourceCurrentState.ASServerMode               | Should -Be $ConfigurationData.AllNodes.AnalysisServicesTabularServerMode
+                $resourceCurrentState.ASBackupDir                | Should -Be (Join-Path -Path $ConfigurationData.AllNodes.InstallSharedDir -ChildPath "MSAS13.$($ConfigurationData.AllNodes.AnalysisServicesTabularInstanceName)\OLAP\Backup")
+                $resourceCurrentState.ASCollation                | Should -Be $ConfigurationData.AllNodes.Collation
+                $resourceCurrentState.ASConfigDir                | Should -Be (Join-Path -Path $ConfigurationData.AllNodes.InstallSharedDir -ChildPath "MSAS13.$($ConfigurationData.AllNodes.AnalysisServicesTabularInstanceName)\OLAP\Config")
+                $resourceCurrentState.ASDataDir                  | Should -Be (Join-Path -Path $ConfigurationData.AllNodes.InstallSharedDir -ChildPath "MSAS13.$($ConfigurationData.AllNodes.AnalysisServicesTabularInstanceName)\OLAP\Data")
+                $resourceCurrentState.ASLogDir                   | Should -Be (Join-Path -Path $ConfigurationData.AllNodes.InstallSharedDir -ChildPath "MSAS13.$($ConfigurationData.AllNodes.AnalysisServicesTabularInstanceName)\OLAP\Log")
+                $resourceCurrentState.ASTempDir                  | Should -Be (Join-Path -Path $ConfigurationData.AllNodes.InstallSharedDir -ChildPath "MSAS13.$($ConfigurationData.AllNodes.AnalysisServicesTabularInstanceName)\OLAP\Temp")
                 $resourceCurrentState.ASSvcAccount               | Should -BeNullOrEmpty
-                $resourceCurrentState.ASSvcAccountUsername       | Should -Be ('.\{0}' -f (Split-Path -Path $mockSqlServicePrimaryAccountUserName -Leaf))
+                $resourceCurrentState.ASSvcAccountUsername       | Should -Be ('.\{0}' -f (Split-Path -Path $ConfigurationData.AllNodes.SqlServicePrimaryAccountUserName -Leaf))
                 $resourceCurrentState.ASSysAdminAccounts         | Should -Be @(
-                    $mockSqlAdminAccountUserName,
-                    "NT SERVICE\SSASTELEMETRY`$$mockAnalysisServicesTabularInstanceName"
+                    $ConfigurationData.AllNodes.SqlAdministratorAccountUserName,
+                    "NT SERVICE\SSASTELEMETRY`$$($ConfigurationData.AllNodes.AnalysisServicesTabularInstanceName)"
                 )
                 $resourceCurrentState.BrowserSvcStartupType      | Should -BeNullOrEmpty
                 $resourceCurrentState.ErrorReporting             | Should -BeNullOrEmpty
                 $resourceCurrentState.FailoverClusterGroupName   | Should -BeNullOrEmpty
                 $resourceCurrentState.FailoverClusterIPAddress   | Should -BeNullOrEmpty
                 $resourceCurrentState.FailoverClusterNetworkName | Should -BeNullOrEmpty
-                $resourceCurrentState.Features                   | Should -Be $mockAnalysisServicesTabularFeatures
+                $resourceCurrentState.Features                   | Should -Be $ConfigurationData.AllNodes.AnalysisServicesTabularFeatures
                 $resourceCurrentState.ForceReboot                | Should -BeNullOrEmpty
                 $resourceCurrentState.FTSvcAccount               | Should -BeNullOrEmpty
                 $resourceCurrentState.FTSvcAccountUsername       | Should -BeNullOrEmpty
-                $resourceCurrentState.InstallSharedDir           | Should -Be $mockInstallSharedDir
-                $resourceCurrentState.InstallSharedWOWDir        | Should -Be $mockInstallSharedWOWDir
+                $resourceCurrentState.InstallSharedDir           | Should -Be $ConfigurationData.AllNodes.InstallSharedDir
+                $resourceCurrentState.InstallSharedWOWDir        | Should -Be $ConfigurationData.AllNodes.InstallSharedWOWDir
                 $resourceCurrentState.InstallSQLDataDir          | Should -BeNullOrEmpty
                 $resourceCurrentState.InstanceDir                | Should -BeNullOrEmpty
                 $resourceCurrentState.InstanceID                 | Should -BeNullOrEmpty
-                $resourceCurrentState.InstanceName               | Should -Be $mockAnalysisServicesTabularInstanceName
+                $resourceCurrentState.InstanceName               | Should -Be $ConfigurationData.AllNodes.AnalysisServicesTabularInstanceName
                 $resourceCurrentState.ISSvcAccount               | Should -BeNullOrEmpty
                 $resourceCurrentState.ISSvcAccountUsername       | Should -BeNullOrEmpty
                 $resourceCurrentState.ProductKey                 | Should -BeNullOrEmpty
@@ -581,7 +519,7 @@ try
                 $resourceCurrentState.SecurityMode               | Should -BeNullOrEmpty
                 $resourceCurrentState.SetupProcessTimeout        | Should -BeNullOrEmpty
                 $resourceCurrentState.SourceCredential           | Should -BeNullOrEmpty
-                $resourceCurrentState.SourcePath                 | Should -Be "$($mockIsoMediaDriveLetter):\"
+                $resourceCurrentState.SourcePath                 | Should -Be "$($ConfigurationData.AllNodes.DriveLetter):\"
                 $resourceCurrentState.SQLBackupDir               | Should -BeNullOrEmpty
                 $resourceCurrentState.SQLCollation               | Should -BeNullOrEmpty
                 $resourceCurrentState.SQLSvcAccount              | Should -BeNullOrEmpty
@@ -596,9 +534,13 @@ try
                 $resourceCurrentState.UpdateEnabled              | Should -BeNullOrEmpty
                 $resourceCurrentState.UpdateSource               | Should -BeNullOrEmpty
             }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be $true
+            }
         }
 
-        $configurationName = "$($script:DSCResourceName)_StopTabularAnalysisServices_Config"
+        $configurationName = "$($script:dscResourceName)_StopTabularAnalysisServices_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
@@ -625,7 +567,7 @@ try
             }
         }
 
-        $configurationName = "$($script:DSCResourceName)_StartServicesInstance_Config"
+        $configurationName = "$($script:dscResourceName)_StartServicesInstance_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
@@ -656,8 +598,6 @@ try
 finally
 {
     #region FOOTER
-
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
-
     #endregion
 }

--- a/Tests/Integration/MSFT_SqlSetup.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlSetup.Integration.Tests.ps1
@@ -91,22 +91,27 @@ try
     . $configFile
 
     # These sets variables used for verification from the dot-sourced $ConfigurationData variable.
-    $mockDatabaseEngineNamedInstanceName = $ConfigurationData.AllNodes.DatabaseEngineNamedInstanceName
-    $mockDatabaseEngineNamedInstanceFeatures = $ConfigurationData.AllNodes.DatabaseEngineNamedInstanceFeatures
-    $mockDatabaseEngineDefaultInstanceName = $ConfigurationData.AllNodes.DatabaseEngineDefaultInstanceName
+    $mockDatabaseEngineNamedInstanceName       = $ConfigurationData.AllNodes.DatabaseEngineNamedInstanceName
+    $mockDatabaseEngineNamedInstanceFeatures   = $ConfigurationData.AllNodes.DatabaseEngineNamedInstanceFeatures
+    $mockDatabaseEngineDefaultInstanceName     = $ConfigurationData.AllNodes.DatabaseEngineDefaultInstanceName
     $mockDatabaseEngineDefaultInstanceFeatures = $ConfigurationData.AllNodes.DatabaseEngineDefaultInstanceFeatures
-    $mockAnalysisServicesTabularInstanceName = $ConfigurationData.AllNodes.AnalysisServicesTabularInstanceName
-    $mockAnalysisServicesTabularFeatures = $ConfigurationData.AllNodes.AnalysisServicesTabularFeatures
-    $mockAnalysisServicesTabularServerMode = $ConfigurationData.AllNodes.AnalysisServicesTabularServerMode
-    $mockAnalysisServicesMultiServerMode = $ConfigurationData.AllNodes.AnalysisServicesMultiServerMode
-    $mockCollation = $ConfigurationData.AllNodes.Collation
-    $mockInstallSharedDir = $ConfigurationData.AllNodes.InstallSharedDir
-    $mockInstallSharedWOWDir = $ConfigurationData.AllNodes.InstallSharedWOWDir
-    $mockUpdateEnable = $ConfigurationData.AllNodes.UpdateEnabled
-    $mockSuppressReboot = $ConfigurationData.AllNodes.SuppressReboot
-    $mockForceReboot = $ConfigurationData.AllNodes.ForceReboot
-    $mockIsoMediaFilePath = $ConfigurationData.AllNodes.ImagePath
-    $mockIsoMediaDriveLetter = $ConfigurationData.AllNodes.DriveLetter
+    $mockAnalysisServicesTabularInstanceName   = $ConfigurationData.AllNodes.AnalysisServicesTabularInstanceName
+    $mockAnalysisServicesTabularFeatures       = $ConfigurationData.AllNodes.AnalysisServicesTabularFeatures
+    $mockAnalysisServicesTabularServerMode     = $ConfigurationData.AllNodes.AnalysisServicesTabularServerMode
+    $mockAnalysisServicesMultiServerMode       = $ConfigurationData.AllNodes.AnalysisServicesMultiServerMode
+    $mockCollation                             = $ConfigurationData.AllNodes.Collation
+    $mockInstallSharedDir                      = $ConfigurationData.AllNodes.InstallSharedDir
+    $mockInstallSharedWOWDir                   = $ConfigurationData.AllNodes.InstallSharedWOWDir
+    $mockUpdateEnable                          = $ConfigurationData.AllNodes.UpdateEnabled
+    $mockSuppressReboot                        = $ConfigurationData.AllNodes.SuppressReboot
+    $mockForceReboot                           = $ConfigurationData.AllNodes.ForceReboot
+    $mockIsoMediaFilePath                      = $ConfigurationData.AllNodes.ImagePath
+    $mockIsoMediaDriveLetter                   = $ConfigurationData.AllNodes.DriveLetter
+    $mockSqlTempdbFileCount                    = $ConfigurationData.AllNodes.SqlTempdbFileCount
+    $mockSqlTempdbFileSize                     = $ConfigurationData.AllNodes.SqlTempdbFileSize
+    $mockSqlTempdbFileGrowth                   = $ConfigurationData.AllNodes.SqlTempdbFileGrowth
+    $mockSqlTempdbLogFileSize                  = $ConfigurationData.AllNodes.SqlTempdbLogFileSize
+    $mockSqlTempdbLogFileGrowth                = $ConfigurationData.AllNodes.SqlTempdbLogFileGrowth
 
     $mockSourceMediaUrl = 'https://download.microsoft.com/download/9/0/7/907AD35F-9F9C-43A5-9789-52470555DB90/ENU/SQLServer2016SP1-FullSlipstream-x64-ENU.iso'
 
@@ -311,7 +316,12 @@ try
                     'sa'
                 )
                 $resourceCurrentState.SQLTempDBDir               | Should -BeNullOrEmpty
+                $resourceCurrentState.SqlTempdbFileCount         | Should -Be $mockSqlTempdbFileCount
+                $resourceCurrentState.SqlTempdbFileSize          | Should -Be $mockSqlTempdbFileSize
+                $resourceCurrentState.SqlTempdbFileGrowth        | Should -Be $mockSqlTempdbFileGrowth
                 $resourceCurrentState.SQLTempDBLogDir            | Should -BeNullOrEmpty
+                $resourceCurrentState.SqlTempdbLogFileSize       | Should -Be $mockSqlTempdbLogFileSize
+                $resourceCurrentState.SqlTempdbLogFileGrowth     | Should -Be $mockSqlTempdbLogFileGrowth
                 $resourceCurrentState.SQLUserDBDir               | Should -Be (Join-Path -Path $mockInstallSharedDir -ChildPath "MSSQL13.$mockDatabaseEngineNamedInstanceName\MSSQL\DATA\")
                 $resourceCurrentState.SQLUserDBLogDir            | Should -Be (Join-Path -Path $mockInstallSharedDir -ChildPath "MSSQL13.$mockDatabaseEngineNamedInstanceName\MSSQL\DATA\")
                 $resourceCurrentState.SQMReporting               | Should -BeNullOrEmpty

--- a/Tests/Integration/MSFT_SqlSetup.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlSetup.Integration.Tests.ps1
@@ -2,21 +2,16 @@
 [Microsoft.DscResourceKit.IntegrationTest(OrderNumber = 1)]
 param()
 
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
+if (Test-SkipContinuousIntegrationTask -Type 'Integration')
+{
+    return
+}
+
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceFriendlyName = 'SqlSetup'
 $script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
-
-if (-not $env:APPVEYOR -eq $true)
-{
-    Write-Warning -Message ('Integration test for {0} will be skipped unless $env:APPVEYOR equals $true' -f $script:DSCResourceName)
-    return
-}
-
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Integration')
-{
-    Write-Verbose -Message ('Integration test for {0} will be skipped unless $env:CONFIGURATION is set to ''Integration''.' -f $script:DSCResourceName) -Verbose
-    return
-}
 
 #region HEADER
 # Integration Test Template Version: 1.1.2

--- a/Tests/Integration/MSFT_SqlSetup.config.ps1
+++ b/Tests/Integration/MSFT_SqlSetup.config.ps1
@@ -231,17 +231,31 @@ Configuration MSFT_SqlSetup_InstallDatabaseEngineNamedInstanceAsSystem_Config
     }
 }
 
-Configuration MSFT_SqlSetup_StopMultiAnalysisServicesInstance_Config
+Configuration MSFT_SqlSetup_StopServicesInstance_Config
 {
     Import-DscResource -ModuleName 'PSDscResources'
 
     node localhost
     {
-        # Service ('StopSqlServerInstance{0}' -f $Node.DatabaseEngineNamedInstanceName)
-        # {
-        #     Name   = ('MSSQL${0}' -f $Node.DatabaseEngineNamedInstanceName)
-        #     State  = 'Stopped'
-        # }
+        <#
+            Stopping the SQL Server Agent service for the named instance.
+            It will be restarted at the end of the tests.
+        #>
+        Service ('StopSqlServerAgentForInstance{0}' -f $Node.DatabaseEngineNamedInstanceName)
+        {
+            Name  = ('SQLAGENT${0}' -f $Node.DatabaseEngineNamedInstanceName)
+            State = 'Stopped'
+        }
+
+        <#
+            Stopping the Database Engine named instance. It will be restarted
+            at the end of the tests.
+        #>
+        Service ('StopSqlServerInstance{0}' -f $Node.DatabaseEngineNamedInstanceName)
+        {
+            Name   = ('MSSQL${0}' -f $Node.DatabaseEngineNamedInstanceName)
+            State  = 'Stopped'
+        }
 
         Service ('StopMultiAnalysisServicesInstance{0}' -f $Node.DatabaseEngineNamedInstanceName)
         {
@@ -380,6 +394,28 @@ Configuration MSFT_SqlSetup_StopTabularAnalysisServices_Config
         {
             Name  = ('MSOLAP${0}' -f $Node.DatabaseEngineNamedInstanceName)
             State = 'Stopped'
+        }
+    }
+}
+
+Configuration MSFT_SqlSetup_StartServicesInstance_Config
+{
+    Import-DscResource -ModuleName 'PSDscResources'
+
+    node localhost
+    {
+        # Start the Database Engine named instance.
+        Service ('StartSqlServerInstance{0}' -f $Node.DatabaseEngineNamedInstanceName)
+        {
+            Name   = ('MSSQL${0}' -f $Node.DatabaseEngineNamedInstanceName)
+            State  = 'Running'
+        }
+
+        # Starting the SQL Server Agent service for the named instance.
+        Service ('StartSqlServerAgentForInstance{0}' -f $Node.DatabaseEngineNamedInstanceName)
+        {
+            Name  = ('SQLAGENT${0}' -f $Node.DatabaseEngineNamedInstanceName)
+            State = 'Running'
         }
     }
 }

--- a/Tests/Integration/MSFT_SqlSetup.config.ps1
+++ b/Tests/Integration/MSFT_SqlSetup.config.ps1
@@ -45,6 +45,13 @@ $ConfigurationData = @{
             ImagePath                             = "$env:TEMP\SQL2016.iso"
             DriveLetter                           = $mockIsoMediaDriveLetter
 
+            # Parameters to configure Tempdb
+            SqlTempdbFileCount                    = '2'
+            SqlTempdbFileSize                     = '128'
+            SqlTempdbFileGrowth                   = '128'
+            SqlTempdbLogFileSize                  = '128'
+            SqlTempdbLogFileGrowth                = '128'
+
             CertificateFile                       = $env:DscPublicCertificatePath
         }
     )
@@ -192,26 +199,31 @@ Configuration MSFT_SqlSetup_InstallDatabaseEngineNamedInstanceAsSystem_Config
     {
         SqlSetup 'Integration_Test'
         {
-            InstanceName          = $Node.DatabaseEngineNamedInstanceName
-            Features              = $Node.DatabaseEngineNamedInstanceFeatures
-            SourcePath            = "$($Node.DriveLetter):\"
-            SqlSvcStartupType     = 'Automatic'
-            AgtSvcStartupType     = 'Automatic'
-            BrowserSvcStartupType = 'Automatic'
-            SecurityMode          = 'SQL'
-            SAPwd                 = $SqlAdministratorCredential
-            SQLCollation          = $Node.Collation
-            SQLSvcAccount         = $SqlServicePrimaryCredential
-            AgtSvcAccount         = $SqlAgentServicePrimaryCredential
-            ASServerMode          = $Node.AnalysisServicesMultiServerMode
-            AsSvcStartupType      = 'Automatic'
-            ASCollation           = $Node.Collation
-            ASSvcAccount          = $SqlServicePrimaryCredential
-            InstallSharedDir      = $Node.InstallSharedDir
-            InstallSharedWOWDir   = $Node.InstallSharedWOWDir
-            UpdateEnabled         = $Node.UpdateEnabled
-            SuppressReboot        = $Node.SuppressReboot
-            ForceReboot           = $Node.ForceReboot
+            InstanceName           = $Node.DatabaseEngineNamedInstanceName
+            Features               = $Node.DatabaseEngineNamedInstanceFeatures
+            SourcePath             = "$($Node.DriveLetter):\"
+            SqlSvcStartupType      = 'Automatic'
+            AgtSvcStartupType      = 'Automatic'
+            BrowserSvcStartupType  = 'Automatic'
+            SecurityMode           = 'SQL'
+            SAPwd                  = $SqlAdministratorCredential
+            SQLCollation           = $Node.Collation
+            SQLSvcAccount          = $SqlServicePrimaryCredential
+            AgtSvcAccount          = $SqlAgentServicePrimaryCredential
+            ASServerMode           = $Node.AnalysisServicesMultiServerMode
+            AsSvcStartupType       = 'Automatic'
+            ASCollation            = $Node.Collation
+            ASSvcAccount           = $SqlServicePrimaryCredential
+            InstallSharedDir       = $Node.InstallSharedDir
+            InstallSharedWOWDir    = $Node.InstallSharedWOWDir
+            UpdateEnabled          = $Node.UpdateEnabled
+            SuppressReboot         = $Node.SuppressReboot
+            ForceReboot            = $Node.ForceReboot
+            SqlTempdbFileCount     = $Node.SqlTempdbFileCount
+            SqlTempdbFileSize      = $Node.SqlTempdbFileSize
+            SqlTempdbFileGrowth    = $Node.SqlTempdbFileGrowth
+            SqlTempdbLogFileSize   = $Node.SqlTempdbLogFileSize
+            SqlTempdbLogFileGrowth = $Node.SqlTempdbLogFileGrowth
 
             # This must be set if using SYSTEM account to install.
             SQLSysAdminAccounts   = @(

--- a/Tests/TestHelpers/CommonTestHelper.psm1
+++ b/Tests/TestHelpers/CommonTestHelper.psm1
@@ -286,3 +286,50 @@ function New-SQLSelfSignedCertificate
 
     return $certificate
 }
+
+<#
+    .SYNOPSIS
+        Returns $true if the the environment variable APPVEYOR is set to $true,
+        and the environment variable CONFIGURATION is set to the value passed
+        in the parameter Type.
+
+    .PARAMETER Name
+        Name of the test script that is called. Defaults to the name of the
+        calling script.
+
+    .PARAMETER Type
+        Type of tests in the test file. Can be set to Unit or Integration.
+#>
+function Test-SkipContinuousIntegrationTask
+{
+    [OutputType([System.Boolean])]
+    [CmdletBinding()]
+    param
+    (
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Name = $MyInvocation.PSCommandPath.Split('\')[-1],
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Unit', 'Integration')]
+        [System.String]
+        $Type
+    )
+
+    $result = $false
+
+    if ($Type -eq 'Integration' -and -not $env:APPVEYOR -eq $true)
+    {
+        Write-Warning -Message ('{1} test for {0} will be skipped unless $env:APPVEYOR is set to $true' -f $Name, $Type)
+        $result = $true
+    }
+
+    if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne $Type)
+    {
+        Write-Verbose -Message ('{1} tests in {0} will be skipped unless $env:CONFIGURATION is set to ''{1}''.' -f $Name, $Type) -Verbose
+        $result = $true
+    }
+
+    return $result
+}

--- a/Tests/TestHelpers/CommonTestHelper.psm1
+++ b/Tests/TestHelpers/CommonTestHelper.psm1
@@ -246,7 +246,7 @@ function New-SQLSelfSignedCertificate
 {
     $sqlPublicCertificatePath = Join-Path -Path $env:temp -ChildPath 'SqlPublicKey.cer'
     $sqlPrivateCertificatePath = Join-Path -Path $env:temp -ChildPath 'SqlPrivateKey.cer'
-    $sqlPriavteKeyPassword = ConvertTo-SecureString -String "1234" -Force -AsPlainText
+    $sqlPrivateKeyPassword = ConvertTo-SecureString -String "1234" -Force -AsPlainText
 
     $certificateSubject = $env:COMPUTERNAME
 
@@ -254,8 +254,8 @@ function New-SQLSelfSignedCertificate
         There are build workers still on Windows Server 2012 R2 so let's
         use the alternate method of New-SelfSignedCertificate.
     #>
-    Install-Module -Name PSPKI -Scope CurrentUser -Force
-    Import-Module -Name PSPKI
+    Install-Module -Name 'PSPKI' -Scope 'CurrentUser' -Force
+    Import-Module -Name 'PSPKI'
 
     $newSelfSignedCertificateExParameters = @{
         Subject            = "CN=$certificateSubject"
@@ -264,7 +264,7 @@ function New-SQLSelfSignedCertificate
         SAN                = "dns:$certificateSubject"
         FriendlyName       = 'Sql Encryption certificate'
         Path               = $sqlPrivateCertificatePath
-        Password           = $sqlPriavteKeyPassword
+        Password           = $sqlPrivateKeyPassword
         Exportable         = $true
         KeyLength          = 2048
         ProviderName       = 'Microsoft Enhanced Cryptographic Provider v1.0'

--- a/Tests/Unit/CommonResourceHelper.Tests.ps1
+++ b/Tests/Unit/CommonResourceHelper.Tests.ps1
@@ -8,21 +8,26 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container1', ContainerImage = 'microsoft/windowsservercore')]
-param()
 
-Describe 'CommonResourceHelper Unit Tests' {
+$script:helperModuleName = 'CommonResourceHelper'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:helperModuleName) -Verbose
+    return
+}
+
+Describe "$script:helperModuleName Unit Tests" {
     BeforeAll {
         # Import the CommonResourceHelper module to test
         $dscResourcesFolderFilePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) `
                                                 -ChildPath 'DscResources'
 
         Import-Module -Name (Join-Path -Path $dscResourcesFolderFilePath `
-                                       -ChildPath 'CommonResourceHelper.psm1') -Force
+                                       -ChildPath "$script:helperModuleName.psm1") -Force
     }
 
-    InModuleScope 'CommonResourceHelper' {
+    InModuleScope $script:helperModuleName {
         Describe 'Get-LocalizedData' {
             $mockTestPath = {
                 return $mockTestPathReturnValue

--- a/Tests/Unit/CommonResourceHelper.Tests.ps1
+++ b/Tests/Unit/CommonResourceHelper.Tests.ps1
@@ -8,14 +8,14 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-$script:helperModuleName = 'CommonResourceHelper'
-
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:helperModuleName) -Verbose
     return
 }
+
+$script:helperModuleName = 'CommonResourceHelper'
 
 Describe "$script:helperModuleName Unit Tests" {
     BeforeAll {

--- a/Tests/Unit/MSFT_SqlAG.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAG.Tests.ps1
@@ -8,9 +8,14 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container1', ContainerImage = 'microsoft/windowsservercore')]
-param()
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlAG'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region HEADER
 
@@ -26,13 +31,14 @@ Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -P
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'Tests' -ChildPath (Join-Path -Path 'TestHelpers' -ChildPath 'CommonTestHelper.psm1'))) -Force -Global
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName 'SqlServerDsc' `
-    -DSCResourceName 'MSFT_SqlAG' `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
     -TestType Unit
 
 #endregion HEADER
 
-function Invoke-TestSetup {
+function Invoke-TestSetup
+{
     # Load the SMO stubs
     Add-Type -Path ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SMO.cs )
 
@@ -40,7 +46,8 @@ function Invoke-TestSetup {
     Import-SQLModuleStub
 }
 
-function Invoke-TestCleanup {
+function Invoke-TestCleanup
+{
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
 }
 
@@ -49,7 +56,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope 'MSFT_SqlAG' {
+    InModuleScope $script:DSCResourceName {
 
         #region parameter mocks
 

--- a/Tests/Unit/MSFT_SqlAG.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAG.Tests.ps1
@@ -15,8 +15,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlAG'
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlAG'
 
 #region HEADER
 
@@ -31,8 +31,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -56,7 +56,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
         # This is relative to the path of the resource module script, not test test script.
         $script:moduleRoot = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent
         Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'Tests' -ChildPath (Join-Path -Path 'TestHelpers' -ChildPath 'CommonTestHelper.psm1'))) -Force -Global

--- a/Tests/Unit/MSFT_SqlAG.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAG.Tests.ps1
@@ -8,14 +8,15 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlAG'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
+
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlAG'
 
 #region HEADER
 
@@ -28,7 +29,6 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 }
 
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
-Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'Tests' -ChildPath (Join-Path -Path 'TestHelpers' -ChildPath 'CommonTestHelper.psm1'))) -Force -Global
 
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $script:DSCModuleName `
@@ -57,6 +57,9 @@ try
     Invoke-TestSetup
 
     InModuleScope $script:DSCResourceName {
+        # This is relative to the path of the resource module script, not test test script.
+        $script:moduleRoot = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent
+        Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'Tests' -ChildPath (Join-Path -Path 'TestHelpers' -ChildPath 'CommonTestHelper.psm1'))) -Force -Global
 
         #region parameter mocks
 

--- a/Tests/Unit/MSFT_SqlAGDatabase.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAGDatabase.Tests.ps1
@@ -15,8 +15,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlAGDatabase'
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlAGDatabase'
 
 #region HEADER
 
@@ -36,8 +36,8 @@ Import-Module -Name ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath
 Add-Type -Path ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SMO.cs )
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -58,7 +58,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
 
         #region Parameter Mocks
 

--- a/Tests/Unit/MSFT_SqlAGDatabase.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAGDatabase.Tests.ps1
@@ -8,14 +8,15 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlAGDatabase'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
+
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlAGDatabase'
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlAGListener.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAGListener.Tests.ps1
@@ -15,8 +15,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlAGListener'
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlAGListener'
 
 #region HEADER
 
@@ -31,8 +31,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -53,7 +53,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
 
         $mockKnownAvailabilityGroup = 'AG01'
         $mockUnknownAvailabilityGroup = 'UnknownAG'

--- a/Tests/Unit/MSFT_SqlAGListener.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAGListener.Tests.ps1
@@ -8,12 +8,14 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container1', ContainerImage = 'microsoft/windowsservercore')]
-param()
-
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceName = 'MSFT_SqlAGListener'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlAGListener.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAGListener.Tests.ps1
@@ -8,14 +8,15 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlAGListener'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
+
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlAGListener'
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlAGReplica.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAGReplica.Tests.ps1
@@ -8,9 +8,15 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container1', ContainerImage = 'microsoft/windowsservercore')]
-param()
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlAGReplica'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
+
 
 #region HEADER
 
@@ -27,8 +33,8 @@ Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -P
 Add-Type -Path ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SMO.cs )
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName 'SqlServerDsc' `
-    -DSCResourceName 'MSFT_SqlAGReplica' `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -47,7 +53,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope 'MSFT_SqlAGReplica' {
+    InModuleScope $script:DSCResourceName {
 
         #region parameter mocks
 

--- a/Tests/Unit/MSFT_SqlAGReplica.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAGReplica.Tests.ps1
@@ -15,8 +15,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlAGReplica'
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlAGReplica'
 
 #region HEADER
 
@@ -33,8 +33,8 @@ Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -P
 Add-Type -Path ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SMO.cs )
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -53,7 +53,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
 
         #region parameter mocks
 

--- a/Tests/Unit/MSFT_SqlAGReplica.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAGReplica.Tests.ps1
@@ -8,15 +8,15 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlAGReplica'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
 
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlAGReplica'
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlAgentOperator.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAgentOperator.Tests.ps1
@@ -1,0 +1,446 @@
+<#
+    .SYNOPSIS
+        Automated unit test for MSFT_SqlAgentOperator DSC resource.
+
+    .NOTES
+        To run this script locally, please make sure to first run the bootstrap
+        script. Read more at
+        https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
+#>
+
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlAgentOperator'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
+#region HEADER
+
+# Unit Test Template Version: 1.2.0
+$script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit
+
+#endregion HEADER
+
+function Invoke-TestSetup
+{
+    # Loading mocked classes
+}
+
+function Invoke-TestCleanup
+{
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+}
+
+# Begin Testing
+try
+{
+    Invoke-TestSetup
+
+    InModuleScope $script:DSCResourceName {
+        $mockServerName = 'localhost'
+        $mockInstanceName = 'MSSQLSERVER'
+        $mockSqlAgentOperatorName = 'Nancy'
+        $mockSqlAgentOperatorEmail = 'nancy@contoso.com'
+        $mockInvalidOperationForCreateMethod = $false
+        $mockInvalidOperationForDropMethod = $false
+        $mockInvalidOperationForAlterMethod = $false
+        $mockExpectedSqlAgentOperatorToCreate = 'Bob'
+        $mockExpectedSqlAgentOperatorToDrop = 'Fred'
+
+        # Default parameters that are used for the It-blocks
+        $mockDefaultParameters = @{
+            InstanceName = $mockInstanceName
+            ServerName   = $mockServerName
+        }
+
+        #region Function mocks
+        $mockConnectSQL = {
+            return @(
+                (
+                New-Object -TypeName Object |
+                    Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockInstanceName -PassThru |
+                    Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockServerName -PassThru |
+                    Add-Member -MemberType ScriptProperty -Name JobServer -Value {
+                        return (New-Object -TypeName Object |
+                            Add-Member -MemberType NoteProperty -Name Name -Value $mockServerName -PassThru |
+                            Add-Member -MemberType ScriptProperty -Name Operators -Value {
+                                return ( New-Object -TypeName Microsoft.SqlServer.Management.Smo.Agent.Operator |
+                                    Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlAgentOperatorName -PassThru -Force |
+                                    Add-Member -MemberType NoteProperty -Name EmailAddress -Value $mockSqlAgentOperatorEmail -PassThru -Force |
+                                    Add-Member -MemberType ScriptMethod -Name Drop -Value {
+                                        if ($mockInvalidOperationForDropMethod)
+                                        {
+                                            throw 'Mock Drop Method was called with invalid operation.'
+                                        }
+                                        if ( $this.Name -ne $mockExpectedSqlAgentOperatorToDrop )
+                                        {
+                                            throw "Called mocked Drop() method without dropping the right sql agent operator. Expected '{0}'. But was '{1}'." `
+                                            -f $mockExpectedSqlAgentOperatorToDrop, $this.Name
+                                        }
+                                    } -PassThru -Force |
+                                    Add-Member -MemberType ScriptMethod -Name Alter -Value {
+                                        if ($mockInvalidOperationForAlterMethod)
+                                        {
+                                            throw 'Mock Alter Method was called with invalid operation.'
+                                        }
+                                    } -PassThru -Force
+                                )
+                            } -PassThru
+                        )
+                    } -PassThru -Force
+                )
+            )
+        }
+
+        $mockNewSqlAgentOperator  = {
+            return @(
+                (
+                    New-Object -TypeName Object |
+                        Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlAgentOperatorName -PassThru |
+                        Add-Member -MemberType ScriptMethod -Name Create -Value {
+                            if ($mockInvalidOperationForCreateMethod)
+                            {
+                                throw 'Mock Create Method was called with invalid operation.'
+                            }
+
+                            if ( $this.Name -ne $mockExpectedSqlAgentOperatorToCreate )
+                            {
+                                throw "Called mocked Create() method without adding the right sql agent operator. Expected '{0}'. But was '{1}'." `
+                                    -f $mockExpectedSqlAgentOperatorToCreate, $this.Name
+                            }
+                        } -PassThru -Force
+                )
+            )
+        }
+        #endregion
+
+        Describe "MSFT_SqlAgentOperator\Get-TargetResource" -Tag 'Get' {
+            BeforeEach {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+                Mock -CommandName New-Object -MockWith $mockNewSqlAgentOperator -ParameterFilter {
+                    $TypeName -eq 'Microsoft.SqlServer.Management.Smo.Agent.Operator'
+                } -Verifiable
+            }
+
+            Context 'When the system is not in the desired state' {
+                $testParameters = $mockDefaultParameters
+                $testParameters += @{
+                    Name         = 'MissingOperator'
+                }
+
+                It 'Should return the state as absent' {
+                    $result = Get-TargetResource @testParameters
+                    $result.Ensure | Should -Be 'Absent'
+                }
+
+                It 'Should return the same values as passed as parameters' {
+                    $result = Get-TargetResource @testParameters
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
+                }
+
+                It 'Should call the mock function Connect-SQL' {
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 2 -Scope Context
+                }
+
+                It 'Should call the mock function New-Object with TypeName equal to Microsoft.SqlServer.Management.Smo.Agent.Operator' {
+                    Assert-MockCalled -CommandName New-Object -Exactly -Times 2 -ParameterFilter {
+                        $TypeName -eq 'Microsoft.SqlServer.Management.Smo.Agent.Operator'
+                    } -Scope Context
+                }
+            }
+
+            Context 'When the system is in the desired state for a sql agent operator' {
+
+                $testParameters = $mockDefaultParameters
+                $testParameters += @{
+                    Name         = 'Nancy'
+                }
+
+                It 'Should return the state as present' {
+                    $result = Get-TargetResource @testParameters
+                    $result.Ensure | Should -Be 'Present'
+                }
+
+                It 'Should return the same values as passed as parameters' {
+                    $result = Get-TargetResource @testParameters
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
+                    $result.Name | Should -Be $testParameters.Name
+                }
+
+                It 'Should call the mock function Connect-SQL' {
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 2 -Scope Context
+                }
+
+                It 'Should call the mock function New-Object with TypeName equal to Microsoft.SqlServer.Management.Smo.Agent.Operator' {
+                    Assert-MockCalled -CommandName New-Object -Exactly -Times 2 -ParameterFilter {
+                        $TypeName -eq 'Microsoft.SqlServer.Management.Smo.Agent.Operator'
+                    } -Scope Context
+                }
+            }
+
+            Assert-VerifiableMock
+        }
+
+        Describe "MSFT_SqlAgentOperator\Test-TargetResource" -Tag 'Test' {
+            BeforeEach {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+                Mock -CommandName New-Object -MockWith $mockNewSqlAgentOperator -ParameterFilter {
+                    $TypeName -eq 'Microsoft.SqlServer.Management.Smo.Agent.Operator'
+                } -Verifiable
+            }
+
+            Context 'When the system is not in the desired state and Ensure is set to Present' {
+                It 'Should return the state as false when desired sql agent operator does not exist' {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        Name         = 'MissingOperator'
+                        EmailAddress = 'missing@operator.com'
+                        Ensure       = 'Present'
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should -Be $false
+                }
+
+                It 'Should return the state as false when desired sql agent operator exists but has the incorrect email' {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        Name            = 'Nancy'
+                        Ensure          = 'Present'
+                        EmailAddress    = 'wrongEmail@contoso.com'
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should -Be $false
+                }
+
+                It 'Should call the mock function Connect-SQL' {
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 2 -Scope Context
+                }
+
+                It 'Should call the mock function New-Object with TypeName equal to Microsoft.SqlServer.Management.Smo.Agent.Operator' {
+                    Assert-MockCalled -CommandName New-Object -Exactly -Times 2 -ParameterFilter {
+                        $TypeName -eq 'Microsoft.SqlServer.Management.Smo.Agent.Operator'
+                    } -Scope Context
+                }
+            }
+
+            Context 'When the system is not in the desired state and Ensure is set to Absent' {
+                It 'Should return the state as false when non-desired sql agent operator exist' {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        Name   = 'Nancy'
+                        Ensure = 'Absent'
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should -Be $false
+                }
+
+                It 'Should call the mock function Connect-SQL' {
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope Context
+                }
+
+                It 'Should call the mock function New-Object with TypeName equal to Microsoft.SqlServer.Management.Smo.Agent.Operator' {
+                    Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -ParameterFilter {
+                        $TypeName -eq 'Microsoft.SqlServer.Management.Smo.Agent.Operator'
+                    } -Scope Context
+                }
+            }
+
+            Context 'When the system is in the desired state and Ensure is set to Present' {
+                It 'Should return the state as true when desired sql agent operator exist' {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        Name      = 'Nancy'
+                        Ensure    = 'Present'
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should -Be $true
+                }
+
+                It 'Should return the state as true when desired sql asgent operator exists and has the correct email' {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        Name            = 'Nancy'
+                        Ensure          = 'Present'
+                        EmailAddress    = 'nancy@contoso.com'
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should -Be $true
+                }
+
+                It 'Should call the mock function Connect-SQL' {
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 2 -Scope Context
+                }
+
+                It 'Should call the mock function New-Object with TypeName equal to Microsoft.SqlServer.Management.Smo.Agent.Operator' {
+                    Assert-MockCalled -CommandName New-Object -Exactly -Times 2 -ParameterFilter {
+                        $TypeName -eq 'Microsoft.SqlServer.Management.Smo.Agent.Operator'
+                    } -Scope Context
+                }
+            }
+
+            Context 'When the system is in the desired state and Ensure is set to Absent' {
+                It 'Should return the state as true when desired sql agent operator does not exist' {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        Name   = 'UnknownOperator'
+                        Ensure = 'Absent'
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should -Be $true
+                }
+
+                It 'Should call the mock function Connect-SQL' {
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope Context
+                }
+
+                It 'Should call the mock function New-Object with TypeName equal to Microsoft.SqlServer.Management.Smo.Agent.Operator' {
+                    Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -ParameterFilter {
+                        $TypeName -eq 'Microsoft.SqlServer.Management.Smo.Agent.Operator'
+                    } -Scope Context
+                }
+            }
+
+            Assert-VerifiableMock
+        }
+
+        Describe "MSFT_SqlAgentOperator\Set-TargetResource" -Tag 'Set' {
+            BeforeEach {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+                Mock -CommandName New-Object -MockWith $mockNewSqlAgentOperator -ParameterFilter {
+                    $TypeName -eq 'Microsoft.SqlServer.Management.Smo.Agent.Operator'
+                } -Verifiable
+            }
+
+            $mockSqlAgentOperatorName = 'Fred'
+
+            Context 'When the system is not in the desired state and Ensure is set to Present' {
+                It 'Should not throw when creating the sql agent operator' {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        Name   = 'Fred'
+                        Ensure = 'Present'
+                    }
+                    { Set-TargetResource @testParameters } | Should -Not -Throw
+                }
+
+                It 'Should not throw when changing the email address' {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        Name      = 'Fred'
+                        Ensure    = 'Present'
+                        EmailAddress = 'newemail@contoso.com'
+                    }
+                    { Set-TargetResource @testParameters } | Should -Not -Throw
+                }
+
+                It 'Should call the mock function Connect-SQL' {
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 2 -Scope Context
+                }
+
+                It 'Should call the mock function New-Object with TypeName equal to Microsoft.SqlServer.Management.Smo.Agent.Operator' {
+                    Assert-MockCalled -CommandName New-Object -Exactly -Times 2 -ParameterFilter {
+                        $TypeName -eq 'Microsoft.SqlServer.Management.Smo.Agent.Operator'
+                    } -Scope Context
+                }
+            }
+
+            Context 'When the system is not in the desired state and Ensure is set to Absent' {
+                It 'Should not throw when dropping the sql agent operator' {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        Name   = 'Bill'
+                        Ensure = 'Absent'
+                    }
+                    { Set-TargetResource @testParameters } | Should -Not -Throw
+                }
+
+                It 'Should call the mock function Connect-SQL' {
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope Context
+                }
+
+                It 'Should call the mock function New-Object with TypeName equal to Microsoft.SqlServer.Management.Smo.Agent.Operator' {
+                    Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -ParameterFilter {
+                        $TypeName -eq 'Microsoft.SqlServer.Management.Smo.Agent.Operator'
+                    } -Scope Context
+                }
+            }
+
+            $mockInvalidOperationForCreateMethod = $true
+            $mockInvalidOperationForAlterMethod = $true
+
+            Context 'When the system is not in the desired state and Ensure is set to Present' {
+                It 'Should throw the correct error when Create() method was called with invalid operation' {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        Name   = 'NewOperator'
+                        Ensure = 'Present'
+                    }
+                    $errorMessage = ($script:localizedData.CreateOperatorSetError -f $testParameters.Name, $testParameters.ServerName, $testParameters.InstanceName)
+                    { Set-TargetResource @testParameters } | Should -Throw $errorMessage
+                }
+
+                It 'Should call the mock function Connect-SQL' {
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope Context
+                }
+
+                It 'Should call the mock function New-Object with TypeName equal to Microsoft.SqlServer.Management.Smo.Agent.Operator' {
+                    Assert-MockCalled -CommandName New-Object -Exactly -Times 2 -ParameterFilter {
+                        $TypeName -eq 'Microsoft.SqlServer.Management.Smo.Agent.Operator'
+                    } -Scope Context
+                }
+            }
+            $mockInvalidOperationForDropMethod = $true
+
+            Context 'When the system is not in the desired state and Ensure is set to Absent' {
+
+                $testParameters = $mockDefaultParameters
+                $testParameters += @{
+                    Name      = 'Fred'
+                    Ensure    = 'Absent'
+                }
+
+                $errorMessage = ($script:localizedData.DropOperatorSetError -f $testParameters.Name, $testParameters.ServerName, $testParameters.InstanceName)
+                It 'Should throw the correct error when Drop() method was called with invalid operation' {
+                    { Set-TargetResource @testParameters } | Should -Throw $errorMessage
+                }
+
+                It 'Should call the mock function Connect-SQL' {
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope Context
+                }
+
+                It 'Should call the mock function New-Object with TypeName equal to Microsoft.SqlServer.Management.Smo.Agent.Operator' {
+                    Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -ParameterFilter {
+                        $TypeName -eq 'Microsoft.SqlServer.Management.Smo.Agent.Operator'
+                    } -Scope Context
+                }
+            }
+            Assert-VerifiableMock
+        }
+    }
+}
+finally
+{
+    Invoke-TestCleanup
+}

--- a/Tests/Unit/MSFT_SqlAgentOperator.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAgentOperator.Tests.ps1
@@ -8,14 +8,16 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
+{
+    return
+}
+
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceName = 'MSFT_SqlAgentOperator'
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
-{
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
-    return
-}
 #region HEADER
 
 # Unit Test Template Version: 1.2.0

--- a/Tests/Unit/MSFT_SqlAgentOperator.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAgentOperator.Tests.ps1
@@ -15,8 +15,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlAgentOperator'
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlAgentOperator'
 
 #region HEADER
 
@@ -31,8 +31,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -52,7 +52,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
         $mockServerName = 'localhost'
         $mockInstanceName = 'MSSQLSERVER'
         $mockSqlAgentOperatorName = 'Nancy'

--- a/Tests/Unit/MSFT_SqlAlias.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAlias.Tests.ps1
@@ -15,8 +15,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlAlias'
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlAlias'
 
 #region HEADER
 
@@ -31,8 +31,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -49,7 +49,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
         $registryPath = 'HKLM:\SOFTWARE\Microsoft\MSSQLServer\Client\ConnectTo'
         $registryPathWow6432Node = 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\MSSQLServer\Client\ConnectTo'
 

--- a/Tests/Unit/MSFT_SqlAlias.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAlias.Tests.ps1
@@ -8,14 +8,15 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlAlias'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
+
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlAlias'
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlAlias.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAlias.Tests.ps1
@@ -8,9 +8,14 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container1', ContainerImage = 'microsoft/windowsservercore')]
-param()
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlAlias'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region HEADER
 
@@ -25,8 +30,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName 'SqlServerDsc' `
-    -DSCResourceName 'MSFT_SqlAlias' `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -43,7 +48,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope 'MSFT_SqlAlias' {
+    InModuleScope $script:DSCResourceName {
         $registryPath = 'HKLM:\SOFTWARE\Microsoft\MSSQLServer\Client\ConnectTo'
         $registryPathWow6432Node = 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\MSSQLServer\Client\ConnectTo'
 

--- a/Tests/Unit/MSFT_SqlAlwaysOnService.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAlwaysOnService.Tests.ps1
@@ -15,8 +15,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlAlwaysOnService'
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlAlwaysOnService'
 
 # Unit Test Template Version: 1.1.0
 [System.String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
@@ -28,8 +28,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 $disableHadr = @{
@@ -59,20 +59,20 @@ $enableHadrNamedInstance = @{
 # Begin Testing
 try
 {
-    Describe "$($script:DSCResourceName)\Get-TargetResource" {
+    Describe "$($script:dscResourceName)\Get-TargetResource" {
         Context 'When HADR is disabled' {
             Mock -CommandName Connect-SQL -MockWith {
                 return New-Object -TypeName PSObject -Property @{
                     IsHadrEnabled = $false
                 }
-            } -ModuleName $script:DSCResourceName -Verifiable
+            } -ModuleName $script:dscResourceName -Verifiable
 
             It 'Should return that HADR is disabled' {
                 # Get the current state
                 $result = Get-TargetResource @enableHadr
                 $result.IsHadrEnabled | Should -Be $false
 
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
             }
 
             It 'Should return that HADR is disabled' {
@@ -80,7 +80,7 @@ try
                 $result = Get-TargetResource @enableHadrNamedInstance
                 $result.IsHadrEnabled | Should -Be $false
 
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
             }
         }
 
@@ -89,14 +89,14 @@ try
                 return New-Object -TypeName PSObject -Property @{
                     IsHadrEnabled = $true
                 }
-            } -ModuleName $script:DSCResourceName -Verifiable
+            } -ModuleName $script:dscResourceName -Verifiable
 
             It 'Should return that HADR is enabled' {
                 # Get the current state
                 $result = Get-TargetResource @enableHadr
                 $result.IsHadrEnabled | Should -Be $true
 
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
             }
 
             It 'Should return that HADR is enabled' {
@@ -104,7 +104,7 @@ try
                 $result = Get-TargetResource @enableHadrNamedInstance
                 $result.IsHadrEnabled | Should -Be $true
 
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
             }
         }
 
@@ -114,7 +114,7 @@ try
                 return New-Object -TypeName PSObject -Property @{
                     IsHadrEnabled = $null
                 }
-            } -ModuleName $script:DSCResourceName -Verifiable
+            } -ModuleName $script:dscResourceName -Verifiable
 
             It 'Should fail with the correct error message' {
                 # Regression test for issue #519
@@ -123,21 +123,21 @@ try
                 $result = Get-TargetResource @enableHadr
                 $result.IsHadrEnabled | Should -Be $false
 
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 2 -Exactly
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Connect-SQL -Scope It -Times 2 -Exactly
             }
         }
     }
 
-    Describe "$($script:DSCResourceName)\Set-TargetResource" {
+    Describe "$($script:dscResourceName)\Set-TargetResource" {
         # Loading stub cmdlets
         Import-Module -Name ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SQLPSStub.psm1 ) -Force
 
-        Mock -CommandName Disable-SqlAlwaysOn -ModuleName $script:DSCResourceName
-        Mock -CommandName Enable-SqlAlwaysOn -ModuleName $script:DSCResourceName
-        Mock -CommandName Import-SQLPSModule -ModuleName $script:DSCResourceName
-        Mock -CommandName New-TerminatingError { $ErrorType } -ModuleName $script:DSCResourceName
-        Mock -CommandName New-VerboseMessage -ModuleName $script:DSCResourceName
-        Mock -CommandName Restart-SqlService -ModuleName $script:DSCResourceName -Verifiable
+        Mock -CommandName Disable-SqlAlwaysOn -ModuleName $script:dscResourceName
+        Mock -CommandName Enable-SqlAlwaysOn -ModuleName $script:dscResourceName
+        Mock -CommandName Import-SQLPSModule -ModuleName $script:dscResourceName
+        Mock -CommandName New-TerminatingError { $ErrorType } -ModuleName $script:dscResourceName
+        Mock -CommandName New-VerboseMessage -ModuleName $script:dscResourceName
+        Mock -CommandName Restart-SqlService -ModuleName $script:dscResourceName -Verifiable
 
         Context 'When HADR is not in the desired state' {
             It 'Should enable SQL Always On when Ensure is set to Present' {
@@ -145,13 +145,13 @@ try
                     return New-Object -TypeName PSObject -Property @{
                         IsHadrEnabled = $true
                     }
-                } -ModuleName $script:DSCResourceName -Verifiable
+                } -ModuleName $script:dscResourceName -Verifiable
 
                 Set-TargetResource @enableHadr
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Disable-SqlAlwaysOn -Scope It -Times 0
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Enable-SqlAlwaysOn -Scope It -Times 1
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Restart-SqlService -Scope It -Times 1
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Connect-SQL -Scope It -Times 1
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Disable-SqlAlwaysOn -Scope It -Times 0
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Enable-SqlAlwaysOn -Scope It -Times 1
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Restart-SqlService -Scope It -Times 1
             }
 
             It 'Should disable SQL Always On when Ensure is set to Absent' {
@@ -159,13 +159,13 @@ try
                     return New-Object -TypeName PSObject -Property @{
                         IsHadrEnabled = $false
                     }
-                } -ModuleName $script:DSCResourceName -Verifiable
+                } -ModuleName $script:dscResourceName -Verifiable
 
                 Set-TargetResource @disableHadr
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Disable-SqlAlwaysOn -Scope It -Times 1
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Enable-SqlAlwaysOn -Scope It -Times 0
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Restart-SqlService -Scope It -Times 1
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Connect-SQL -Scope It -Times 1
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Disable-SqlAlwaysOn -Scope It -Times 1
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Enable-SqlAlwaysOn -Scope It -Times 0
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Restart-SqlService -Scope It -Times 1
             }
 
             It 'Should enable SQL Always On on a named instance when Ensure is set to Present' {
@@ -173,13 +173,13 @@ try
                     return New-Object -TypeName PSObject -Property @{
                         IsHadrEnabled = $true
                     }
-                } -ModuleName $script:DSCResourceName -Verifiable
+                } -ModuleName $script:dscResourceName -Verifiable
 
                 Set-TargetResource @enableHadrNamedInstance
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Disable-SqlAlwaysOn -Scope It -Times 0
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Enable-SqlAlwaysOn -Scope It -Times 1
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Restart-SqlService -Scope It -Times 1
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Connect-SQL -Scope It -Times 1
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Disable-SqlAlwaysOn -Scope It -Times 0
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Enable-SqlAlwaysOn -Scope It -Times 1
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Restart-SqlService -Scope It -Times 1
             }
 
             It 'Should disable SQL Always On on a named instance when Ensure is set to Absent' {
@@ -187,13 +187,13 @@ try
                     return New-Object -TypeName PSObject -Property @{
                         IsHadrEnabled = $false
                     }
-                } -ModuleName $script:DSCResourceName -Verifiable
+                } -ModuleName $script:dscResourceName -Verifiable
 
                 Set-TargetResource @disableHadrNamedInstance
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Disable-SqlAlwaysOn -Scope It -Times 1
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Enable-SqlAlwaysOn -Scope It -Times 0
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Restart-SqlService -Scope It -Times 1
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Connect-SQL -Scope It -Times 1
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Disable-SqlAlwaysOn -Scope It -Times 1
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Enable-SqlAlwaysOn -Scope It -Times 0
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Restart-SqlService -Scope It -Times 1
             }
 
             It 'Should throw the correct error message when Ensure is set to Present, but IsHadrEnabled is $false' {
@@ -201,14 +201,14 @@ try
                     return New-Object -TypeName PSObject -Property @{
                         IsHadrEnabled = $false
                     }
-                } -ModuleName $script:DSCResourceName -Verifiable
+                } -ModuleName $script:dscResourceName -Verifiable
 
                 { Set-TargetResource @enableHadr } | Should -Throw 'AlterAlwaysOnServiceFailed'
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Disable-SqlAlwaysOn -Scope It -Times 0
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Enable-SqlAlwaysOn -Scope It -Times 1
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Restart-SqlService -Scope It -Times 1
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-TerminatingError -Scope It -Times 1
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Connect-SQL -Scope It -Times 1
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Disable-SqlAlwaysOn -Scope It -Times 0
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Enable-SqlAlwaysOn -Scope It -Times 1
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Restart-SqlService -Scope It -Times 1
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName New-TerminatingError -Scope It -Times 1
             }
 
             It 'Should throw the correct error message when Ensure is set to Absent, but IsHadrEnabled is $true' {
@@ -216,25 +216,25 @@ try
                     return New-Object -TypeName PSObject -Property @{
                         IsHadrEnabled = $true
                     }
-                } -ModuleName $script:DSCResourceName -Verifiable
+                } -ModuleName $script:dscResourceName -Verifiable
 
                 { Set-TargetResource @disableHadr } | Should -Throw 'AlterAlwaysOnServiceFailed'
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Disable-SqlAlwaysOn -Scope It -Times 1
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Enable-SqlAlwaysOn -Scope It -Times 0
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Restart-SqlService -Scope It -Times 1
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-TerminatingError -Scope It -Times 1
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Connect-SQL -Scope It -Times 1
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Disable-SqlAlwaysOn -Scope It -Times 1
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Enable-SqlAlwaysOn -Scope It -Times 0
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Restart-SqlService -Scope It -Times 1
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName New-TerminatingError -Scope It -Times 1
             }
         }
     }
 
-    Describe "$($script:DSCResourceName)\Test-TargetResource" {
+    Describe "$($script:dscResourceName)\Test-TargetResource" {
         Context 'When HADR is not in the desired state' {
             Mock -CommandName Connect-SQL -MockWith {
                 return New-Object -TypeName PSObject -Property @{
                     IsHadrEnabled = $true
                 }
-            } -ModuleName $script:DSCResourceName -Verifiable
+            } -ModuleName $script:dscResourceName -Verifiable
 
             It 'Should cause Test-TargetResource to return false when not in the desired state' {
                 Test-TargetResource @disableHadr | Should -Be $false
@@ -246,7 +246,7 @@ try
                 return New-Object -TypeName PSObject -Property @{
                     IsHadrEnabled = $true
                 }
-            } -ModuleName $script:DSCResourceName -Verifiable
+            } -ModuleName $script:dscResourceName -Verifiable
 
             It 'Should cause Test-TargetResource to return true when in the desired state' {
                 Test-TargetResource @enableHadr | Should -Be $true

--- a/Tests/Unit/MSFT_SqlAlwaysOnService.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAlwaysOnService.Tests.ps1
@@ -8,14 +8,15 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlAlwaysOnService'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
+
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlAlwaysOnService'
 
 # Unit Test Template Version: 1.1.0
 [System.String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)

--- a/Tests/Unit/MSFT_SqlAlwaysOnService.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAlwaysOnService.Tests.ps1
@@ -8,12 +8,14 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container1', ContainerImage = 'microsoft/windowsservercore')]
-param()
-
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceName = 'MSFT_SqlAlwaysOnService'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 # Unit Test Template Version: 1.1.0
 [System.String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)

--- a/Tests/Unit/MSFT_SqlDatabase.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabase.Tests.ps1
@@ -8,14 +8,15 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlDatabase'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
+
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlDatabase'
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlDatabase.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabase.Tests.ps1
@@ -8,12 +8,14 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container1', ContainerImage = 'microsoft/windowsservercore')]
-param()
-
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceName = 'MSFT_SqlDatabase'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlDatabase.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabase.Tests.ps1
@@ -15,8 +15,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlDatabase'
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlDatabase'
 
 #region HEADER
 
@@ -31,8 +31,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -52,7 +52,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
         $mockServerName = 'localhost'
         $mockInstanceName = 'MSSQLSERVER'
         $mockSqlDatabaseName = 'AdventureWorks'

--- a/Tests/Unit/MSFT_SqlDatabaseDefaultLocation.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabaseDefaultLocation.Tests.ps1
@@ -7,15 +7,15 @@
         script. Read more at
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
+{
+    return
+}
 
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceName = 'MSFT_SqlDatabaseDefaultLocation'
-
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
-{
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
-    return
-}
 
 #region Header
 

--- a/Tests/Unit/MSFT_SqlDatabaseDefaultLocation.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabaseDefaultLocation.Tests.ps1
@@ -14,8 +14,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlDatabaseDefaultLocation'
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlDatabaseDefaultLocation'
 
 #region Header
 
@@ -32,8 +32,8 @@ Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -P
 Add-Type -Path ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SMO.cs )
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -53,7 +53,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
         $mockServerName = 'localhost'
         $mockInstanceName = 'MSSQLSERVER'
         $mockSQLDataPath = 'C:\Program Files\Data\'

--- a/Tests/Unit/MSFT_SqlDatabaseDefaultLocation.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabaseDefaultLocation.Tests.ps1
@@ -8,9 +8,14 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container1', ContainerImage = 'microsoft/windowsservercore')]
-param()
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlDatabaseDefaultLocation'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region Header
 
@@ -27,8 +32,8 @@ Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -P
 Add-Type -Path ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SMO.cs )
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName 'SqlServerDsc' `
-    -DSCResourceName 'MSFT_SqlDatabaseDefaultLocation' `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -48,7 +53,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope 'MSFT_SqlDatabaseDefaultLocation' {
+    InModuleScope $script:DSCResourceName {
         $mockServerName = 'localhost'
         $mockInstanceName = 'MSSQLSERVER'
         $mockSQLDataPath = 'C:\Program Files\Data\'

--- a/Tests/Unit/MSFT_SqlDatabaseOwner.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabaseOwner.Tests.ps1
@@ -8,12 +8,14 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container1', ContainerImage = 'microsoft/windowsservercore')]
-param()
-
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceName = 'MSFT_SqlDatabaseOwner'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlDatabaseOwner.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabaseOwner.Tests.ps1
@@ -7,15 +7,15 @@
         script. Read more at
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
+{
+    return
+}
 
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceName = 'MSFT_SqlDatabaseOwner'
-
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
-{
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
-    return
-}
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlDatabaseOwner.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabaseOwner.Tests.ps1
@@ -14,8 +14,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlDatabaseOwner'
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlDatabaseOwner'
 
 #region HEADER
 
@@ -30,8 +30,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -50,7 +50,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
         $mockServerName = 'localhost'
         $mockInstanceName = 'MSSQLSERVER'
         $mockSqlDatabaseName = 'AdventureWorks'

--- a/Tests/Unit/MSFT_SqlDatabasePermission.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabasePermission.Tests.ps1
@@ -8,12 +8,14 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container1', ContainerImage = 'microsoft/windowsservercore')]
-param()
-
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceName = 'MSFT_SqlDatabasePermission'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlDatabasePermission.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabasePermission.Tests.ps1
@@ -8,14 +8,15 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlDatabasePermission'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
+
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlDatabasePermission'
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlDatabasePermission.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabasePermission.Tests.ps1
@@ -15,8 +15,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlDatabasePermission'
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlDatabasePermission'
 
 #region HEADER
 
@@ -31,8 +31,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -53,7 +53,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
         $mockServerName = 'localhost'
         $mockInstanceName = 'MSSQLSERVER'
         $mockSqlDatabaseName = 'AdventureWorks'

--- a/Tests/Unit/MSFT_SqlDatabaseRecoveryModel.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabaseRecoveryModel.Tests.ps1
@@ -14,8 +14,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlDatabaseRecoveryModel'
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlDatabaseRecoveryModel'
 
 #region HEADER
 
@@ -30,8 +30,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -50,7 +50,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
         $mockServerName = 'localhost'
         $mockInstanceName = 'MSSQLSERVER'
         $mockSqlDatabaseName = 'AdventureWorks'

--- a/Tests/Unit/MSFT_SqlDatabaseRecoveryModel.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabaseRecoveryModel.Tests.ps1
@@ -7,15 +7,15 @@
         script. Read more at
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
+{
+    return
+}
 
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceName = 'MSFT_SqlDatabaseRecoveryModel'
-
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
-{
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
-    return
-}
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlDatabaseRecoveryModel.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabaseRecoveryModel.Tests.ps1
@@ -8,12 +8,14 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container1', ContainerImage = 'microsoft/windowsservercore')]
-param()
-
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceName = 'MSFT_SqlDatabaseRecoveryModel'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region HEADER
 
@@ -47,6 +49,7 @@ function Invoke-TestCleanup
 try
 {
     Invoke-TestSetup
+
     InModuleScope $script:DSCResourceName {
         $mockServerName = 'localhost'
         $mockInstanceName = 'MSSQLSERVER'

--- a/Tests/Unit/MSFT_SqlDatabaseRole.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabaseRole.Tests.ps1
@@ -15,8 +15,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlDatabaseRole'
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlDatabaseRole'
 
 #region HEADER
 
@@ -31,8 +31,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -53,7 +53,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
         $mockServerName = 'localhost'
         $mockInstanceName = 'MSSQLSERVER'
         $mockSqlDatabaseName = 'AdventureWorks'

--- a/Tests/Unit/MSFT_SqlDatabaseRole.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabaseRole.Tests.ps1
@@ -8,12 +8,14 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container1', ContainerImage = 'microsoft/windowsservercore')]
-param()
-
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceName = 'MSFT_SqlDatabaseRole'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlDatabaseRole.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlDatabaseRole.Tests.ps1
@@ -8,14 +8,15 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlDatabaseRole'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
+
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlDatabaseRole'
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlRS.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlRS.Tests.ps1
@@ -8,12 +8,14 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container1', ContainerImage = 'microsoft/windowsservercore')]
-param()
-
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceName = 'MSFT_SqlRS'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlRS.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlRS.Tests.ps1
@@ -14,8 +14,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlRS'
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlRS'
 
 #region HEADER
 
@@ -30,8 +30,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName   `
-    -DSCResourceName $script:DSCResourceName  `
+    -DSCModuleName $script:dscModuleName   `
+    -DSCResourceName $script:dscResourceName  `
     -TestType Unit
 
 #endregion HEADER
@@ -51,7 +51,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
         $mockNamedInstanceName = 'INSTANCE'
         $mockDefaultInstanceName = 'MSSQLSERVER'
         $mockReportingServicesDatabaseServerName = 'SERVER'

--- a/Tests/Unit/MSFT_SqlRS.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlRS.Tests.ps1
@@ -7,15 +7,15 @@
         script. Read more at
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
+{
+    return
+}
 
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceName = 'MSFT_SqlRS'
-
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
-{
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
-    return
-}
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlScript.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlScript.Tests.ps1
@@ -12,14 +12,15 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 param()
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlScript'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
+
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlScript'
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlScript.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlScript.Tests.ps1
@@ -19,8 +19,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlScript'
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlScript'
 
 #region HEADER
 
@@ -37,8 +37,8 @@ Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath 'SqlServerDsc
 
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -58,9 +58,9 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
         InModuleScope 'SqlServerDscHelper' {
-            $script:DSCModuleName = 'SqlServerDsc'
+            $script:dscModuleName = 'SqlServerDsc'
             $resourceName = 'MSFT_SqlScript'
 
             $testParameters = @{

--- a/Tests/Unit/MSFT_SqlScript.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlScript.Tests.ps1
@@ -8,11 +8,18 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container2', ContainerImage = 'microsoft/windowsservercore')]
 # Suppression of this PSSA rule allowed in tests.
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 param()
+
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlScript'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region HEADER
 
@@ -29,8 +36,8 @@ Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath 'SqlServerDsc
 
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName 'SqlServerDsc' `
-    -DSCResourceName 'MSFT_SqlScript'  `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -50,7 +57,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope 'MSFT_SqlScript' {
+    InModuleScope $script:DSCResourceName {
         InModuleScope 'SqlServerDscHelper' {
             $script:DSCModuleName = 'SqlServerDsc'
             $resourceName = 'MSFT_SqlScript'

--- a/Tests/Unit/MSFT_SqlScriptQuery.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlScriptQuery.Tests.ps1
@@ -19,8 +19,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlScriptQuery'
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlScriptQuery'
 
 #region HEADER
 
@@ -36,8 +36,8 @@ Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath 'SqlServerDscHelper.psm1')
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -57,9 +57,9 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
         InModuleScope 'SqlServerDscHelper' {
-            $script:DSCModuleName = 'SqlServerDsc'
+            $script:dscModuleName = 'SqlServerDsc'
             $resourceName = 'MSFT_SqlScriptQuery'
 
             $testParameters = @{

--- a/Tests/Unit/MSFT_SqlScriptQuery.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlScriptQuery.Tests.ps1
@@ -8,11 +8,18 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container1', ContainerImage = 'microsoft/windowsservercore')]
 # Suppression of this PSSA rule allowed in tests.
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 Param()
+
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlScriptQuery'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region HEADER
 
@@ -28,8 +35,8 @@ Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath 'SqlServerDscHelper.psm1')
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName 'SqlServerDsc' `
-    -DSCResourceName 'MSFT_SqlScriptQuery'  `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -49,7 +56,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope 'MSFT_SqlScriptQuery' {
+    InModuleScope $script:DSCResourceName {
         InModuleScope 'SqlServerDscHelper' {
             $script:DSCModuleName = 'SqlServerDsc'
             $resourceName = 'MSFT_SqlScriptQuery'

--- a/Tests/Unit/MSFT_SqlScriptQuery.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlScriptQuery.Tests.ps1
@@ -12,14 +12,15 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 Param()
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlScriptQuery'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
+
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlScriptQuery'
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlServerConfiguration.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerConfiguration.Tests.ps1
@@ -8,15 +8,15 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
+{
+    return
+}
 
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceName = 'MSFT_SqlServerConfiguration'
-
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
-{
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
-    return
-}
 
 # Unit Test Template Version: 1.1.0
 [System.String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)

--- a/Tests/Unit/MSFT_SqlServerConfiguration.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerConfiguration.Tests.ps1
@@ -15,8 +15,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlServerConfiguration'
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlServerConfiguration'
 
 # Unit Test Template Version: 1.1.0
 [System.String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
@@ -28,8 +28,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 $defaultState = @{
@@ -79,7 +79,7 @@ $invalidOption = @{
 
 try
 {
-    Describe "$($script:DSCResourceName)\Get-TargetResource" {
+    Describe "$($script:dscResourceName)\Get-TargetResource" {
         Context 'The system is not in the desired state' {
             Mock -CommandName Connect-SQL -MockWith {
                 $mock = New-Object -TypeName PSObject -Property @{
@@ -97,7 +97,7 @@ try
                 $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
 
                 return $mock
-            } -ModuleName $script:DSCResourceName -Verifiable
+            } -ModuleName $script:dscResourceName -Verifiable
 
             # Get the current state.
             $result = Get-TargetResource @desiredState
@@ -112,7 +112,7 @@ try
             }
 
             It 'Should call Connect-SQL mock when getting the current state' {
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope Context -Times 1
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Connect-SQL -Scope Context -Times 1
             }
         }
 
@@ -133,7 +133,7 @@ try
                 $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
 
                 return $mock
-            } -ModuleName $script:DSCResourceName -Verifiable
+            } -ModuleName $script:dscResourceName -Verifiable
 
             # Get the current state.
             $result = Get-TargetResource @desiredState
@@ -148,7 +148,7 @@ try
             }
 
             It 'Should call Connect-SQL mock when getting the current state' {
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope Context -Times 1
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Connect-SQL -Scope Context -Times 1
             }
         }
 
@@ -169,7 +169,7 @@ try
                 $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
 
                 return $mock
-            } -ModuleName $script:DSCResourceName -Verifiable
+            } -ModuleName $script:dscResourceName -Verifiable
 
             It 'Should throw the correct error message' {
                 $errorMessage = ($script:localizedData.ConfigurationOptionNotFound -f $invalidOption.OptionName)
@@ -178,7 +178,7 @@ try
         }
     }
 
-    Describe "$($script:DSCResourceName)\Test-TargetResource" {
+    Describe "$($script:dscResourceName)\Test-TargetResource" {
         Mock -CommandName Connect-SQL -MockWith {
             $mock = New-Object -TypeName PSObject -Property @{
                 Configuration = @{
@@ -195,7 +195,7 @@ try
             $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
 
             return $mock
-        } -ModuleName $script:DSCResourceName -Verifiable
+        } -ModuleName $script:dscResourceName -Verifiable
 
         It 'Should cause Test-TargetResource to return false when not in the desired state' {
             Test-TargetResource @defaultState | Should -Be $false
@@ -206,8 +206,8 @@ try
         }
     }
 
-    Describe "$($script:DSCResourceName)\Set-TargetResource" {
-        Mock -CommandName New-TerminatingError -ModuleName $script:DSCResourceName
+    Describe "$($script:dscResourceName)\Set-TargetResource" {
+        Mock -CommandName New-TerminatingError -ModuleName $script:dscResourceName
         Mock -CommandName Connect-SQL -MockWith {
             $mock = New-Object -TypeName PSObject -Property @{
                 Configuration = @{
@@ -225,7 +225,7 @@ try
             $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
 
             return $mock
-        } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { $ServerName -eq 'CLU01' }
+        } -ModuleName $script:dscResourceName -Verifiable -ParameterFilter { $ServerName -eq 'CLU01' }
 
         Mock -CommandName Connect-SQL -MockWith {
             $mock = New-Object -TypeName PSObject -Property @{
@@ -244,31 +244,31 @@ try
             $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
 
             return $mock
-        } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { $ServerName -eq 'CLU02' }
+        } -ModuleName $script:dscResourceName -Verifiable -ParameterFilter { $ServerName -eq 'CLU02' }
 
-        Mock -CommandName Restart-SqlService -ModuleName $script:DSCResourceName -Verifiable
-        Mock -CommandName Write-Warning -ModuleName $script:DSCResourceName -Verifiable
+        Mock -CommandName Restart-SqlService -ModuleName $script:dscResourceName -Verifiable
+        Mock -CommandName Write-Warning -ModuleName $script:dscResourceName -Verifiable
 
         Context 'Change the system to the desired state' {
             It 'Should not restart SQL for a dynamic option' {
                 Set-TargetResource @dynamicOption
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Restart-SqlService -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Restart-SqlService -Scope It -Times 0 -Exactly
             }
 
             It 'Should restart SQL for a non-dynamic option' {
                 Set-TargetResource @desiredStateRestart
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Restart-SqlService -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Restart-SqlService -Scope It -Times 1 -Exactly
             }
 
             It 'Should warn about restart when required, but not requested' {
                 Set-TargetResource @desiredState
 
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Write-Warning -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Restart-SqlService -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Write-Warning -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Restart-SqlService -Scope It -Times 0 -Exactly
             }
 
             It 'Should call Connect-SQL to get option values' {
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope Context -Times 3
+                Assert-MockCalled -ModuleName $script:dscResourceName -CommandName Connect-SQL -Scope Context -Times 3
             }
         }
 
@@ -289,7 +289,7 @@ try
                 $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
 
                 return $mock
-            } -ModuleName $script:DSCResourceName -Verifiable
+            } -ModuleName $script:dscResourceName -Verifiable
 
             It 'Should throw the correct error message' {
                 $errorMessage = ($script:localizedData.ConfigurationOptionNotFound -f $invalidOption.OptionName)

--- a/Tests/Unit/MSFT_SqlServerConfiguration.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerConfiguration.Tests.ps1
@@ -8,12 +8,15 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container2', ContainerImage = 'microsoft/windowsservercore')]
-param()
 
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceName = 'MSFT_SqlServerConfiguration'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 # Unit Test Template Version: 1.1.0
 [System.String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)

--- a/Tests/Unit/MSFT_SqlServerDatabaseMail.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerDatabaseMail.Tests.ps1
@@ -8,14 +8,15 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlServerDatabaseMail'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
+
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlServerDatabaseMail'
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlServerDatabaseMail.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerDatabaseMail.Tests.ps1
@@ -15,8 +15,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlServerDatabaseMail'
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlServerDatabaseMail'
 
 #region HEADER
 
@@ -31,8 +31,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -51,7 +51,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
         $mockServerName = 'localhost'
         $mockInstanceName = 'MSSQLSERVER'
         $mockAccountName = 'MyMail'

--- a/Tests/Unit/MSFT_SqlServerDatabaseMail.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerDatabaseMail.Tests.ps1
@@ -8,12 +8,14 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container2', ContainerImage = 'microsoft/windowsservercore')]
-param()
-
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceName = 'MSFT_SqlServerDatabaseMail'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlServerEndpoint.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerEndpoint.Tests.ps1
@@ -15,8 +15,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName      = 'SqlServerDsc'
-$script:DSCResourceName    = 'MSFT_SqlServerEndpoint'
+$script:dscModuleName      = 'SqlServerDsc'
+$script:dscResourceName    = 'MSFT_SqlServerEndpoint'
 
 #region HEADER
 
@@ -31,8 +31,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -51,7 +51,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
         $mockServerName = 'localhost'
         $mockInstanceName = 'INSTANCE1'
         $mockPrincipal = 'COMPANY\SqlServiceAcct'

--- a/Tests/Unit/MSFT_SqlServerEndpoint.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerEndpoint.Tests.ps1
@@ -8,14 +8,15 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-$script:DSCModuleName      = 'SqlServerDsc'
-$script:DSCResourceName    = 'MSFT_SqlServerEndpoint'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
+
+$script:DSCModuleName      = 'SqlServerDsc'
+$script:DSCResourceName    = 'MSFT_SqlServerEndpoint'
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlServerEndpoint.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerEndpoint.Tests.ps1
@@ -8,12 +8,14 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container2', ContainerImage = 'microsoft/windowsservercore')]
-param()
-
 $script:DSCModuleName      = 'SqlServerDsc'
 $script:DSCResourceName    = 'MSFT_SqlServerEndpoint'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlServerEndpoint.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerEndpoint.Tests.ps1
@@ -59,11 +59,13 @@ try
         $mockEndpointType = 'DatabaseMirroring'
         $mockEndpointListenerPort = 5022
         $mockEndpointListenerIpAddress = '0.0.0.0'  # 0.0.0.0 means listen on all IP addresses.
+        $mockEndpointOwner = 'sa'
 
         $mockOtherEndpointName = 'UnknownEndpoint'
         $mockOtherEndpointType = 'UnknownType'
         $mockOtherEndpointListenerPort = 9001
         $mockOtherEndpointListenerIpAddress = '192.168.0.20'
+        $mockOtherEndpointOwner = 'COMPANY\OtherAcct'
 
         $script:mockMethodAlterRan = $false
         $script:mockMethodCreateRan = $false
@@ -74,6 +76,7 @@ try
         $mockDynamicEndpointType = $mockEndpointType
         $mockDynamicEndpointListenerPort = $mockEndpointListenerPort
         $mockDynamicEndpointListenerIpAddress = $mockEndpointListenerIpAddress
+        $mockDynamicEndpointOwner = $mockEndpointOwner
 
         $mockEndpointObject = {
             # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
@@ -81,6 +84,7 @@ try
                 Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDynamicEndpointName -PassThru |
                 Add-Member -MemberType NoteProperty -Name 'EndpointType' -Value $mockDynamicEndpointType -PassThru |
                 Add-Member -MemberType NoteProperty -Name 'ProtocolType' -Value $null -PassThru |
+                Add-Member -MemberType NoteProperty -Name 'Owner' -Value $mockDynamicEndpointOwner -PassThru |
                 Add-Member -MemberType ScriptProperty -Name 'Protocol' -Value {
                     return New-Object -TypeName Object |
                         Add-Member -MemberType ScriptProperty -Name 'Tcp' -Value {
@@ -184,6 +188,7 @@ try
                     $result.EndpointName | Should -Be ''
                     $result.Port | Should -Be ''
                     $result.IpAddress | Should -Be ''
+                    $result.Owner | Should -Be ''
                 }
 
                 It 'Should call the mock function Connect-SQL' {
@@ -208,6 +213,7 @@ try
                     $result.EndpointName | Should -Be $testParameters.EndpointName
                     $result.Port | Should -Be $mockEndpointListenerPort
                     $result.IpAddress | Should -Be $mockEndpointListenerIpAddress
+                    $result.Owner | Should -Be $mockEndpointOwner
                 }
 
                 It 'Should call the mock function Connect-SQL' {
@@ -265,6 +271,7 @@ try
                     $testParameters.Add('Ensure', 'Present')
                     $testParameters.Add('Port', $mockEndpointListenerPort)
                     $testParameters.Add('IpAddress', $mockEndpointListenerIpAddress)
+                    $testParameters.Add('Owner', $mockEndpointOwner)
 
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $false
@@ -322,6 +329,26 @@ try
 
                 # Make sure the mock do return the correct endpoint listener IP address
                 $mockDynamicEndpointListenerIpAddress = $mockEndpointListenerIpAddress
+
+                # Make sure the mock do return the correct endpoint, but does not return the correct endpoint owner
+                $mockDynamicEndpointName = $mockEndpointName
+                $mockDynamicEndpointOwner = $mockOtherEndpointOwner
+
+                Context 'When listener Owner is not in desired state' {
+                    It 'Should return that desired state is absent' {
+                        $testParameters.Add('Ensure', 'Present')
+                        $testParameters.Add('Owner', $mockEndpointOwner)
+
+
+                        $result = Test-TargetResource @testParameters
+                        $result | Should -Be $false
+
+                        Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
+                    }
+                }
+
+                # Make sure the mock do return the correct endpoint owner
+                $mockDynamicEndpointOwner = $mockEndpointOwner
             }
 
             Context 'When the system is in the desired state' {
@@ -372,7 +399,7 @@ try
                 # Set what the expected endpoint name should be when Create() method is called.
                 $mockExpectedNameWhenCallingMethod = $mockEndpointName
 
-                It 'Should call the the method Create when desired state is to be Present (using default values)' {
+                It 'Should call the method Create when desired state is to be Present (using default values)' {
                     Mock -CommandName Get-TargetResource -MockWith {
                         return @{
                             Ensure = 'Absent'
@@ -397,7 +424,7 @@ try
                 # Set what the expected endpoint name should be when Create() method is called.
                 $mockExpectedNameWhenCallingMethod = $mockEndpointName
 
-                It 'Should call the the method Create when desired state is to be Present (setting all parameters)' {
+                It 'Should call the method Create when desired state is to be Present (setting all parameters)' {
                     Mock -CommandName Get-TargetResource -MockWith {
                         return @{
                             Ensure = 'Absent'
@@ -407,6 +434,7 @@ try
                     $testParameters.Add('Ensure', 'Present')
                     $testParameters.Add('Port', $mockEndpointListenerPort)
                     $testParameters.Add('IpAddress', $mockEndpointListenerIpAddress)
+                    $testParameters.Add('Owner', $mockEndpointOwner)
 
                     { Set-TargetResource @testParameters } | Should -Not -Throw
                     $script:mockMethodCreateRan | Should -Be $true
@@ -426,7 +454,7 @@ try
                 # Set what the expected endpoint name should be when Drop() method is called.
                 $mockExpectedNameWhenCallingMethod = $mockEndpointName
 
-                It 'Should call the the method Drop when desired state is to be Absent' {
+                It 'Should call the method Drop when desired state is to be Absent' {
                     Mock -CommandName Get-TargetResource -MockWith {
                         return @{
                             Ensure = 'Present'
@@ -453,7 +481,7 @@ try
                 # Set what the expected endpoint name should be when Alter() method is called.
                 $mockExpectedNameWhenCallingMethod = $mockEndpointName
 
-                It 'Should not call Alter method when listener port is not in desired state' {
+                It 'Should call Alter method when listener port is not in desired state' {
                     Mock -CommandName Get-TargetResource -MockWith {
                         return @{
                             Ensure = 'Present'
@@ -465,6 +493,7 @@ try
                     $testParameters.Add('Ensure', 'Present')
                     $testParameters.Add('Port', $mockOtherEndpointListenerPort)
                     $testParameters.Add('IpAddress', $mockEndpointListenerIpAddress)
+                    $testParameters.Add('Owner', $mockEndpointOwner)
 
                     { Set-TargetResource @testParameters } | Should -Not -Throw
                     $script:mockMethodCreateRan | Should -Be $false
@@ -484,7 +513,7 @@ try
                 # Set what the expected endpoint name should be when Alter() method is called.
                 $mockExpectedNameWhenCallingMethod = $mockEndpointName
 
-                It 'Should not call Alter method when listener IP address is not in desired state' {
+                It 'Should call Alter method when listener IP address is not in desired state' {
                     Mock -CommandName Get-TargetResource -MockWith {
                         return @{
                             Ensure = 'Present'
@@ -496,6 +525,39 @@ try
                     $testParameters.Add('Ensure', 'Present')
                     $testParameters.Add('Port', $mockEndpointListenerPort)
                     $testParameters.Add('IpAddress', $mockOtherEndpointListenerIpAddress)
+                    $testParameters.Add('Owner', $mockEndpointOwner)
+
+                    { Set-TargetResource @testParameters } | Should -Not -Throw
+                    $script:mockMethodCreateRan | Should -Be $false
+                    $script:mockMethodStartRan | Should -Be $false
+                    $script:mockMethodAlterRan | Should -Be $true
+                    $script:mockMethodDropRan | Should -Be $false
+
+                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
+                }
+
+                # Set all method call tests variables to $false
+                $script:mockMethodCreateRan = $false
+                $script:mockMethodStartRan = $false
+                $script:mockMethodAlterRan = $false
+                $script:mockMethodDropRan = $false
+
+                # Set what the expected endpoint name should be when Alter() method is called.
+                $mockExpectedNameWhenCallingMethod = $mockEndpointName
+
+                It 'Should call Alter method when Owner is not in desired state' {
+                    Mock -CommandName Get-TargetResource -MockWith {
+                        return @{
+                            Ensure = 'Present'
+                            Port = $mockEndpointListenerPort
+                            IpAddress = $mockEndpointListenerIpAddress
+                        }
+                    } -Verifiable
+
+                    $testParameters.Add('Ensure', 'Present')
+                    $testParameters.Add('Port', $mockEndpointListenerPort)
+                    $testParameters.Add('IpAddress', $mockEndpointListenerIpAddress)
+                    $testParameters.Add('Owner', $mockOtherEndpointOwner)
 
                     { Set-TargetResource @testParameters } | Should -Not -Throw
                     $script:mockMethodCreateRan | Should -Be $false
@@ -516,6 +578,7 @@ try
                                 Ensure = 'Present'
                                 Port = $mockEndpointListenerPort
                                 IpAddress = $mockEndpointListenerIpAddress
+                                Owner = $mockEndpointOwner
                             }
                         } -Verifiable
 
@@ -530,6 +593,7 @@ try
                                 Ensure = 'Present'
                                 Port = $mockEndpointListenerPort
                                 IpAddress = $mockEndpointListenerIpAddress
+                                Owner = $mockEndpointOwner
                             }
                         } -Verifiable
 
@@ -551,11 +615,12 @@ try
                 }
             }
 
-            Context 'When the system is in the desired state' {
+            Context '    ' {
                 # Make sure the mock do return the correct endpoint
                 $mockDynamicEndpointName = $mockEndpointName
                 $mockDynamicEndpointListenerPort = $mockEndpointListenerPort
                 $mockDynamicEndpointListenerIpAddress = $mockEndpointListenerIpAddress
+                $mockDynamicEndpointOwner = $mockEndpointOwner
 
                 # Set all method call tests variables to $false
                 $script:mockMethodCreateRan = $false
@@ -569,12 +634,14 @@ try
                             Ensure = 'Present'
                             Port = $mockEndpointListenerPort
                             IpAddress = $mockEndpointListenerIpAddress
+                            Owner = $mockEndpointOwner
                         }
                     } -Verifiable
 
                     $testParameters.Add('Ensure', 'Present')
                     $testParameters.Add('Port', $mockEndpointListenerPort)
                     $testParameters.Add('IpAddress', $mockEndpointListenerIpAddress)
+                    $testParameters.Add('Owner', $mockEndpointOwner)
 
                     { Set-TargetResource @testParameters } | Should -Not -Throw
                     $script:mockMethodCreateRan | Should -Be $false
@@ -657,6 +724,7 @@ try
                         $testParameters.Add('Ensure', 'Present')
                         $testParameters.Add('Port', $mockOtherEndpointListenerPort)
                         $testParameters.Add('IpAddress', $mockEndpointListenerIpAddress)
+                        $testParameters.Add('Owner', $mockEndpointOwner)
 
                         { Set-TargetResource @testParameters } | Should -Throw 'Exception calling "Alter" with "0" argument(s): "Called mocked Alter() method on and endpoint with wrong name. Expected ''UnknownEndpoint''. But was ''DefaultEndpointMirror''."'
                     }

--- a/Tests/Unit/MSFT_SqlServerEndpointPermission.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerEndpointPermission.Tests.ps1
@@ -15,8 +15,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlServerEndpointPermission'
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlServerEndpointPermission'
 
 #region HEADER
 
@@ -31,8 +31,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -53,7 +53,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
         $mockNodeName = 'localhost'
         $mockInstanceName = 'SQL2016'
         $mockPrincipal = 'COMPANY\SqlServiceAcct'

--- a/Tests/Unit/MSFT_SqlServerEndpointPermission.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerEndpointPermission.Tests.ps1
@@ -8,12 +8,14 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container2', ContainerImage = 'microsoft/windowsservercore')]
-param()
-
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceName = 'MSFT_SqlServerEndpointPermission'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlServerEndpointPermission.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerEndpointPermission.Tests.ps1
@@ -8,14 +8,15 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlServerEndpointPermission'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
+
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlServerEndpointPermission'
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlServerEndpointState.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerEndpointState.Tests.ps1
@@ -15,8 +15,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlServerEndpointState'
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlServerEndpointState'
 
 #region HEADER
 
@@ -31,8 +31,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -53,7 +53,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
         $mockNodeName = 'localhost'
         $mockInstanceName = 'INSTANCE1'
         $mockEndpointName = 'DefaultEndpointMirror'

--- a/Tests/Unit/MSFT_SqlServerEndpointState.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerEndpointState.Tests.ps1
@@ -8,12 +8,14 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container2', ContainerImage = 'microsoft/windowsservercore')]
-param()
-
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceName = 'MSFT_SqlServerEndpointState'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlServerEndpointState.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerEndpointState.Tests.ps1
@@ -8,14 +8,15 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlServerEndpointState'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
+
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlServerEndpointState'
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerLogin.Tests.ps1
@@ -19,8 +19,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlServerLogin'
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlServerLogin'
 
 #region HEADER
 
@@ -35,8 +35,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -57,7 +57,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
         # Create PSCredential object for SQL Logins
         $mockSqlLoginUser = 'dba'
         $mockSqlLoginPassword = 'P@ssw0rd-12P@ssw0rd-12' | ConvertTo-SecureString -AsPlainText -Force
@@ -693,11 +693,11 @@ try
         }
 
         Describe 'MSFT_SqlServerLogin\Set-TargetResource' {
-            Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -ModuleName $script:DSCResourceName
-            Mock -CommandName Update-SQLServerLogin -ModuleName $script:DSCResourceName
-            Mock -CommandName New-SQLServerLogin -ModuleName $script:DSCResourceName
-            Mock -CommandName Remove-SQLServerLogin -ModuleName $script:DSCResourceName
-            Mock -CommandName Set-SQLServerLoginPassword -ModuleName $script:DSCResourceName
+            Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -ModuleName $script:dscResourceName
+            Mock -CommandName Update-SQLServerLogin -ModuleName $script:dscResourceName
+            Mock -CommandName New-SQLServerLogin -ModuleName $script:dscResourceName
+            Mock -CommandName Remove-SQLServerLogin -ModuleName $script:dscResourceName
+            Mock -CommandName Set-SQLServerLoginPassword -ModuleName $script:dscResourceName
 
             Context 'When the desired state is Absent' {
                 BeforeEach {
@@ -1103,7 +1103,7 @@ try
         }
 
         Describe 'MSFT_SqlServerLogin\Update-SQLServerLogin' {
-            Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -ModuleName $script:DSCResourceName
+            Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -ModuleName $script:dscResourceName
 
             Context 'When the Login is altered' {
                 It 'Should silently alter the login' {
@@ -1124,7 +1124,7 @@ try
         }
 
         Describe 'MSFT_SqlServerLogin\New-SQLServerLogin' {
-            Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -ModuleName $script:DSCResourceName
+            Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -ModuleName $script:dscResourceName
 
             Context 'When the Login is created' {
                 It 'Should silently create a Windows login' {
@@ -1199,7 +1199,7 @@ try
         }
 
         Describe 'MSFT_SqlServerLogin\Remove-SQLServerLogin' {
-            Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -ModuleName $script:DSCResourceName
+            Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -ModuleName $script:dscResourceName
 
             Context 'When the Login is dropped' {
                 It 'Should silently drop the login' {
@@ -1220,7 +1220,7 @@ try
         }
 
         Describe 'MSFT_SqlServerLogin\Set-SQLServerLoginPassword' {
-            Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -ModuleName $script:DSCResourceName
+            Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -ModuleName $script:dscResourceName
 
             Context 'When the password is set on an existing login' {
                 It 'Should silently set the password' {

--- a/Tests/Unit/MSFT_SqlServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerLogin.Tests.ps1
@@ -12,14 +12,15 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 param()
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlServerLogin'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
+
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlServerLogin'
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlServerMaxDop.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerMaxDop.Tests.ps1
@@ -15,8 +15,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlServerMaxDop'
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlServerMaxDop'
 
 #region HEADER
 
@@ -34,8 +34,8 @@ Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\
 Add-Type -Path ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SMO.cs )
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -54,7 +54,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
         $mockServerName = 'localhost'
         $mockInstanceName = 'MSSQLSERVER'
         $mockMaxDegreeOfParallelism = 4

--- a/Tests/Unit/MSFT_SqlServerMaxDop.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerMaxDop.Tests.ps1
@@ -8,12 +8,14 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container2', ContainerImage = 'microsoft/windowsservercore')]
-param()
-
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceName = 'MSFT_SqlServerMaxDop'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlServerMaxDop.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerMaxDop.Tests.ps1
@@ -8,14 +8,15 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlServerMaxDop'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
+
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlServerMaxDop'
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlServerMemory.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerMemory.Tests.ps1
@@ -8,14 +8,15 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlServerMemory'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
+
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlServerMemory'
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlServerMemory.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerMemory.Tests.ps1
@@ -15,8 +15,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlServerMemory'
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlServerMemory'
 
 #region HEADER
 
@@ -34,8 +34,8 @@ Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\
 Add-Type -Path ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SMO.cs )
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -54,7 +54,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
         $mockServerName = 'localhost'
         $mockInstanceName = 'MSSQLSERVER'
         $mockMinServerMemory = 2048

--- a/Tests/Unit/MSFT_SqlServerMemory.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerMemory.Tests.ps1
@@ -8,12 +8,14 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container2', ContainerImage = 'microsoft/windowsservercore')]
-param()
-
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceName = 'MSFT_SqlServerMemory'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlServerNetwork.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerNetwork.Tests.ps1
@@ -8,12 +8,14 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container2', ContainerImage = 'microsoft/windowsservercore')]
-param()
-
 $script:DSCModuleName      = 'SqlServerDsc'
 $script:DSCResourceName    = 'MSFT_SqlServerNetwork'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlServerNetwork.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerNetwork.Tests.ps1
@@ -15,8 +15,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName      = 'SqlServerDsc'
-$script:DSCResourceName    = 'MSFT_SqlServerNetwork'
+$script:dscModuleName      = 'SqlServerDsc'
+$script:dscResourceName    = 'MSFT_SqlServerNetwork'
 
 #region HEADER
 
@@ -31,8 +31,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -49,7 +49,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
         $mockInstanceName = 'TEST'
         $mockTcpProtocolName = 'Tcp'
         $mockNamedPipesProtocolName = 'NP'

--- a/Tests/Unit/MSFT_SqlServerNetwork.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerNetwork.Tests.ps1
@@ -8,14 +8,15 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-$script:DSCModuleName      = 'SqlServerDsc'
-$script:DSCResourceName    = 'MSFT_SqlServerNetwork'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
+
+$script:DSCModuleName      = 'SqlServerDsc'
+$script:DSCResourceName    = 'MSFT_SqlServerNetwork'
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlServerPermission.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerPermission.Tests.ps1
@@ -8,14 +8,15 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlServerPermission'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
+
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlServerPermission'
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlServerPermission.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerPermission.Tests.ps1
@@ -15,8 +15,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlServerPermission'
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlServerPermission'
 
 #region HEADER
 
@@ -31,8 +31,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -53,7 +53,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
         $mockServerName = 'localhost'
         $mockInstanceName = 'DEFAULT'
         $mockPrincipal = 'COMPANY\SqlServiceAcct'

--- a/Tests/Unit/MSFT_SqlServerPermission.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerPermission.Tests.ps1
@@ -8,12 +8,14 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container2', ContainerImage = 'microsoft/windowsservercore')]
-param()
-
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceName = 'MSFT_SqlServerPermission'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlServerReplication.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerReplication.Tests.ps1
@@ -9,13 +9,17 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container2', ContainerImage = 'microsoft/windowsservercore')]
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
 param()
 
 $script:DSCModuleName   = 'SqlServerDSC'
 $script:DSCResourceName = 'MSFT_SqlServerReplication'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region HEADER
 # Unit Test Template Version: 1.1.0

--- a/Tests/Unit/MSFT_SqlServerReplication.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerReplication.Tests.ps1
@@ -12,14 +12,15 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
 param()
 
-$script:DSCModuleName   = 'SqlServerDSC'
-$script:DSCResourceName = 'MSFT_SqlServerReplication'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
+
+$script:DSCModuleName   = 'SqlServerDSC'
+$script:DSCResourceName = 'MSFT_SqlServerReplication'
 
 #region HEADER
 # Unit Test Template Version: 1.1.0

--- a/Tests/Unit/MSFT_SqlServerReplication.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerReplication.Tests.ps1
@@ -19,8 +19,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName   = 'SqlServerDSC'
-$script:DSCResourceName = 'MSFT_SqlServerReplication'
+$script:dscModuleName   = 'SqlServerDSC'
+$script:dscResourceName = 'MSFT_SqlServerReplication'
 
 #region HEADER
 # Unit Test Template Version: 1.1.0
@@ -33,15 +33,15 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
 # Begin Testing
 try
 {
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
 
         Describe 'Helper functions' {
             Context 'Get-SqlServerMajorVersion' {

--- a/Tests/Unit/MSFT_SqlServerRole.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerRole.Tests.ps1
@@ -8,12 +8,14 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container2', ContainerImage = 'microsoft/windowsservercore')]
-param()
-
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceName = 'MSFT_SqlServerRole'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlServerRole.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerRole.Tests.ps1
@@ -8,14 +8,15 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlServerRole'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
+
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlServerRole'
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlServerRole.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerRole.Tests.ps1
@@ -15,8 +15,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlServerRole'
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlServerRole'
 
 #region HEADER
 
@@ -31,8 +31,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -51,7 +51,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
         $mockServerName = 'localhost'
         $mockInstanceName = 'MSSQLSERVER'
         $mockSqlServerRole = 'AdminSqlforBI'

--- a/Tests/Unit/MSFT_SqlServerSecureConnection.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerSecureConnection.Tests.ps1
@@ -15,8 +15,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlServerSecureConnection'
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlServerSecureConnection'
 
 #region HEADER
 
@@ -31,8 +31,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName   `
-    -DSCResourceName $script:DSCResourceName  `
+    -DSCModuleName $script:dscModuleName   `
+    -DSCResourceName $script:dscResourceName  `
     -TestType Unit
 
 #endregion HEADER
@@ -52,7 +52,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
         class MockedAccessControl
         {
             [hashtable]$Access = @{

--- a/Tests/Unit/MSFT_SqlServerSecureConnection.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerSecureConnection.Tests.ps1
@@ -8,14 +8,15 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlServerSecureConnection'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
+
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlServerSecureConnection'
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlServerSecureConnection.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerSecureConnection.Tests.ps1
@@ -8,12 +8,14 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container2', ContainerImage = 'microsoft/windowsservercore')]
-param()
-
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceName = 'MSFT_SqlServerSecureConnection'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlServiceAccount.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServiceAccount.Tests.ps1
@@ -8,14 +8,15 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-$script:DSCModuleName = 'SqlServerDsc'
-$script:DSCResourceName = 'MSFT_SqlServiceAccount'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
+
+$script:DSCModuleName = 'SqlServerDsc'
+$script:DSCResourceName = 'MSFT_SqlServiceAccount'
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlServiceAccount.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServiceAccount.Tests.ps1
@@ -8,12 +8,14 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container2', ContainerImage = 'microsoft/windowsservercore')]
-param()
-
 $script:DSCModuleName = 'SqlServerDsc'
 $script:DSCResourceName = 'MSFT_SqlServiceAccount'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region HEADER
 
@@ -177,7 +179,7 @@ try
             $managedComputerObject = New-Object -TypeName PSObject -Property @{
                 Name           = $mockDefaultInstanceName
                 ServiceAccount = $mockManagedServiceAccountName
-                Type           = 'SqlServer'      
+                Type           = 'SqlServer'
             }
 
             $managedComputerObject | Add-Member @mockAddMemberParameters_SetServiceAccount
@@ -498,7 +500,7 @@ try
                     )
 
                     # Get the service name
-                    Get-SqlServiceName -InstanceName $mockDefaultInstanceName -ServiceType $ServiceType  | Should -Be $ExpectedServiceName                        
+                    Get-SqlServiceName -InstanceName $mockDefaultInstanceName -ServiceType $ServiceType  | Should -Be $ExpectedServiceName
 
                     # Ensure the mock is utilized
                     Assert-MockCalled -CommandName Get-ChildItem -ParameterFilter $mockGetChildItem_ParameterFilter -Scope It -Exactly -Times 1
@@ -806,7 +808,7 @@ try
                     ServerName     = $mockSqlServer
                     InstanceName   = $mockDefaultInstanceName
                     ServiceType    = $mockServiceType
-                    ServiceAccount = $mockManagedServiceAccountCredential                   
+                    ServiceAccount = $mockManagedServiceAccountCredential
                 }
 
                 It 'Should have the Managed Service Account' {

--- a/Tests/Unit/MSFT_SqlSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlSetup.Tests.ps1
@@ -3154,6 +3154,11 @@ try
                             AsSvcStartupType = $mockAsSvcStartupType
                             IsSvcStartupType = $mockIsSvcStartupType
                             RsSvcStartupType = $mockRsSvcStartupType
+                            SqlTempdbFileCount = 2
+                            SqlTempdbFileSize = 128
+                            SqlTempdbFileGrowth = 128
+                            SqlTempdbLogFileSize = 128
+                            SqlTempdbLogFileGrowth = 128
                         }
 
                         if ( $mockSqlMajorVersion -in (13,14) )
@@ -3182,6 +3187,11 @@ try
                             AsSvcStartupType = $mockAsSvcStartupType
                             IsSvcStartupType = $mockIsSvcStartupType
                             RsSvcStartupType = $mockRsSvcStartupType
+                            SqlTempdbFileCount = 2
+                            SqlTempdbFileSize = 128
+                            SqlTempdbFileGrowth = 128
+                            SqlTempdbLogFileSize = 128
+                            SqlTempdbLogFileGrowth = 128
                         }
 
                         { Set-TargetResource @testParameters } | Should -Not -Throw

--- a/Tests/Unit/MSFT_SqlSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlSetup.Tests.ps1
@@ -12,14 +12,15 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 param()
 
-$script:DSCModuleName      = 'SqlServerDsc'
-$script:DSCResourceName    = 'MSFT_SqlSetup'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
+
+$script:DSCModuleName      = 'SqlServerDsc'
+$script:DSCResourceName    = 'MSFT_SqlSetup'
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlSetup.Tests.ps1
@@ -19,8 +19,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName      = 'SqlServerDsc'
-$script:DSCResourceName    = 'MSFT_SqlSetup'
+$script:dscModuleName      = 'SqlServerDsc'
+$script:dscResourceName    = 'MSFT_SqlSetup'
 
 #region HEADER
 
@@ -35,8 +35,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -53,7 +53,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
         <#
             .SYNOPSIS
                 Used to test arguments passed to Start-SqlSetupProcess while inside and It-block.

--- a/Tests/Unit/MSFT_SqlSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlSetup.Tests.ps1
@@ -8,14 +8,18 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container2', ContainerImage = 'microsoft/windowsservercore')]
 # Suppressing this rule because PlainText is required for one of the functions used in this test
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 param()
 
 $script:DSCModuleName      = 'SqlServerDsc'
 $script:DSCResourceName    = 'MSFT_SqlSetup'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlWaitForAG.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlWaitForAG.Tests.ps1
@@ -8,12 +8,14 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container2', ContainerImage = 'microsoft/windowsservercore')]
-param()
-
 $script:DSCModuleName      = 'SqlServerDsc'
 $script:DSCResourceName    = 'MSFT_SqlWaitForAG'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region HEADER
 
@@ -28,8 +30,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName 'SqlServerDsc' `
-    -DSCResourceName 'MSFT_SqlWaitForAG' `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -46,7 +48,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope 'MSFT_SqlWaitForAG' {
+    InModuleScope $script:DSCResourceName {
         $mockClusterGroupName = 'AGTest'
         $mockRetryInterval = 1
         $mockRetryCount = 2

--- a/Tests/Unit/MSFT_SqlWaitForAG.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlWaitForAG.Tests.ps1
@@ -15,8 +15,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName      = 'SqlServerDsc'
-$script:DSCResourceName    = 'MSFT_SqlWaitForAG'
+$script:dscModuleName      = 'SqlServerDsc'
+$script:dscResourceName    = 'MSFT_SqlWaitForAG'
 
 #region HEADER
 
@@ -31,8 +31,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -49,7 +49,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
         $mockClusterGroupName = 'AGTest'
         $mockRetryInterval = 1
         $mockRetryCount = 2

--- a/Tests/Unit/MSFT_SqlWaitForAG.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlWaitForAG.Tests.ps1
@@ -8,14 +8,15 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-$script:DSCModuleName      = 'SqlServerDsc'
-$script:DSCResourceName    = 'MSFT_SqlWaitForAG'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
+
+$script:DSCModuleName      = 'SqlServerDsc'
+$script:DSCResourceName    = 'MSFT_SqlWaitForAG'
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlWindowsFirewall.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlWindowsFirewall.Tests.ps1
@@ -8,14 +8,15 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-$script:DSCModuleName      = 'SqlServerDsc'
-$script:DSCResourceName    = 'MSFT_SqlWindowsFirewall'
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
 {
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
     return
 }
+
+$script:DSCModuleName      = 'SqlServerDsc'
+$script:DSCResourceName    = 'MSFT_SqlWindowsFirewall'
 
 #region HEADER
 

--- a/Tests/Unit/MSFT_SqlWindowsFirewall.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlWindowsFirewall.Tests.ps1
@@ -8,9 +8,14 @@
         https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
 #>
 
-# This is used to make sure the unit test run in a container.
-[Microsoft.DscResourceKit.UnitTest(ContainerName = 'Container2', ContainerImage = 'microsoft/windowsservercore')]
-param()
+$script:DSCModuleName      = 'SqlServerDsc'
+$script:DSCResourceName    = 'MSFT_SqlWindowsFirewall'
+
+if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
+{
+    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:DSCResourceName) -Verbose
+    return
+}
 
 #region HEADER
 
@@ -25,8 +30,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName 'SqlServerDsc' `
-    -DSCResourceName 'MSFT_SqlWindowsFirewall' `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -43,7 +48,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope 'MSFT_SqlWindowsFirewall' {
+    InModuleScope $script:DSCResourceName {
         <#
             Testing two major versions to verify Integration Services differences (i.e service name).
             No point in testing each supported SQL Server version, since there are no difference

--- a/Tests/Unit/MSFT_SqlWindowsFirewall.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlWindowsFirewall.Tests.ps1
@@ -15,8 +15,8 @@ if (Test-SkipContinuousIntegrationTask -Type 'Unit')
     return
 }
 
-$script:DSCModuleName      = 'SqlServerDsc'
-$script:DSCResourceName    = 'MSFT_SqlWindowsFirewall'
+$script:dscModuleName      = 'SqlServerDsc'
+$script:dscResourceName    = 'MSFT_SqlWindowsFirewall'
 
 #region HEADER
 
@@ -31,8 +31,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Unit
 
 #endregion HEADER
@@ -49,7 +49,7 @@ try
 {
     Invoke-TestSetup
 
-    InModuleScope $script:DSCResourceName {
+    InModuleScope $script:dscResourceName {
         <#
             Testing two major versions to verify Integration Services differences (i.e service name).
             No point in testing each supported SQL Server version, since there are no difference

--- a/Tests/Unit/SqlServerDSCHelper.Tests.ps1
+++ b/Tests/Unit/SqlServerDSCHelper.Tests.ps1
@@ -611,7 +611,7 @@ InModuleScope $script:helperModuleName {
         }
 
         BeforeEach {
-            Mock -CommandName Connect-SQL -MockWith $mockConnectSql -ModuleName $script:DSCResourceName -Verifiable
+            Mock -CommandName Connect-SQL -MockWith $mockConnectSql -ModuleName $script:dscResourceName -Verifiable
             Mock -CommandName New-InvalidOperationException -MockWith $mockThrowLocalizedMessage -Verifiable
         }
 

--- a/Tests/Unit/SqlServerDSCHelper.Tests.ps1
+++ b/Tests/Unit/SqlServerDSCHelper.Tests.ps1
@@ -12,15 +12,16 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 param ()
 
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
+{
+    return
+}
+
 # Unit Test Template Version: 1.1.0
 
 $script:helperModuleName = 'SqlServerDscHelper'
-
-if ($env:APPVEYOR -eq $true -and $env:CONFIGURATION -ne 'Unit')
-{
-    Write-Verbose -Message ('Unit test for {0} will be skipped unless $env:CONFIGURATION is set to ''Unit''.' -f $script:helperModuleName) -Verbose
-    return
-}
 
 [System.String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,19 @@
 #      environment configuration  #
 #---------------------------------#
 version: 9.0.{build}.0
+environment:
+  gallery_api:
+    secure: 9ekJzfsPCDBkyLrfmov83XbbhZ6E2N3z+B/Io8NbDetbHc6hWS19zsDmy7t0Vvxv
+  # The job where deploy step should run (normally the last job)
+  DeployInJobNumber: 3
+
+# The image that will be used when building the job matrix.
 image: Visual Studio 2017
+
+# The configuration that will be used when building the job matrix.
+# Meta = Test Framework Common Test
+# Unit = Module Unit Tests.
+# Integration = Module Integration Tests.
 configuration:
   - Meta
   - Unit
@@ -23,6 +35,12 @@ build: false
 #---------------------------------#
 #      test configuration         #
 #---------------------------------#
+
+# This will build the job matrix
+#
+# Job 1: Run meta test (common tests) on image Visual Studio 2017.
+# Job 2: Run unit tests on image Visual Studio 2017, including Codecov report.
+# Job 3: Run integration tests on image Visual Studio 2017.
 
 for:
 -
@@ -87,11 +105,24 @@ for:
 
         Invoke-AppveyorTestScriptTask -CodeCoverage -CodeCovIo -ExcludeTag @() -RunTestInOrder
 
+# Runs for all jobs.
+after_test:
+  - ps: |
+        Import-Module -Name "$env:APPVEYOR_BUILD_FOLDER\DscResource.Tests\AppVeyor.psm1"
+        Invoke-AppveyorAfterTestTask
+
 #---------------------------------#
 #      deployment configuration   #
 #---------------------------------#
 
-# scripts to run before deployment
+# Runs only in a branch (not in PR).
 deploy_script:
-    - ps: |
-        Invoke-AppveyorAfterTestTask
+  - ps: |
+        if ($env:APPVEYOR_JOB_NUMBER -eq $env:DeployInJobNumber)
+        {
+            Invoke-AppVeyorDeployTask
+        }
+        else
+        {
+            Write-Verbose -Message ('Skipping deploy step. Deploy step was requested to run in job number {0}. Current job number is {1}.' -f $env:DeployInJobNumber, $env:APPVEYOR_JOB_NUMBER) -Verbose
+        }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,10 @@
 version: 9.0.{build}.0
 image: Visual Studio 2017
 configuration:
+  - Meta
   - Unit
   - Integration
+
 install:
     - git clone https://github.com/PowerShell/DscResource.Tests
     - ps: Write-Verbose -Message "PowerShell version $($PSVersionTable.PSVersion)" -Verbose
@@ -26,7 +28,18 @@ for:
 -
   matrix:
     only:
+      - configuration: Meta
+
+  test_script:
+    - ps: |
+        Invoke-AppveyorTestScriptTask -ExcludeTag @()
+
+-
+  matrix:
+    only:
       - configuration: Integration
+  environment:
+    SkipAllCommonTests: True
 
   test_script:
     - ps: |
@@ -56,6 +69,8 @@ for:
   matrix:
     only:
       - configuration: Unit
+  environment:
+    SkipAllCommonTests: True
 
   test_script:
     - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,11 +3,11 @@
 #---------------------------------#
 version: 9.0.{build}.0
 image: Visual Studio 2017
+configuration:
+  - Unit
+  - Integration
 install:
     - git clone https://github.com/PowerShell/DscResource.Tests
-    - ps: Start-Sleep -Seconds 5
-    - ps: Restart-Computer -Force
-    - ps: Start-Sleep -Seconds 5
     - ps: Write-Verbose -Message "PowerShell version $($PSVersionTable.PSVersion)" -Verbose
     - ps: Import-Module "$env:APPVEYOR_BUILD_FOLDER\DscResource.Tests\AppVeyor.psm1"
     - ps: Invoke-AppveyorInstallTask
@@ -22,9 +22,14 @@ build: false
 #      test configuration         #
 #---------------------------------#
 
-test_script:
+for:
+-
+  matrix:
+    only:
+      - configuration: Integration
+
+  test_script:
     - ps: |
-        # Workaround for issue #239 and issue #774.
         Write-Verbose -Message '--- WORKAROUND FOR ISSUE #239 AND ISSUE #774 ---' -Verbose
         $sqlModules = Get-Module -ListAvailable -Name 'sql*'
         $sqlUniqueModulePath = Split-Path -Path (Split-Path $sqlModules.Path -Parent) -Parent | Sort-Object -Unique
@@ -33,14 +38,32 @@ test_script:
             Write-Verbose ('Renaming ''{0}'' to ''..\{1}''' -f $_, $newFolderName) -Verbose
             Rename-Item $_ -NewName $newFolderName -Force
         }
-
         Write-Verbose -Message '' -Verbose
-
         # Workaround for issue #798
         Write-Verbose -Message '--- WORKAROUND FOR ISSUE #798 ---' -Verbose
-        $azureModules = Get-Module -ListAvailable -Name 'Azure*'
+        $azureModules = Get-Module -ListAvailable -Name 'Azure*' | Where-Object -FilterScript { $_.Name -notlike 'AzureRm*' }
         $azureUniqueModulePath = Split-Path -Path (Split-Path $azureModules.Path -Parent) -Parent | Sort-Object -Unique
         $azureUniqueModulePath | ForEach-Object -Process {
+            $newFolderName = '{0}.old' -f (Split-Path -Path $_ -Leaf)
+            Write-Verbose ('Renaming ''{0}'' to ''..\{1}''' -f $_, $newFolderName) -Verbose
+            Rename-Item $_ -NewName $newFolderName -Force
+        }
+        Write-Verbose -Message '' -Verbose
+
+        Invoke-AppveyorTestScriptTask -ExcludeTag @() -RunTestInOrder
+
+-
+  matrix:
+    only:
+      - configuration: Unit
+
+  test_script:
+    - ps: |
+        # Workaround for issue #239 and issue #774.
+        Write-Verbose -Message '--- WORKAROUND FOR ISSUE #239 AND ISSUE #774 ---' -Verbose
+        $sqlModules = Get-Module -ListAvailable -Name 'sql*'
+        $sqlUniqueModulePath = Split-Path -Path (Split-Path $sqlModules.Path -Parent) -Parent | Sort-Object -Unique
+        $sqlUniqueModulePath | ForEach-Object -Process {
             $newFolderName = '{0}.old' -f (Split-Path -Path $_ -Leaf)
             Write-Verbose ('Renaming ''{0}'' to ''..\{1}''' -f $_, $newFolderName) -Verbose
             Rename-Item $_ -NewName $newFolderName -Force


### PR DESCRIPTION
Updated Cim Class to Win32_ComputerSystem (instead of Win32_PhysicalMemory) because the correct memory size was not being detected correctly on Azure VMs

Fixes #914
Fixes #1154

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/1284)
<!-- Reviewable:end -->
