### PR TITLE
SQLServerSecureConnection: Setting ServiceAccount to SYSTEM if user specifies LocalSystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## 12.4.0.0
 
 - Changes to SqlServerDsc
+  - Updated SqlServerSecureConnection module to replace 'LocalSystem' Service Account Name with 'SYSTEM'
+    to fix issue where the LocalSystem account throws an exception, but connects successfully.
   - Added new resources.
     - SqlRSSetup
   - Added helper module DscResource.Common from the repository

--- a/DSCResources/MSFT_SqlServerSecureConnection/MSFT_SqlServerSecureConnection.psm1
+++ b/DSCResources/MSFT_SqlServerSecureConnection/MSFT_SqlServerSecureConnection.psm1
@@ -212,6 +212,12 @@ function Set-TargetResource
 
     $encryptionState = Get-TargetResource @parameters
 
+	# Error is thrown but connection succeeds if 'LocalSystem' is set as ServiceAccount. Setting ServiceAccount to use SYSTEM instead. 
+	if ($ServiceAccount -eq 'LocalSystem')
+	{
+		ServiceAccount	= 'SYSTEM'
+	}
+
     if ($Ensure -eq 'Present')
     {
         if ($ForceEncryption -ne $encryptionState.ForceEncryption -or $Thumbprint -ne $encryptionState.Thumbprint)

--- a/DSCResources/MSFT_SqlServerSecureConnection/MSFT_SqlServerSecureConnection.psm1
+++ b/DSCResources/MSFT_SqlServerSecureConnection/MSFT_SqlServerSecureConnection.psm1
@@ -212,11 +212,11 @@ function Set-TargetResource
 
     $encryptionState = Get-TargetResource @parameters
 
-	# Error is thrown but connection succeeds if 'LocalSystem' is set as ServiceAccount. Setting ServiceAccount to use SYSTEM instead. 
+    # Error is thrown but connection succeeds if 'LocalSystem' is set as ServiceAccount. Setting ServiceAccount to use SYSTEM instead. 
 	if ($ServiceAccount -eq 'LocalSystem')
-	{
-		ServiceAccount	= 'SYSTEM'
-	}
+    {
+        ServiceAccount  = 'SYSTEM'
+    }
 
     if ($Ensure -eq 'Present')
     {


### PR DESCRIPTION
#### Pull Request (PR) description

Exception is thrown but connection succeeds if the ServiceAccount is specified as 'LocalSystem'. LocalSystem uses the SYSTEM token (https://docs.microsoft.com/en-us/windows/desktop/Services/localsystem-account), so setting the ServiceAccount to use SYSTEM instead which doesn't throw an error.

#### This Pull Request (PR) fixes the following issues
    - Fixes #1300 

#### Task list
- [X] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/1320)
<!-- Reviewable:end -->
