### PR TITLE
SqlServerMemory: Localization, unit tests and fix bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@
   - Refactored unit tests to simplify them add add slightly more code
     coverage.
 
-
 ## 12.4.0.0
 
 - Changes to SqlServerDsc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@
   - Added en-US localization ([issue #625](https://github.com/PowerShell/SqlServerDsc/issues/625)).
 - Changes to SqlServerPermission
   - Added en-US localization ([issue #619](https://github.com/PowerShell/SqlServerDsc/issues/619)).
+- Changes to SqlServerMemory
+  - Added en-US localization ([issue #617](https://github.com/PowerShell/SqlServerDsc/issues/617)).
+  - No longer will the resource set the MinMemory value if it was provided
+    in a configuration that also set the `Ensure` parameter to 'Absent'
+    ([issue #1329](https://github.com/PowerShell/SqlServerDsc/issues/1329)).
+  - Refactored unit tests to simplify them add add slightly more code
+    coverage.
+
 
 ## 12.4.0.0
 

--- a/DSCResources/MSFT_SqlServerMemory/en-US/MSFT_SqlServerMemory.strings.psd1
+++ b/DSCResources/MSFT_SqlServerMemory/en-US/MSFT_SqlServerMemory.strings.psd1
@@ -1,0 +1,17 @@
+ConvertFrom-StringData @'
+    GetMemoryValues = Getting the current values for minimum and maximum SQL server memory for instance '{0}'.
+    SetNewValues = Setting the minimum and maximum memory that will be used by the instance '{0}'.
+    MaxMemoryParamMustBeNull = The parameter MaxMemory must be null when the parameter DynamicAlloc is set to true.
+    MaxMemoryParamMustNotBeNull = The parameter MaxMemory must not be null when the parameter DynamicAlloc is set to false.
+    DynamicMaxMemoryValue = Dynamic maximum memory has been calculated to {0}MB.
+    MaximumMemoryLimited = Maximum memory used by the instance '{0}' has been limited to {1}MB.
+    MinimumMemoryLimited = Minimum memory used by the instance '{0}' has been set to {1}MB.
+    DefaultValues = Resetting to the default values; MinMemory = {0}, MaxMemory = {1}.
+    ResetDefaultValues = Minimum and maximum server memory values used by the instance {0} has been reset to the default values.
+    AlterServerMemoryFailed = Failed to alter the server configuration memory for {0}\{1}.
+    ErrorGetDynamicMaxMemory = Failed to calculate dynamically the maximum memory.
+    EvaluatingMinAndMaxMemory = Determines the values of the minimum and maximum memory server configuration option for the instance '{0}'.
+    NotActiveNode = The node '{0}' is not actively hosting the instance '{1}'. Will always return success for this resource on this node, until this node is actively hosting the instance.
+    WrongMaximumMemory = Current maximum server memory used by the instance is {0}MB, but expected {1}MB.
+    WrongMinimumMemory = Current minimum server memory used by the instance is {0}MB, but expected {1}MB.
+'@

--- a/DSCResources/MSFT_SqlServerMemory/en-US/MSFT_SqlServerMemory.strings.psd1
+++ b/DSCResources/MSFT_SqlServerMemory/en-US/MSFT_SqlServerMemory.strings.psd1
@@ -8,7 +8,7 @@ ConvertFrom-StringData @'
     MinimumMemoryLimited = Minimum memory used by the instance '{0}' has been set to {1}MB.
     DefaultValues = Resetting to the default values; MinMemory = {0}, MaxMemory = {1}.
     ResetDefaultValues = Minimum and maximum server memory values used by the instance {0} has been reset to the default values.
-    AlterServerMemoryFailed = Failed to alter the server configuration memory for {0}\{1}.
+    AlterServerMemoryFailed = Failed to alter the server configuration memory for {0}\\{1}.
     ErrorGetDynamicMaxMemory = Failed to calculate dynamically the maximum memory.
     EvaluatingMinAndMaxMemory = Determines the values of the minimum and maximum memory server configuration option for the instance '{0}'.
     NotActiveNode = The node '{0}' is not actively hosting the instance '{1}'. Will always return success for this resource on this node, until this node is actively hosting the instance.

--- a/Modules/DscResource.Common/en-US/DscResource.Common.strings.psd1
+++ b/Modules/DscResource.Common/en-US/DscResource.Common.strings.psd1
@@ -132,12 +132,6 @@ ConvertFrom-StringData @'
     MaxDopSetError = Unexpected result when trying to configure the max degree of parallelism server configuration option.
     MaxDopParamMustBeNull = MaxDop parameter must be set to $null or not assigned if DynamicAlloc parameter is set to $true.
 
-    # Server Memory
-    MaxMemoryParamMustBeNull = The parameter MaxMemory must be null when DynamicAlloc is set to true.
-    MaxMemoryParamMustNotBeNull = The parameter MaxMemory must not be null when DynamicAlloc is set to false.
-    AlterServerMemoryFailed = Failed to alter the server configuration memory for {0}\\{1}.
-    ErrorGetDynamicMaxMemory = Failed to calculate dynamically the maximum memory.
-
     # SQLServerDatabase
     CreateDatabaseSetError = Failed to create the database named {2} on {0}\\{1}.
     DropDatabaseSetError = Failed to drop the database named {2} on {0}\\{1}.

--- a/Modules/DscResource.Common/sv-SE/DscResource.Common.strings.psd1
+++ b/Modules/DscResource.Common/sv-SE/DscResource.Common.strings.psd1
@@ -126,12 +126,6 @@ ConvertFrom-StringData @'
     MaxDopSetError = Unexpected result when trying to configure the max degree of parallelism server configuration option.
     MaxDopParamMustBeNull = MaxDop parameter must be set to $null or not assigned if DynamicAlloc parameter is set to $true.
 
-    # Server Memory
-    MaxMemoryParamMustBeNull = The parameter MaxMemory must be null when DynamicAlloc is set to true.
-    MaxMemoryParamMustNotBeNull = The parameter MaxMemory must not be null when DynamicAlloc is set to false.
-    AlterServerMemoryFailed = Failed to alter the server configuration memory for {0}\\{1}.
-    ErrorGetDynamicMaxMemory = Failed to calculate dynamically the maximum memory.
-
     # SQLServerDatabase
     CreateDatabaseSetError = Failed to create the database named {2} on {0}\\{1}.
     DropDatabaseSetError = Failed to drop the database named {2} on {0}\\{1}.

--- a/Tests/Unit/MSFT_SqlServerMemory.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlServerMemory.Tests.ps1
@@ -137,11 +137,11 @@ try
                 }
 
                 It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope Context
                 }
 
                 It 'Should call the mock function Test-ActiveNode' {
-                    Assert-MockCalled Test-ActiveNode -Exactly -Times 1 -Scope Context
+                    Assert-MockCalled -CommandName Test-ActiveNode -Exactly -Times 1 -Scope Context
                 }
             }
 
@@ -149,37 +149,24 @@ try
         }
 
         Describe "MSFT_SqlServerMemory\Test-TargetResource" -Tag 'Test' {
-            Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+            BeforeEach {
+                Mock -CommandName Get-SqlDscDynamicMaxMemory -MockWith {
+                    return 8192 # MB
+                }
 
-            Mock -CommandName Get-CimInstance -MockWith {
-                throw 'Mocked function Get-CimInstance was called with the wrong set of parameter filters.'
+                Mock -CommandName Get-TargetResource -MockWith {
+                    return @{
+                        InstanceName = $mockInstanceName
+                        ServerName   = $mockServerName
+                        MinMemory    = $mockMinServerMemory
+                        MaxMemory    = $mockMaxServerMemory
+                        IsActiveNode = $mockTestActiveNode
+                    }
+                }
             }
 
-            Mock -CommandName Get-CimInstance -MockWith {
-
-                New-Object -TypeName PSObject -Property @{
-                    TotalPhysicalMemory = 17179869184
-                }
-
-            } -ParameterFilter { $ClassName -eq 'Win32_ComputerSystem' } -Verifiable
-
-            Mock -CommandName Get-CimInstance -MockWith {
-                $mockGetCimInstanceProc = [PSCustomObject]@{
-                    NumberOfCores = 2
-                }
-
-                $mockGetCimInstanceProc
-            } -ParameterFilter { $ClassName -eq 'Win32_Processor' } -Verifiable
-
-            Mock -CommandName Get-CimInstance -MockWith {
-                $mockGetCimInstanceOS = [PSCustomObject]@{
-                    OSArchitecture = '64-bit'
-                }
-
-                $mockGetCimInstanceOS
-            } -ParameterFilter { $ClassName -eq 'Win32_OperatingSystem' } -Verifiable
-
-            Mock -CommandName Test-ActiveNode -MockWith { return $mockTestActiveNode } -Verifiable
+            $mockMinServerMemory = 0
+            $mockMaxServerMemory = 16384
 
             Context 'When the system is not in the desired state and DynamicAlloc is set to false' {
                 $testParameters = $mockDefaultParameters
@@ -193,14 +180,6 @@ try
                 It 'Should return the state as false when desired MinMemory and MaxMemory are not present' {
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $false
-                }
-
-                It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
-                }
-
-                It 'Should not call the mock function Get-CimInstance' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 0 -Scope Context
                 }
             }
 
@@ -216,36 +195,20 @@ try
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $false
                 }
-
-                It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
-                }
-
-                It 'Should not call the mock function Get-CimInstance' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 0 -Scope Context
-                }
             }
 
             Context 'When the system is in the desired state and DynamicAlloc is set to false' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
                     Ensure       = 'Present'
