### PR TITLE
SqlAgDatabase: Adding statementTimeout and Replace for restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Change log for SqlServerDsc
 
 ## Unreleased
-
+- Changes to SqlServerDscHelper
+  - Added parameter StatementTimeout with default value 600 (10 minutes) to functions SQL-Connect and Invoke-Query.
+    [issue #1358]
+- Changes to SqlAGDatabase
+  - Added 'REPLACE' to restore command to allow secondary database to be overwritten after a failed configuration. 
+  - Added parameter StatementTimeout with value 0 (unlimited) to functions SQL-Connect and Invoke-Query
+    [issue #1358]
 - Changes to SqlServerMemory
   - Updated Cim Class to Win32_ComputerSystem (instead of Win32_PhysicalMemory)
     because the correct memory size was not being detected correctly on Azure VMs

--- a/SqlServerDscHelper.psm1
+++ b/SqlServerDscHelper.psm1
@@ -23,6 +23,9 @@ $script:localizedData = Get-LocalizedData -ResourceName 'SqlServerDscHelper' -Sc
         If the SetupCredential is set, specify with this parameter, which type
         of credentials are set: Native SQL login or Windows user Login. Default
         value is 'WindowsUser'.
+
+    .PARAMETER StatementTimeout
+    Set the query StatementTimeout in seconds. Default value 600 seconds (10mins).
 #>
 function Connect-SQL
 {
@@ -965,6 +968,9 @@ function Restart-ReportingServicesService
 
     .PARAMETER WithResults
     Specifies if the query should return results.
+
+    .PARAMETER StatementTimeout
+    Set the query StatementTimeout in seconds. Default 600 seconds (10mins).
 
     .EXAMPLE
     Invoke-Query -SQLServer Server1 -SQLInstanceName MSSQLSERVER -Database master -Query 'SELECT name FROM sys.databases' -WithResults

--- a/Tests/Unit/SqlServerDSCHelper.Tests.ps1
+++ b/Tests/Unit/SqlServerDSCHelper.Tests.ps1
@@ -108,6 +108,8 @@ InModuleScope $script:helperModuleName {
                     Add-Member -MemberType NoteProperty -Name ConnectAsUser -Value $false -PassThru |
                     Add-Member -MemberType NoteProperty -Name ConnectAsUserPassword -Value '' -PassThru |
                     Add-Member -MemberType NoteProperty -Name ConnectAsUserName -Value '' -PassThru |
+                    Add-Member -MemberType NoteProperty -Name StatementTimeout -Value 600 -PassThru |
+                    Add-Member -MemberType NoteProperty -Name ApplicationName -Value 'SqlServerDsc' -PassThru |
                     Add-Member -MemberType ScriptMethod -Name Connect -Value {
                         if ($mockExpectedDatabaseEngineInstance -eq 'MSSQLSERVER')
                         {
@@ -1467,6 +1469,7 @@ InModuleScope $script:helperModuleName {
                 $mockExpectedDatabaseEngineInstance = $mockInstanceName
 
                 Mock -CommandName New-Object `
+                    -MockWith $mockNewObject_MicrosoftDatabaseEngine `
                     -ParameterFilter $mockNewObject_MicrosoftDatabaseEngine_ParameterFilter `
                     -Verifiable
 
@@ -2052,7 +2055,7 @@ InModuleScope $script:helperModuleName {
                 Assert-MockCalled -CommandName Stop-Service -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName Start-Service -Scope It -Exactly -Times 2
                 Assert-MockCalled -CommandName Start-Sleep -Scope It -Exactly -Times 1
-        }
+            }
         }
     }
 


### PR DESCRIPTION
#### Pull Request (PR) description
"SqlServerDscHelper.psm1": I've added a new parameter "StatementTimeout" to function "Connect-SQL", and "Invoke-Query". 

"MSFT_SqlAGDatabase.psm1": I've added -StatementTimeout 0 on the long running commands.

#### This Pull Request (PR) fixes the following issues
- Should fix #1358

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/1362)
<!-- Reviewable:end -->
