### PR TITLE
SqlServerMemory: Fix so auto memory on Azure VMs is reported correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 - Changes to SqlServerDsc
+  - Updated Cim Class to Win32_ComputerSystem (instead of Win32_PhysicalMemory)
+    because the correct memory size was not being detected correctly on Azure VMs
+    [issue #914](https://github.com/PowerShell/SqlServerDsc/issues/914)
+    [issue #1154](https://github.com/PowerShell/SqlServerDsc/issues/1154)
   - Reverting the change that was made as part of the
     [issue #1260](https://github.com/PowerShell/SqlServerDsc/issues/1260)
     in the previous release, as it only mitigated the issue, it did not

--- a/DSCResources/MSFT_SqlServerMemory/MSFT_SqlServerMemory.psm1
+++ b/DSCResources/MSFT_SqlServerMemory/MSFT_SqlServerMemory.psm1
@@ -340,7 +340,7 @@ function Get-SqlDscDynamicMaxMemory
 {
     try
     {
-        $physicalMemory = ((Get-CimInstance -ClassName Win32_PhysicalMemory).Capacity | Measure-Object -Sum).Sum
+        $physicalMemory = (Get-CimInstance -ClassName Win32_ComputerSystem).TotalPhysicalMemory
         $physicalMemoryInMegaBytes = [Math]::Round($physicalMemory / 1MB)
 
         # Find how much to save for OS: 20% of total ram for under 15GB / 12.5% for over 20GB

--- a/Tests/Unit/MSFT_SqlServerMemory.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerMemory.Tests.ps1
@@ -157,13 +157,11 @@ try
             }
 
             Mock -CommandName Get-CimInstance -MockWith {
-                $mockGetCimInstanceMem = @()
 
-                $mockGetCimInstanceMem += New-Object -TypeName PSObject -Property @{
+                New-Object -TypeName PSObject -Property @{
                     TotalPhysicalMemory = 17179869184
                 }
 
-                $mockGetCimInstanceMem
             } -ParameterFilter { $ClassName -eq 'Win32_ComputerSystem' } -Verifiable
 
             Mock -CommandName Get-CimInstance -MockWith {
@@ -489,21 +487,11 @@ try
             }
 
             Mock -CommandName Get-CimInstance -MockWith {
-                $mockGetCimInstanceMem = @()
 
-                $mockGetCimInstanceMem += New-Object -TypeName PSObject -Property @{
-                    Name     = 'Physical Memory'
-                    Tag      = 'Physical Memory 0'
-                    Capacity = 17179869184
+                New-Object -TypeName PSObject -Property @{
+                    TotalPhysicalMemory = 17179869184
                 }
 
-                $mockGetCimInstanceMem += New-Object -TypeName PSObject -Property @{
-                    Name     = 'Physical Memory'
-                    Tag      = 'Physical Memory 1'
-                    Capacity = 17179869184
-                }
-
-                $mockGetCimInstanceMem
             } -ParameterFilter { $ClassName -eq 'Win32_ComputerSystem' } -Verifiable
 
             Mock -CommandName Get-CimInstance -MockWith {

--- a/Tests/Unit/MSFT_SqlServerMemory.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerMemory.Tests.ps1
@@ -160,19 +160,11 @@ try
                 $mockGetCimInstanceMem = @()
 
                 $mockGetCimInstanceMem += New-Object -TypeName PSObject -Property @{
-                    Name     = 'Physical Memory'
-                    Tag      = 'Physical Memory 0'
-                    Capacity = 8589934592
-                }
-
-                $mockGetCimInstanceMem += New-Object -TypeName PSObject -Property @{
-                    Name     = 'Physical Memory'
-                    Tag      = 'Physical Memory 1'
-                    Capacity = 8589934592
+                    TotalPhysicalMemory = 17179869184
                 }
 
                 $mockGetCimInstanceMem
-            } -ParameterFilter { $ClassName -eq 'Win32_PhysicalMemory' } -Verifiable
+            } -ParameterFilter { $ClassName -eq 'Win32_ComputerSystem' } -Verifiable
 
             Mock -CommandName Get-CimInstance -MockWith {
                 $mockGetCimInstanceProc = [PSCustomObject]@{
@@ -317,9 +309,9 @@ try
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
 
-                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_PhysicalMemory' {
+                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_ComputerSystem' {
                     Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
-                        $ClassName -eq 'Win32_PhysicalMemory'
+                        $ClassName -eq 'Win32_ComputerSystem'
                     } -Scope Context
                 }
 
@@ -361,9 +353,9 @@ try
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
 
-                It 'Should not call the mock function Get-CimInstance with ClassName equal to Win32_PhysicalMemory' {
+                It 'Should not call the mock function Get-CimInstance with ClassName equal to Win32_ComputerSystem' {
                     Assert-MockCalled Get-CimInstance -Exactly -Times 0 -ParameterFilter {
-                        $ClassName -eq 'Win32_PhysicalMemory'
+                        $ClassName -eq 'Win32_ComputerSystem'
                     } -Scope Context
                 }
 
@@ -401,9 +393,9 @@ try
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
 
-                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_PhysicalMemory' {
+                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_ComputerSystem' {
                     Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
-                        $ClassName -eq 'Win32_PhysicalMemory'
+                        $ClassName -eq 'Win32_ComputerSystem'
                     } -Scope Context
                 }
 
@@ -512,7 +504,7 @@ try
                 }
 
                 $mockGetCimInstanceMem
-            } -ParameterFilter { $ClassName -eq 'Win32_PhysicalMemory' } -Verifiable
+            } -ParameterFilter { $ClassName -eq 'Win32_ComputerSystem' } -Verifiable
 
             Mock -CommandName Get-CimInstance -MockWith {
                 $mockGetCimInstanceProc = [PSCustomObject]@{
@@ -636,9 +628,9 @@ try
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
 
-                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_PhysicalMemory' {
+                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_ComputerSystem' {
                     Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
-                        $ClassName -eq 'Win32_PhysicalMemory'
+                        $ClassName -eq 'Win32_ComputerSystem'
                     } -Scope Context
                 }
 
@@ -678,9 +670,9 @@ try
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
 
-                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_PhysicalMemory' {
+                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_ComputerSystem' {
                     Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
-                        $ClassName -eq 'Win32_PhysicalMemory'
+                        $ClassName -eq 'Win32_ComputerSystem'
                     } -Scope Context
                 }
 
@@ -768,9 +760,9 @@ try
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
 
-                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_PhysicalMemory' {
+                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_ComputerSystem' {
                     Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
-                        $ClassName -eq 'Win32_PhysicalMemory'
+                        $ClassName -eq 'Win32_ComputerSystem'
                     } -Scope Context
                 }
 


### PR DESCRIPTION
Updated Cim Class to Win32_ComputerSystem (instead of Win32_PhysicalMemory) because the correct memory size was not being detected correctly on Azure VMs

Fixes #914
Fixes #1154

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/1285)
<!-- Reviewable:end -->