-                    MinMemory    = 0
-                    MaxMemory    = 10300
+                    MinMemory    = $mockMinServerMemory
+                    MaxMemory    = $mockMaxServerMemory
                     DynamicAlloc = $false
                 }
 
                 It 'Should return the state as true when desired MinMemory and MaxMemory are present' {
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $true
-                }
-
-                It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
-                }
-
-                It 'Should not call the mock function Get-CimInstance' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 0 -Scope Context
                 }
             }
 
@@ -258,15 +221,7 @@ try
                 }
 
                 It 'Should throw the correct error' {
-                    { Test-TargetResource @testParameters } | Should -Throw 'The parameter MaxMemory must be null when DynamicAlloc is set to true.'
-                }
-
-                It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
-                }
-
-                It 'Should not call the mock function Get-CimInstance' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 0 -Scope Context
+                    { Test-TargetResource @testParameters } | Should -Throw $script:localizedData.MaxMemoryParamMustBeNull
                 }
             }
 
@@ -278,15 +233,7 @@ try
                 }
 
                 It 'Should throw the correct error' {
-                    {Test-TargetResource @testParameters } | Should -Throw 'The parameter MaxMemory must not be null when DynamicAlloc is set to false.'
-                }
-
-                It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
-                }
-
-                It 'Should not call the mock function Get-CimInstance' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 0 -Scope Context
+                    {Test-TargetResource @testParameters } | Should -Throw $script:localizedData.MaxMemoryParamMustNotBeNull
                 }
             }
 
