### PR TITLE
SqlAGReplica: Fix read-only routing list reaching desired state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@
     parameters will still change existing replicas ([issue #1244](https://github.com/PowerShell/SqlServerDsc/issues/1244)).
   - ReadOnlyRoutingList now gets updated without throwing an error on the first
     run ([issue #518](https://github.com/PowerShell/SqlServerDsc/issues/518)).
+  - Test-Resource fixed to report whether ReadOnlyRoutingList desired state
+    has been reached correctly ([issue #1305](https://github.com/PowerShell/SqlServerDsc/issues/1305)).
 
 ## 12.3.0.0
 

--- a/DSCResources/MSFT_SqlAG/MSFT_SqlAG.psm1
+++ b/DSCResources/MSFT_SqlAG/MSFT_SqlAG.psm1
@@ -695,7 +695,7 @@ function Test-TargetResource
                     {
                         New-VerboseMessage -Message "'$($parameterName)' should be '$($parameterValue)' but is '$($getTargetResourceResult.($parameterName))'"
 
-                        $result = $False
+                        $result = $false
                     }
                 }
 

--- a/DSCResources/MSFT_SqlAGReplica/MSFT_SqlAGReplica.psm1
+++ b/DSCResources/MSFT_SqlAGReplica/MSFT_SqlAGReplica.psm1
@@ -666,9 +666,12 @@ function Test-TargetResource
                         continue
                     }
 
-                    if ( $parameterName -eq 'ReadOnlyRoutingList' ) {
+                    if ( $parameterName -eq 'ReadOnlyRoutingList' )
+                    {
                         $different = ( $getTargetResourceResult.($parameterName) -join ',' ) -ne ( $parameterValue -join ',' )
-                    } else {
+                    }
+                    else
+                    {
                         $different = $getTargetResourceResult.($parameterName) -ne $parameterValue
                     }
 

--- a/DSCResources/MSFT_SqlAGReplica/MSFT_SqlAGReplica.psm1
+++ b/DSCResources/MSFT_SqlAGReplica/MSFT_SqlAGReplica.psm1
@@ -666,7 +666,7 @@ function Test-TargetResource
                         continue
                     }
 
-                    if ( $parameterName -eq 'ReadyOnlyRoutingList' ) {
+                    if ( $parameterName -eq 'ReadOnlyRoutingList' ) {
                         $different = ( $getTargetResourceResult.($parameterName) -join ',' ) -ne ( $parameterValue -join ',' )
                     } else {
                         $different = $getTargetResourceResult.($parameterName) -ne $parameterValue

--- a/DSCResources/MSFT_SqlAGReplica/MSFT_SqlAGReplica.psm1
+++ b/DSCResources/MSFT_SqlAGReplica/MSFT_SqlAGReplica.psm1
@@ -666,11 +666,17 @@ function Test-TargetResource
                         continue
                     }
 
-                    if ( $getTargetResourceResult.($parameterName) -ne $parameterValue )
+                    if ( $parameterName -eq 'ReadyOnlyRoutingList' ) {
+                        $different = ( $getTargetResourceResult.($parameterName) -join ',' ) -ne ( $parameterValue -join ',' )
+                    } else {
+                        $different = $getTargetResourceResult.($parameterName) -ne $parameterValue
+                    }
+
+                    if ( $different )
                     {
                         New-VerboseMessage -Message "'$($parameterName)' should be '$($parameterValue)' but is '$($getTargetResourceResult.($parameterName))'"
 
-                        $result = $False
+                        $result = $false
                     }
                 }
 

--- a/DSCResources/MSFT_SqlServerEndpointPermission/MSFT_SqlServerEndpointPermission.psm1
+++ b/DSCResources/MSFT_SqlServerEndpointPermission/MSFT_SqlServerEndpointPermission.psm1
@@ -49,7 +49,7 @@ function Get-TargetResource
         {
             New-VerboseMessage -Message "Enumerating permissions for endpoint $Name"
 
-            $permissionSet = New-Object -Property @{ Connect = $True } -TypeName Microsoft.SqlServer.Management.Smo.ObjectPermissionSet
+            $permissionSet = New-Object -Property @{ Connect = $true } -TypeName Microsoft.SqlServer.Management.Smo.ObjectPermissionSet
 
             $endpointPermission = $endpointObject.EnumObjectPermissions( $permissionSet ) | Where-Object { $_.PermissionState -eq "Grant" -and $_.Grantee -eq $Principal }
             if ($endpointPermission.Count -ne 0)
@@ -152,7 +152,7 @@ function Set-TargetResource
         $endpointObject = $sqlServerObject.Endpoints[$Name]
         if ($null -ne $endpointObject)
         {
-            $permissionSet = New-Object -Property @{ Connect = $True } -TypeName Microsoft.SqlServer.Management.Smo.ObjectPermissionSet
+            $permissionSet = New-Object -Property @{ Connect = $true } -TypeName Microsoft.SqlServer.Management.Smo.ObjectPermissionSet
 
             if ($Ensure -eq 'Present')
             {

--- a/Examples/Resources/SqlAG/3-CreateAvailabilityGroupDetailed.ps1
+++ b/Examples/Resources/SqlAG/3-CreateAvailabilityGroupDetailed.ps1
@@ -23,9 +23,9 @@ $ConfigurationData = @{
             FailoverMode                  = 'Automatic'
             HealthCheckTimeout            = 15000
 
-            BasicAvailabilityGroup        = $False
-            DatabaseHealthTrigger         = $True
-            DtcSupportEnabled             = $True
+            BasicAvailabilityGroup        = $false
+            DatabaseHealthTrigger         = $true
+            DtcSupportEnabled             = $true
         },
 
         @{

--- a/Tests/Unit/MSFT_SqlAGReplica.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAGReplica.Tests.ps1
@@ -71,7 +71,7 @@ try
         $mockEndpointHostName = $mockServerName
         $mockFailoverMode = 'Manual'
         $mockReadOnlyRoutingConnectionUrl = "TCP://$($mockServerName).domain.com:1433"
-        $mockReadOnlyRoutingList = @($mockServerName)
+        $mockReadOnlyRoutingList = @('Server1', 'Server2')
         $mockProcessOnlyOnActiveNode = $false
 
         #endregion
@@ -153,7 +153,7 @@ try
         $mockAvailabilityGroupReplica1EndpointUrl = "$($mockAvailabilityGroupReplica1EndpointProtocol)://$($mockServer1Name):$($mockAvailabilityGroupReplica1EndpointPort)"
         $mockAvailabilityGroupReplica1FailoverMode = 'Manual'
         $mockAvailabilityGroupReplica1ReadOnlyRoutingConnectionUrl = "TCP://$($mockServer1Name).domain.com:1433"
-        $mockAvailabilityGroupReplica1ReadOnlyRoutingList = @($mockServer1Name)
+        $mockAvailabilityGroupReplica1ReadOnlyRoutingList = $mockReadOnlyRoutingList
 
         $mockAvailabilityGroupReplica2Name = $mockServer2Name
         $mockAvailabilityGroupReplica2AvailabilityMode = 'AsynchronousCommit'
@@ -165,7 +165,7 @@ try
         $mockAvailabilityGroupReplica2EndpointUrl = "$($mockAvailabilityGroupReplica2EndpointProtocol)://$($mockServer2Name):$($mockAvailabilityGroupReplica2EndpointPort)"
         $mockAvailabilityGroupReplica2FailoverMode = 'Manual'
         $mockAvailabilityGroupReplica2ReadOnlyRoutingConnectionUrl = "TCP://$($mockServer2Name).domain.com:1433"
-        $mockAvailabilityGroupReplica2ReadOnlyRoutingList = @($mockServer2Name)
+        $mockAvailabilityGroupReplica2ReadOnlyRoutingList = $mockReadOnlyRoutingList
 
         $mockAvailabilityGroupReplica3Name = $mockServer3Name
         $mockAvailabilityGroupReplica3AvailabilityMode = 'AsynchronousCommit'
@@ -177,7 +177,7 @@ try
         $mockAvailabilityGroupReplica3EndpointUrl = "$($mockAvailabilityGroupReplica3EndpointProtocol)://$($mockServer3Name):$($mockAvailabilityGroupReplica3EndpointPort)"
         $mockAvailabilityGroupReplica3FailoverMode = 'Manual'
         $mockAvailabilityGroupReplica3ReadOnlyRoutingConnectionUrl = "TCP://$($mockServer3Name).domain.com:1433"
-        $mockAvailabilityGroupReplica3ReadOnlyRoutingList = @($mockServer3Name)
+        $mockAvailabilityGroupReplica3ReadOnlyRoutingList = $mockReadOnlyRoutingList
 
         #endregion
 
@@ -612,7 +612,7 @@ try
                     $getTargetResourceResult.FailoverMode | Should -Be $mockFailoverMode
                     $getTargetResourceResult.Name | Should -Be $mockServerName
                     $getTargetResourceResult.ReadOnlyRoutingConnectionUrl | Should -Be $mockReadOnlyRoutingConnectionUrl
-                    $getTargetResourceResult.ReadOnlyRoutingList | Should -Be $mockServerName
+                    $getTargetResourceResult.ReadOnlyRoutingList | Should -Be $mockReadOnlyRoutingList
                     $getTargetResourceResult.ServerName | Should -Be $mockServerName
                     $getTargetResourceResult.InstanceName | Should -Be $mockInstanceName
                     $getTargetResourceResult.EndpointHostName | Should -Be $mockServerName
@@ -1083,7 +1083,7 @@ try
                         ConnectionModeInSecondaryRole = 'AllowReadIntentConnectionsOnly'
                         FailoverMode                  = 'Automatic'
                         ReadOnlyRoutingConnectionUrl  = 'TCP://TestHost.domain.com:1433'
-                        ReadOnlyRoutingList           = @('Server1', 'Server2')
+                        ReadOnlyRoutingList           = @('Server2', 'Server1')
                     }
                 }
 
@@ -1353,6 +1353,13 @@ try
                         ReadOnlyRoutingConnectionUrl  = 'WrongUrl'
                         ReadOnlyRoutingList           = @('WrongServer')
                     }
+                }
+
+                It "Should return $true when the Availability Replica is present all properties are in the desired state" {
+                    Test-TargetResource @testTargetResourceParameters | Should -Be $true
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Test-ActiveNode -Scope It -Times 1 -Exactly
                 }
 
                 It 'Should return $false when the Availability Replica is absent' {

--- a/Tests/Unit/MSFT_SqlServerPermission.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerPermission.Tests.ps1
@@ -78,7 +78,7 @@ try
                     $mockObjectSmoServer.Name = "$mockServerName\$mockInstanceName"
                     $mockObjectSmoServer.DisplayName = $mockInstanceName
                     $mockObjectSmoServer.InstanceName = $mockInstanceName
-                    $mockObjectSmoServer.IsHadrEnabled = $False
+                    $mockObjectSmoServer.IsHadrEnabled = $false
                     $mockObjectSmoServer.MockGranteeName = $mockPrincipal
 
                     return $mockObjectSmoServer
@@ -204,7 +204,7 @@ try
                     $mockObjectSmoServer.Name = "$mockServerName\$mockInstanceName"
                     $mockObjectSmoServer.DisplayName = $mockInstanceName
                     $mockObjectSmoServer.InstanceName = $mockInstanceName
-                    $mockObjectSmoServer.IsHadrEnabled = $False
+                    $mockObjectSmoServer.IsHadrEnabled = $false
                     $mockObjectSmoServer.MockGranteeName = $mockPrincipal
 
                     return $mockObjectSmoServer
@@ -272,7 +272,7 @@ try
                     $mockObjectSmoServer.Name = "$mockServerName\$mockInstanceName"
                     $mockObjectSmoServer.DisplayName = $mockInstanceName
                     $mockObjectSmoServer.InstanceName = $mockInstanceName
-                    $mockObjectSmoServer.IsHadrEnabled = $False
+                    $mockObjectSmoServer.IsHadrEnabled = $false
                     $mockObjectSmoServer.MockGranteeName = $mockPrincipal
 
                     return $mockObjectSmoServer
@@ -329,7 +329,7 @@ try
                             $mockObjectSmoServer.Name = "$mockServerName\$mockInstanceName"
                             $mockObjectSmoServer.DisplayName = $mockInstanceName
                             $mockObjectSmoServer.InstanceName = $mockInstanceName
-                            $mockObjectSmoServer.IsHadrEnabled = $False
+                            $mockObjectSmoServer.IsHadrEnabled = $false
                             # This make the SMO Server object mock to throw when Grant() method is called.
                             $mockObjectSmoServer.MockGranteeName = $mockOtherPrincipal
 

--- a/Tests/Unit/MSFT_SqlServerSecureConnection.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerSecureConnection.Tests.ps1
@@ -638,7 +638,7 @@ try
 
                 It 'Should return False when no permissions were found' {
                     $result = Test-CertificatePermission -Thumbprint '12345678' -ServiceAccount 'Everyone'
-                    $result | Should -be $False
+                    $result | Should -be $false
                     Assert-VerifiableMock
                 }
             }
@@ -654,7 +654,7 @@ try
 
                 It 'Should return False when the wrong permissions are added' {
                     $result = Test-CertificatePermission -Thumbprint '12345678' -ServiceAccount 'Everyone'
-                    $result | Should -be $False
+                    $result | Should -be $false
                     Assert-VerifiableMock
                 }
             }


### PR DESCRIPTION
#### Pull Request (PR) description
This fixes the Test-Resource portion of SqlAGReplica so that it compares read only routing lists properly. This allows desired state to be reached.

I added no entry in CHANGELOG as it's fixing the unreleased feature.

In the unit tests I modified the read only routing list defaults. Using an array instead of a single server name here causes the tests to fail on the old code (as they should) and pass on the new code (as they should). 

In the unit tests I also added another section to confirm that the test resource passes when nothing has changed. This also picked up the old bad code and passes on the new code.

Finally I did a search replace of $True and $False.

#### This Pull Request (PR) fixes the following issues
- Fixes #1305

#### Task list
- [ ] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/1312)
<!-- Reviewable:end -->