@@ -300,28 +247,6 @@ try
                 It 'Should return the state as false when desired MinMemory and MaxMemory are not present' {
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $false
-                }
-
-                It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
-                }
-
-                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_ComputerSystem' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
-                        $ClassName -eq 'Win32_ComputerSystem'
-                    } -Scope Context
-                }
-
-                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_Processor' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
-                        $ClassName -eq 'Win32_Processor'
-                    } -Scope Context
-                }
-
-                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_OperatingSystem' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
-                        $ClassName -eq 'Win32_OperatingSystem'
-                    } -Scope Context
                 }
             }
 
@@ -345,34 +270,10 @@ try
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $true
                 }
-
-                It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
-                }
-
-                It 'Should not call the mock function Get-CimInstance with ClassName equal to Win32_ComputerSystem' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 0 -ParameterFilter {
-                        $ClassName -eq 'Win32_ComputerSystem'
-                    } -Scope Context
-                }
-
-                It 'Should not call the mock function Get-CimInstance with ClassName equal to Win32_Processor' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 0 -ParameterFilter {
-                        $ClassName -eq 'Win32_Processor'
-                    } -Scope Context
-                }
-
-                It 'Should not call the mock function Get-CimInstance with ClassName equal to Win32_OperatingSystem' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 0 -ParameterFilter {
-                        $ClassName -eq 'Win32_OperatingSystem'
-                    } -Scope Context
-                }
             }
 
             $mockMinServerMemory = 0
             $mockMaxServerMemory = 12083
-
-            Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
             Context 'When the system is in the desired state and DynamicAlloc is set to true' {
                 $testParameters = $mockDefaultParameters
@@ -381,38 +282,14 @@ try
                     DynamicAlloc = $true
                 }
 
-                It 'Should return the state as true when desired MinMemory and MaxMemory are present' {
+                It 'Should return the state as false when desired MinMemory and MaxMemory are wrong values' {
                     $result = Test-TargetResource @testParameters
-                    $result | Should -Be $true
-                }
-
-                It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
-                }
-
-                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_ComputerSystem' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
-                        $ClassName -eq 'Win32_ComputerSystem'
-                    } -Scope Context
-                }
-
-                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_Processor' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
-                        $ClassName -eq 'Win32_Processor'
-                    } -Scope Context
-                }
-
-                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_OperatingSystem' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
-                        $ClassName -eq 'Win32_OperatingSystem'
-                    } -Scope Context
+                    $result | Should -Be $false
                 }
             }
 
             $mockMinServerMemory = 1024
             $mockMaxServerMemory = 8192
-
-            Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
             Context 'When the system is not in the desired state and Ensure is set to Absent' {
                 $testParameters = $mockDefaultParameters
@@ -424,20 +301,10 @@ try
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $false
                 }
-
-                It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
-                }
-
-                It 'Should not call the mock function Get-CimInstance' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 0 -Scope Context
-                }
             }
 
             $mockMinServerMemory = 0
             $mockMaxServerMemory = 2147483647
-
-            Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
             Context 'When the system is in the desired state and Ensure is set to Absent' {
                 $testParameters = $mockDefaultParameters
@@ -448,14 +315,6 @@ try
                 It 'Should return the state as true when desired MinMemory and MaxMemory are present' {
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $true
-                }
-
-                It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
-                }
-
-                It 'Should not call the mock function Get-CimInstance' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 0 -Scope Context
                 }
             }
 
@@ -480,34 +339,9 @@ try
             $mockMaxServerMemory = 2147483647
 
             Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
-
-            Mock -CommandName Get-CimInstance -MockWith {
-                throw 'Mocked function Get-CimInstance was called with the wrong set of parameter filters.'
+            Mock -CommandName Get-SqlDscDynamicMaxMemory -MockWith {
+                return 16384 # MB
             }
-
-            Mock -CommandName Get-CimInstance -MockWith {
-
-                New-Object -TypeName PSObject -Property @{
-                    TotalPhysicalMemory = 17179869184
-                }
-
-            } -ParameterFilter { $ClassName -eq 'Win32_ComputerSystem' } -Verifiable
-
-            Mock -CommandName Get-CimInstance -MockWith {
-                $mockGetCimInstanceProc = [PSCustomObject]@{
-                    NumberOfCores = 6
-                }
-
-                $mockGetCimInstanceProc
-            } -ParameterFilter { $ClassName -eq 'Win32_Processor' } -Verifiable
-
-            Mock -CommandName Get-CimInstance -MockWith {
-                $mockGetCimInstanceOS = [PSCustomObject]@{
-                    OSArchitecture = 'IA64-bit'
-                }
-
-                $mockGetCimInstanceOS
-            } -ParameterFilter { $ClassName -eq 'Win32_OperatingSystem' } -Verifiable
 
             Context 'When the MaxMemory parameter is not null and DynamicAlloc is set to true' {
                 $testParameters = $mockDefaultParameters
@@ -518,15 +352,15 @@ try
                 }
 
                 It 'Should throw the correct error' {
-                    { Set-TargetResource @testParameters } | Should -Throw 'The parameter MaxMemory must be null when DynamicAlloc is set to true.'
+                    { Set-TargetResource @testParameters } | Should -Throw $script:localizedData.MaxMemoryParamMustBeNull
                 }
 
                 It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope Context
                 }
 
-                It 'Should not call the mock function Get-CimInstance' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 0 -Scope Context
+                It 'Should not call the mock function Get-SqlDscDynamicMaxMemory' {
+                    Assert-MockCalled -CommandName Get-SqlDscDynamicMaxMemory -Exactly -Times 0 -Scope Context
                 }
             }
 
@@ -538,15 +372,15 @@ try
                 }
 
                 It 'Should throw the correct error' {
-                    { Set-TargetResource @testParameters } | Should -Throw 'The parameter MaxMemory must not be null when DynamicAlloc is set to false.'
+                    { Set-TargetResource @testParameters } | Should -Throw $script:localizedData.MaxMemoryParamMustNotBeNull
                 }
 
                 It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope Context
                 }
 
-                It 'Should not call the mock function Get-CimInstance' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 0 -Scope Context
+                It 'Should not call the mock function Get-SqlDscDynamicMaxMemory' {
+                    Assert-MockCalled -CommandName Get-SqlDscDynamicMaxMemory -Exactly -Times 0 -Scope Context
                 }
             }
 
@@ -562,11 +396,11 @@ try
                 }
 
                 It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope Context
                 }
 
-                It 'Should not call the mock function Get-CimInstance' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 0 -Scope Context
+                It 'Should not call the mock function Get-SqlDscDynamicMaxMemory' {
+                    Assert-MockCalled -CommandName Get-SqlDscDynamicMaxMemory -Exactly -Times 0 -Scope Context
                 }
             }
 
@@ -591,11 +425,11 @@ try
                 }
 
                 It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope Context
                 }
 
-                It 'Should not call the mock function Get-CimInstance' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 0 -Scope Context
+                It 'Should not call the mock function Get-SqlDscDynamicMaxMemory' {
+                    Assert-MockCalled -CommandName Get-SqlDscDynamicMaxMemory -Exactly -Times 0 -Scope Context
                 }
             }
 
@@ -612,67 +446,11 @@ try
                 }
 
                 It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope Context
                 }
 
-                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_ComputerSystem' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
-                        $ClassName -eq 'Win32_ComputerSystem'
-                    } -Scope Context
-                }
-
-                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_Processor' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
-                        $ClassName -eq 'Win32_Processor'
-                    } -Scope Context
-                }
-
-                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_OperatingSystem' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
-                        $ClassName -eq 'Win32_OperatingSystem'
-                    } -Scope Context
-                }
-            }
-
-            Mock -CommandName Get-CimInstance -MockWith {
-                $mockGetCimInstanceOS = [PSCustomObject]@{
-                    OSArchitecture = '32-bit'
-                }
-
-                $mockGetCimInstanceOS
-            } -ParameterFilter { $ClassName -eq 'Win32_OperatingSystem' } -Verifiable
-
-            Context 'When the system (OS 32-bit) is not in the desired state and Ensure is set to Present, and DynamicAlloc is set to true' {
-                $testParameters = $mockDefaultParameters
-                $testParameters += @{
-                    DynamicAlloc = $true
-                    Ensure       = 'Present'
-                }
-
-                It 'Should set the MaxMemory to the correct values when Ensure parameter is set to Present and DynamicAlloc is set to true' {
-                    { Set-TargetResource @testParameters } | Should -Not -Throw
-                }
-
-                It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
-                }
-
-                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_ComputerSystem' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
-                        $ClassName -eq 'Win32_ComputerSystem'
-                    } -Scope Context
-                }
-
-                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_Processor' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
-                        $ClassName -eq 'Win32_Processor'
-                    } -Scope Context
-                }
-
-                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_OperatingSystem' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
-                        $ClassName -eq 'Win32_OperatingSystem'
-                    } -Scope Context
+                It 'Should call the mock function Get-SqlDscDynamicMaxMemory' {
+                    Assert-MockCalled -CommandName Get-SqlDscDynamicMaxMemory -Exactly -Times 1 -Scope Context
                 }
             }
 
@@ -714,59 +492,244 @@ try
                 }
 
                 It 'Should throw the correct error' {
-                    { Set-TargetResource @testParameters } | Should -Throw ("Failed to alter the server configuration memory for $($env:COMPUTERNAME)" + "\" + `
-                            "$mockInstanceName. InnerException: Exception calling ""Alter"" with ""0"" argument(s): " + `
-                            """Mock Alter Method was called with invalid operation.""")
+                    { Set-TargetResource @testParameters } | Should -Throw ($script:localizedData.AlterServerMemoryFailed -f $env:COMPUTERNAME, $mockInstanceName)
                 }
 
                 It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope Context
                 }
 
-                It 'Should not call the mock function Get-CimInstance' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 0 -Scope Context
-                }
-            }
-
-            Mock -CommandName Get-CimInstance -MockWith {
-                throw
-            } -ParameterFilter { $ClassName -eq 'Win32_OperatingSystem' } -Verifiable
-
-            Context 'When the Get-SqlDscDynamicMaxMemory fails to calculate the MaxMemory' {
-                $testParameters = $mockDefaultParameters
-                $testParameters += @{
-                    DynamicAlloc = $true
-                    Ensure       = 'Present'
-                }
-
-                It 'Should throw the correct error' {
-                    { Set-TargetResource @testParameters } | Should -Throw 'Failed to calculate dynamically the maximum memory.'
-                }
-
-                It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
-                }
-
-                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_ComputerSystem' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
-                        $ClassName -eq 'Win32_ComputerSystem'
-                    } -Scope Context
-                }
-
-                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_Processor' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
-                        $ClassName -eq 'Win32_Processor'
-                    } -Scope Context
-                }
-
-                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_OperatingSystem' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
-                        $ClassName -eq 'Win32_OperatingSystem'
-                    } -Scope Context
+                It 'Should not call the mock function Get-SqlDscDynamicMaxMemory' {
+                    Assert-MockCalled -CommandName Get-SqlDscDynamicMaxMemory -Exactly -Times 0 -Scope Context
                 }
             }
 
             Assert-VerifiableMock
+        }
+
+        Describe 'MSFT_SqlServerMemory\Get-SqlDscDynamicMaxMemory' -Tag 'Helper' {
+            Context 'When the physical memory should be calculated' {
+                BeforeEach {
+                    Mock -CommandName Get-CimInstance -MockWith {
+                        return New-Object -TypeName PSObject -Property @{
+                            TotalPhysicalMemory = $mockTotalPhysicalMemory
+                        }
+                    } -ParameterFilter { $ClassName -eq 'Win32_ComputerSystem' }
+
+                    Mock -CommandName Get-CimInstance -MockWith {
+                        return  [PSCustomObject]@{
+                            NumberOfCores = $mockNumberOfCores
+                        }
+                    } -ParameterFilter { $ClassName -eq 'Win32_Processor' }
+
+                    Mock -CommandName Get-CimInstance -MockWith {
+                        return [PSCustomObject]@{
+                            OSArchitecture = $mockOSArchitecture
+                        }
+                    } -ParameterFilter { $ClassName -eq 'Win32_OperatingSystem' }
+                }
+
+                Context 'When number of cores is 2' {
+                    $mockNumberOfCores = 2
+
+                    Context 'When OS Architecture is 64-bit' {
+                        $mockOSArchitecture = '64-bit'
+
+                        context 'When physical memory is less than 20480MB' {
+                            $mockTotalPhysicalMemory = 20426260480
+
+                            It 'Should return the correct max memory (in megabytes) value' {
+                                $result = Get-SqlDscDynamicMaxMemory
+                                $result | Should -Be 14560
+                            }
+                        }
+
+                        context 'When physical memory is equal to 20480MB' {
+                            $mockTotalPhysicalMemory = 21474836480
+
+                            It 'Should return the correct max memory (in megabytes) value' {
+                                $result = Get-SqlDscDynamicMaxMemory
+                                $result | Should -Be 16896
+                            }
+                        }
+
+                        context 'When physical memory is more than 20480MB' {
+                            $mockTotalPhysicalMemory = 31960596480
+
+                            It 'Should return the correct max memory (in megabytes) value' {
+                                $result = Get-SqlDscDynamicMaxMemory
+                                $result | Should -Be 25646
+                            }
+                        }
+
+
+                    }
+
+                    Context 'When OS Architecture is 32-bit' {
+                        $mockOSArchitecture = '32-bit'
+
+                        context 'When physical memory is less than 20480MB' {
+                            # Dynamically set the mock return value.
+                            $mockTotalPhysicalMemory = 20426260480
+
+                            It 'Should return the correct max memory (in megabytes) value' {
+                                $result = Get-SqlDscDynamicMaxMemory
+                                $result | Should -Be 14560
+                            }
+                        }
+
+                        context 'When physical memory is equal to 20480MB' {
+                            $mockTotalPhysicalMemory = 21474836480
+
+                            It 'Should return the correct max memory (in megabytes) value' {
+                                $result = Get-SqlDscDynamicMaxMemory
+                                $result | Should -Be 16896
+                            }
+                        }
+
+                        context 'When physical memory is more than 20480MB' {
+                            $mockTotalPhysicalMemory = 31960596480
+
+                            It 'Should return the correct max memory (in megabytes) value' {
+                                $result = Get-SqlDscDynamicMaxMemory
+                                $result | Should -Be 25646
+                            }
+                        }
+                    }
+
+                    Context 'When OS Architecture is IA64-bit' {
+                        $mockOSArchitecture = 'IA64-bit'
+
+                        context 'When physical memory is less than 20480MB' {
+                            # Dynamically set the mock return value.
+                            $mockTotalPhysicalMemory = 20426260480
+
+                            It 'Should return the correct max memory (in megabytes) value' {
+                                $result = Get-SqlDscDynamicMaxMemory
+                                $result | Should -Be 14560
+                            }
+                        }
+
+                        context 'When physical memory is equal to 20480MB' {
+                            $mockTotalPhysicalMemory = 21474836480
+
+                            It 'Should return the correct max memory (in megabytes) value' {
+                                $result = Get-SqlDscDynamicMaxMemory
+                                $result | Should -Be 16896
+                            }
+                        }
+
+                        context 'When physical memory is more than 20480MB' {
+                            $mockTotalPhysicalMemory = 31960596480
+
+                            It 'Should return the correct max memory (in megabytes) value' {
+                                $result = Get-SqlDscDynamicMaxMemory
+                                $result | Should -Be 25646
+                            }
+                        }
+                    }
+                }
+
+                Context 'When number of cores is 4' {
+                    $mockNumberOfCores = 4
+                    Context 'When OS Architecture is 64-bit' {
+                        $mockOSArchitecture = '64-bit'
+
+                        context 'When physical memory is more than 20480MB' {
+                            $mockTotalPhysicalMemory = 31960596480
+
+                            It 'Should return the correct max memory (in megabytes) value' {
+                                $result = Get-SqlDscDynamicMaxMemory
+                                $result | Should -Be 25134
+                            }
+                        }
+                    }
+
+                    Context 'When OS Architecture is 32-bit' {
+                        $mockOSArchitecture = '32-bit'
+
+                        context 'When physical memory is more than 20480MB' {
+                            # Dynamically set the mock return value.
+                            $mockTotalPhysicalMemory = 31960596480
+
+                            It 'Should return the correct max memory (in megabytes) value' {
+                                $result = Get-SqlDscDynamicMaxMemory
+                                $result | Should -Be 25390
+                            }
+                        }
+                    }
+
+                    Context 'When OS Architecture is IA64-bit' {
+                        $mockOSArchitecture = 'IA64-bit'
+
+                        context 'When physical memory is more than 20480MB' {
+                            # Dynamically set the mock return value.
+                            $mockTotalPhysicalMemory = 31960596480
+
+                            It 'Should return the correct max memory (in megabytes) value' {
+                                $result = Get-SqlDscDynamicMaxMemory
+                                $result | Should -Be 24622
+                            }
+                        }
+                    }
+                }
+
+                Context 'When number of cores is 6' {
+                    $mockNumberOfCores = 6
+                    Context 'When OS Architecture is 64-bit' {
+                        $mockOSArchitecture = '64-bit'
+
+                        context 'When physical memory is more than 20480MB' {
+                            $mockTotalPhysicalMemory = 31960596480
+
+                            It 'Should return the correct max memory (in megabytes) value' {
+                                $result = Get-SqlDscDynamicMaxMemory
+                                $result | Should -Be 24078
+                            }
+                        }
+                    }
+
+                    Context 'When OS Architecture is 32-bit' {
+                        $mockOSArchitecture = '32-bit'
+
+                        context 'When physical memory is more than 20480MB' {
+                            # Dynamically set the mock return value.
+                            $mockTotalPhysicalMemory = 31960596480
+
+                            It 'Should return the correct max memory (in megabytes) value' {
+                                $result = Get-SqlDscDynamicMaxMemory
+                                $result | Should -Be 24350
+                            }
+                        }
+                    }
+
+                    Context 'When OS Architecture is IA64-bit' {
+                        $mockOSArchitecture = 'IA64-bit'
+
+                        context 'When physical memory is more than 20480MB' {
+                            # Dynamically set the mock return value.
+                            $mockTotalPhysicalMemory = 31960596480
+
+                            It 'Should return the correct max memory (in megabytes) value' {
+                                $result = Get-SqlDscDynamicMaxMemory
+                                $result | Should -Be 23534
+                            }
+                        }
+                    }
+                }
+            }
+
+            Context 'When the physical memory fails to be calculated' {
+                BeforeAll {
+                    Mock -CommandName Get-CimInstance -MockWith {
+                        throw 'mocked unkown error'
+                    }
+                }
+
+                It 'Should throw the correct error' {
+                    { Get-SqlDscDynamicMaxMemory } | Should -Throw $script:localizedData.ErrorGetDynamicMaxMemory
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
- Changes to SqlServerMemory
  - Added en-US localization (issue #617).
  - No longer will the resource set the MinMemory value if it was provided
    in a configuration that also set the `Ensure` parameter to 'Absent' (issue #1329).
  - Refactored unit tests to simplify them add add slightly more code
    coverage.

#### This Pull Request (PR) fixes the following issues
- Fixes #617

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/1330)
<!-- Reviewable:end -->
