### PR TITLE
SqlAgentFailsafe: Adding resource to manage Agent Failsafe Operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Changes to SqlServerDsc
+  - New DSC resource SqlAgentFailsafe
   - New DSC resource SqlDatabaseUser ([issue #846](https://github.com/PowerShell/SqlServerDsc/issues/846)).
     - Adds ability to create database users with more fine-grained control,
       e.g. re-mapping of orphaned logins or a different login. Supports

--- a/DSCResources/MSFT_SqlAgentFailsafe/MSFT_SqlAgentFailsafe.psm1
+++ b/DSCResources/MSFT_SqlAgentFailsafe/MSFT_SqlAgentFailsafe.psm1
@@ -8,16 +8,16 @@ $script:localizedData = Get-LocalizedData -ResourceName 'MSFT_SqlAgentFailsafe'
 
 <#
     .SYNOPSIS
-    This function gets the SQL Agent Failsafe Operator.
+        This function gets the SQL Agent Failsafe Operator.
 
     .PARAMETER Name
-    The name of the SQL Agent Failsafe Operator.
+        The name of the SQL Agent Failsafe Operator.
 
     .PARAMETER ServerName
-    The host name of the SQL Server to be configured. Default is $env:COMPUTERNAME.
+        The host name of the SQL Server to be configured. Default is $env:COMPUTERNAME.
 
     .PARAMETER InstanceName
-    The name of the SQL instance to be configured.
+        The name of the SQL instance to be configured.
 #>
 function Get-TargetResource
 {
@@ -25,7 +25,6 @@ function Get-TargetResource
     [OutputType([System.Collections.Hashtable])]
     param
     (
-
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
@@ -39,11 +38,10 @@ function Get-TargetResource
         [ValidateNotNullOrEmpty()]
         [System.String]
         $InstanceName
-
     )
 
     $returnValue = @{
-        Name               = $null
+        Name               = $Name
         Ensure             = 'Absent'
         ServerName         = $ServerName
         InstanceName       = $InstanceName
@@ -57,16 +55,19 @@ function Get-TargetResource
         Write-Verbose -Message (
             $script:localizedData.GetSqlAgentFailsafe
         )
-        $sqlFailsafetObject = $sqlServerObject.JobServer.AlertSystem | Where-Object -FilterScript {$_.FailSafeOperator -eq $Name}
-        if ($sqlFailsafetObject)
+
+        $sqlAlertSystemObject = $sqlServerObject.JobServer.AlertSystem | Where-Object -FilterScript {$_.FailSafeOperator -eq $Name}
+
+        if ($sqlAlertSystemObject)
         {
             Write-Verbose -Message (
                 $script:localizedData.SqlFailsafePresent `
                     -f $Name
             )
+
             $returnValue['Ensure'] = 'Present'
-            $returnValue['Name'] = $sqlFailsafetObject.FailSafeOperator
-            $returnValue['NotificationMethod'] = $sqlFailsafetObject.NotificationMethod
+            $returnValue['Name'] = $sqlAlertSystemObject.FailSafeOperator
+            $returnValue['NotificationMethod'] = $sqlAlertSystemObject.NotificationMethod
         }
         else
         {
@@ -87,22 +88,22 @@ function Get-TargetResource
 
 <#
     .SYNOPSIS
-    This function sets the SQL Agent Failsafe Operator.
+        This function sets the SQL Agent Failsafe Operator.
 
     .PARAMETER Ensure
-    Specifies if the SQL Agent Failsafe Operator should be present or absent. Default is Present
+        Specifies if the SQL Agent Failsafe Operator should be present or absent. Default is Present
 
     .PARAMETER Name
-    The name of the SQL Agent Failsafe Operator.
+        The name of the SQL Agent Failsafe Operator.
 
     .PARAMETER ServerName
-    The host name of the SQL Server to be configured. Default is $env:COMPUTERNAME.
+        The host name of the SQL Server to be configured. Default is $env:COMPUTERNAME.
 
     .PARAMETER InstanceName
-    The name of the SQL instance to be configured.
+        The name of the SQL instance to be configured.
 
     .PARAMETER NotificationMethod
-    The method of notification for the Failsafe Operator.
+        The method of notification for the Failsafe Operator.
 #>
 function Set-TargetResource
 {
@@ -133,7 +134,6 @@ function Set-TargetResource
         [ValidateSet('None', 'NotifyEmail', 'Pager', 'NetSend', 'NotifyAll')]
         [System.String]
         $NotificationMethod
-
     )
 
     $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
@@ -146,21 +146,25 @@ function Set-TargetResource
             {
                 try
                 {
-                    $sqlFailsafetObject = $sqlServerObject.JobServer.AlertSystem
+                    $sqlAlertSystemObject = $sqlServerObject.JobServer.AlertSystem
+
                     Write-Verbose -Message (
                         $script:localizedData.UpdateFailsafeOperator `
                             -f $Name
                     )
-                    $sqlFailsafetObject.FailSafeOperator = $Name
+
+                    $sqlAlertSystemObject.FailSafeOperator = $Name
                     if ($PSBoundParameters.ContainsKey('NotificationMethod'))
                     {
                         Write-Verbose -Message (
                             $script:localizedData.UpdateNotificationMethod `
                                 -f $NotificationMethod, $Name
                         )
-                        $sqlFailsafetObject.NotificationMethod = $NotificationMethod
+
+                        $sqlAlertSystemObject.NotificationMethod = $NotificationMethod
                     }
-                    $sqlFailsafetObject.Alter()
+
+                    $sqlAlertSystemObject.Alter()
                 }
                 catch
                 {
@@ -168,17 +172,20 @@ function Set-TargetResource
                     New-InvalidOperationException -Message $errorMessage -ErrorRecord $_
                 }
             }
+
             'Absent'
             {
                 try
                 {
-                    $sqlFailsafetObject = $sqlServerObject.JobServer.AlertSystem
+                    $sqlAlertSystemObject = $sqlServerObject.JobServer.AlertSystem
+
                     Write-Verbose -Message (
                         $script:localizedData.RemoveFailsafeOperator
                     )
-                    $sqlFailsafetObject.FailSafeOperator = $null
-                    $sqlFailsafetObject.NotificationMethod = 'None'
-                    $sqlFailsafetObject.Alter()
+
+                    $sqlAlertSystemObject.FailSafeOperator = $null
+                    $sqlAlertSystemObject.NotificationMethod = 'None'
+                    $sqlAlertSystemObject.Alter()
                 }
                 catch
                 {
@@ -197,22 +204,22 @@ function Set-TargetResource
 
 <#
     .SYNOPSIS
-    This function tests the SQL Agent Failsafe Operator.
+        This function tests the SQL Agent Failsafe Operator.
 
     .PARAMETER Ensure
-    Specifies if the SQL Agent Failsafe Operator should be present or absent. Default is Present
+        Specifies if the SQL Agent Failsafe Operator should be present or absent. Default is Present
 
     .PARAMETER Name
-    The name of the SQL Agent Failsafe Operator.
+        The name of the SQL Agent Failsafe Operator.
 
     .PARAMETER ServerName
-    The host name of the SQL Server to be configured. Default is $env:COMPUTERNAME.
+        The host name of the SQL Server to be configured. Default is $env:COMPUTERNAME.
 
     .PARAMETER InstanceName
-    The name of the SQL instance to be configured.
+        The name of the SQL instance to be configured.
 
     .PARAMETER NotificationMethod
-    The method of notification for the Failsafe Operator.
+        The method of notification for the Failsafe Operator.
 #>
 function Test-TargetResource
 {
@@ -243,7 +250,6 @@ function Test-TargetResource
         [ValidateSet('None', 'NotifyEmail', 'Pager', 'NetSend', 'NotifyAll')]
         [System.String]
         $NotificationMethod
-
     )
 
     $getTargetResourceParameters = @{

--- a/DSCResources/MSFT_SqlAgentFailsafe/MSFT_SqlAgentFailsafe.psm1
+++ b/DSCResources/MSFT_SqlAgentFailsafe/MSFT_SqlAgentFailsafe.psm1
@@ -41,7 +41,7 @@ function Get-TargetResource
     )
 
     $returnValue = @{
-        Name               = $Name
+        Name               = $null
         Ensure             = 'Absent'
         ServerName         = $ServerName
         InstanceName       = $InstanceName

--- a/DSCResources/MSFT_SqlAgentFailsafe/MSFT_SqlAgentFailsafe.psm1
+++ b/DSCResources/MSFT_SqlAgentFailsafe/MSFT_SqlAgentFailsafe.psm1
@@ -1,0 +1,284 @@
+$script:resourceModulePath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent
+$script:modulesFolderPath = Join-Path -Path $script:resourceModulePath -ChildPath 'Modules'
+
+$script:resourceHelperModulePath = Join-Path -Path $script:modulesFolderPath -ChildPath 'SqlServerDsc.Common'
+Import-Module -Name (Join-Path -Path $script:resourceHelperModulePath -ChildPath 'SqlServerDsc.Common.psm1')
+
+$script:localizedData = Get-LocalizedData -ResourceName 'MSFT_SqlAgentFailsafe'
+
+<#
+    .SYNOPSIS
+    This function gets the SQL Agent Failsafe Operator.
+
+    .PARAMETER Name
+    The name of the SQL Agent Failsafe Operator.
+
+    .PARAMETER ServerName
+    The host name of the SQL Server to be configured. Default is $env:COMPUTERNAME.
+
+    .PARAMETER InstanceName
+    The name of the SQL instance to be configured.
+#>
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Name,
+
+        [Parameter()]
+        [System.String]
+        $ServerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $InstanceName
+
+    )
+
+    $returnValue = @{
+        Name               = $null
+        Ensure             = 'Absent'
+        ServerName         = $ServerName
+        InstanceName       = $InstanceName
+        NotificationMethod = $null
+    }
+
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+
+    if ($sqlServerObject)
+    {
+        Write-Verbose -Message (
+            $script:localizedData.GetSqlAgentFailsafe
+        )
+        $sqlFailsafetObject = $sqlServerObject.JobServer.AlertSystem | Where-Object -FilterScript {$_.FailSafeOperator -eq $Name}
+        if ($sqlFailsafetObject)
+        {
+            Write-Verbose -Message (
+                $script:localizedData.SqlFailsafePresent `
+                    -f $Name
+            )
+            $returnValue['Ensure'] = 'Present'
+            $returnValue['Name'] = $sqlFailsafetObject.FailSafeOperator
+            $returnValue['NotificationMethod'] = $sqlFailsafetObject.NotificationMethod
+        }
+        else
+        {
+            Write-Verbose -Message (
+                $script:localizedData.SqlFailsafeAbsent `
+                    -f $Name
+            )
+        }
+    }
+    else
+    {
+        $errorMessage = $script:localizedData.ConnectServerFailed -f $ServerName, $InstanceName
+        New-InvalidOperationException -Message $errorMessage
+    }
+
+    return $returnValue
+}
+
+<#
+    .SYNOPSIS
+    This function sets the SQL Agent Failsafe Operator.
+
+    .PARAMETER Ensure
+    Specifies if the SQL Agent Failsafe Operator should be present or absent. Default is Present
+
+    .PARAMETER Name
+    The name of the SQL Agent Failsafe Operator.
+
+    .PARAMETER ServerName
+    The host name of the SQL Server to be configured. Default is $env:COMPUTERNAME.
+
+    .PARAMETER InstanceName
+    The name of the SQL instance to be configured.
+
+    .PARAMETER NotificationMethod
+    The method of notification for the Failsafe Operator.
+#>
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter()]
+        [ValidateSet('Present', 'Absent')]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Ensure = 'Present',
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Name,
+
+        [Parameter()]
+        [System.String]
+        $ServerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $InstanceName,
+
+        [Parameter()]
+        [ValidateSet('None', 'NotifyEmail', 'Pager', 'NetSend', 'NotifyAll')]
+        [System.String]
+        $NotificationMethod
+
+    )
+
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+
+    if ($sqlServerObject)
+    {
+        switch ($Ensure)
+        {
+            'Present'
+            {
+                try
+                {
+                    $sqlFailsafetObject = $sqlServerObject.JobServer.AlertSystem
+                    Write-Verbose -Message (
+                        $script:localizedData.UpdateFailsafeOperator `
+                            -f $Name
+                    )
+                    $sqlFailsafetObject.FailSafeOperator = $Name
+                    if ($PSBoundParameters.ContainsKey('NotificationMethod'))
+                    {
+                        Write-Verbose -Message (
+                            $script:localizedData.UpdateNotificationMethod `
+                                -f $NotificationMethod, $Name
+                        )
+                        $sqlFailsafetObject.NotificationMethod = $NotificationMethod
+                    }
+                    $sqlFailsafetObject.Alter()
+                }
+                catch
+                {
+                    $errorMessage = $script:localizedData.UpdateFailsafeOperatorError -f  $Name, $ServerName, $InstanceName
+                    New-InvalidOperationException -Message $errorMessage -ErrorRecord $_
+                }
+            }
+            'Absent'
+            {
+                try
+                {
+                    $sqlFailsafetObject = $sqlServerObject.JobServer.AlertSystem
+                    Write-Verbose -Message (
+                        $script:localizedData.RemoveFailsafeOperator
+                    )
+                    $sqlFailsafetObject.FailSafeOperator = $null
+                    $sqlFailsafetObject.NotificationMethod = 'None'
+                    $sqlFailsafetObject.Alter()
+                }
+                catch
+                {
+                    $errorMessage = $script:localizedData.UpdateFailsafeOperatorError -f $Name, $ServerName, $InstanceName
+                    New-InvalidOperationException -Message $errorMessage -ErrorRecord $_
+                }
+            }
+        }
+    }
+    else
+    {
+        $errorMessage = $script:localizedData.ConnectServerFailed -f $ServerName, $InstanceName
+        New-InvalidOperationException -Message $errorMessage
+    }
+}
+
+<#
+    .SYNOPSIS
+    This function tests the SQL Agent Failsafe Operator.
+
+    .PARAMETER Ensure
+    Specifies if the SQL Agent Failsafe Operator should be present or absent. Default is Present
+
+    .PARAMETER Name
+    The name of the SQL Agent Failsafe Operator.
+
+    .PARAMETER ServerName
+    The host name of the SQL Server to be configured. Default is $env:COMPUTERNAME.
+
+    .PARAMETER InstanceName
+    The name of the SQL instance to be configured.
+
+    .PARAMETER NotificationMethod
+    The method of notification for the Failsafe Operator.
+#>
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [Parameter()]
+        [ValidateSet('Present', 'Absent')]
+        [System.String]
+        $Ensure = 'Present',
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Name,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $InstanceName,
+
+        [Parameter()]
+        [System.String]
+        $ServerName = $env:COMPUTERNAME,
+
+        [Parameter()]
+        [ValidateSet('None', 'NotifyEmail', 'Pager', 'NetSend', 'NotifyAll')]
+        [System.String]
+        $NotificationMethod
+
+    )
+
+    $getTargetResourceParameters = @{
+        ServerName     = $ServerName
+        InstanceName   = $InstanceName
+        Name           = $Name
+    }
+
+    $returnValue = $false
+
+    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+
+    Write-Verbose -Message (
+        $script:localizedData.TestingConfiguration
+    )
+
+    if ($Ensure -eq 'Present')
+    {
+        $returnValue = Test-DscParameterState `
+            -CurrentValues $getTargetResourceResult `
+            -DesiredValues $PSBoundParameters `
+            -ValuesToCheck @(
+            'FailsafeOperator'
+            'NotificationMethod'
+        )
+    }
+    else
+    {
+        if ($Ensure -eq $getTargetResourceResult.Ensure)
+        {
+            $returnValue = $true
+        }
+    }
+
+    return $returnValue
+}
+
+Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/MSFT_SqlAgentFailsafe/MSFT_SqlAgentFailsafe.schema.mof
+++ b/DSCResources/MSFT_SqlAgentFailsafe/MSFT_SqlAgentFailsafe.schema.mof
@@ -1,0 +1,9 @@
+[ClassVersion("1.0.0.0"), FriendlyName("SqlAgentFailsafe")]
+class MSFT_SqlAgentFailsafe : OMI_BaseResource
+{
+    [Key, Description("The name of the SQL Agent Failsafe Operator.")] String Name;
+    [Write, Description("Specifies if the SQL Agent Failsafe Operator should be present or absent. Default is Present."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Write, Description("The host name of the SQL Server to be configured. Default is $env:COMPUTERNAME.")] String ServerName;
+    [Key, Description("The name of the SQL instance to be configured.")] String InstanceName;
+    [Write, Description("The method of notification for the Failsafe Operator."), ValueMap{"None","NotifyEmail","Pager","NetSend","NotifyAll"}, Values{"None","NotifyEmail","Pager","NetSend","NotifyAll"}] String NotificationMethod;
+};

--- a/DSCResources/MSFT_SqlAgentFailsafe/MSFT_SqlAgentFailsafe.schema.mof
+++ b/DSCResources/MSFT_SqlAgentFailsafe/MSFT_SqlAgentFailsafe.schema.mof
@@ -1,7 +1,7 @@
 [ClassVersion("1.0.0.0"), FriendlyName("SqlAgentFailsafe")]
 class MSFT_SqlAgentFailsafe : OMI_BaseResource
 {
-    [Key, Description("The name of the SQL Agent Failsafe Operator.")] String Name;
+    [Required, Description("The name of the SQL Agent Failsafe Operator.")] String Name;
     [Write, Description("Specifies if the SQL Agent Failsafe Operator should be present or absent. Default is Present."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("The host name of the SQL Server to be configured. Default is $env:COMPUTERNAME.")] String ServerName;
     [Key, Description("The name of the SQL instance to be configured.")] String InstanceName;

--- a/DSCResources/MSFT_SqlAgentFailsafe/en-US/MSFT_SqlAgentFailsafe.strings.psd1
+++ b/DSCResources/MSFT_SqlAgentFailsafe/en-US/MSFT_SqlAgentFailsafe.strings.psd1
@@ -1,0 +1,13 @@
+# Localized resources for MSFT_SqlServerAgentFailsafe
+
+ConvertFrom-StringData @'
+    GetSqlAgentFailsafe = Getting SQL Agent Failsafe Operator.
+    SqlFailsafePresent = SQL Agent Failsafe Operator '{0}' is present.
+    SqlFailsafeAbsent = SQL Agent Failsafe Operator '{0}' is absent.
+    UpdateFailsafeOperator = Updating Sql Agent Failsafe Operator to '{0}'.
+    UpdateNotificationMethod = Updating notification method to '{0}' for SQL Agent Failsafe Operator '{1}'.
+    UpdateFailsafeOperatorError = Unable to update Sql Agent Failsafe Operator '{0}' on {1}\\{2}.
+    RemoveFailsafeOperator = Removing Sql Agent Failsafe Operator.
+    ConnectServerFailed = Unable to connect to {0}\\{1}.
+    TestingConfiguration = Determines if the SQL Agent Failsafe Operator is in the desired state.
+'@

--- a/Examples/Resources/SqlAgentFailsafe/1-AddFailsafe.ps1
+++ b/Examples/Resources/SqlAgentFailsafe/1-AddFailsafe.ps1
@@ -1,0 +1,21 @@
+<#
+    .EXAMPLE
+        This example shows how to ensure that the SQL Agent
+        Failsafe Operator 'FailsafeOp' exists with the correct Notification.
+#>
+
+Configuration Example
+{
+
+    Import-DscResource -ModuleName SqlServerDsc
+
+    node localhost {
+        SqlAgentFailsafe Add_FailsafeOp {
+            Ensure               = 'Present'
+            Name                 = 'FailsafeOp'
+            ServerName           = 'TestServer'
+            InstanceName         = 'MSSQLServer'
+            NotificationMethod   = 'NotifyEmail'
+        }
+    }
+}

--- a/Examples/Resources/SqlAgentFailsafe/2-RemoveFailsafe.ps1
+++ b/Examples/Resources/SqlAgentFailsafe/2-RemoveFailsafe.ps1
@@ -1,0 +1,20 @@
+<#
+    .EXAMPLE
+        This example shows how to ensure that the SQL Agent
+        failsafe operator FailsafeOp does not exist.
+#>
+
+Configuration Example
+{
+
+    Import-DscResource -ModuleName SqlServerDsc
+
+    node localhost {
+        SqlAgentFailsafe Remove_FailsafeOp {
+            Ensure               = 'Absent'
+            Name                 = 'FailsafeOp'
+            ServerName           = 'TestServer'
+            InstanceName         = 'MSSQLServer'
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ update the severity or message id.
 * **`[String]` Name** _(Key)_: The name of the SQL Agent Alert.
 * **`[String]` Ensure** _(Write)_: Specifies if the SQL Agent Alert should
   be present or absent. Default is Present. { *Present* | Absent }
-* **`[String]` ServerName** _(Key)_: The host name of the SQL Server to be
+* **`[String]` ServerName** _(Write)_: The host name of the SQL Server to be
   configured. Default is $env:COMPUTERNAME.
 * **`[String]` InstanceName** _(Key)_: The name of the SQL instance to be configured.
 * **`[String]` Severity** _(Write)_: The severity of the SQL Agent Alert.
@@ -368,11 +368,11 @@ update the Notification method.
 * **`[String]` Name** _(Key)_: The name of the SQL Agent Failsafe Operator.
 * **`[String]` Ensure** _(Write)_: Specifies if the SQL Agent Failsafe Operator
   should be present or absent. Default is Present. { *Present* | Absent }
-* **`[String]` ServerName** _(Key)_: The host name of the SQL Server to be
+* **`[String]` ServerName** _(Write)_: The host name of the SQL Server to be
   configured. Default is $env:COMPUTERNAME.
 * **`[String]` InstanceName** _(Key)_: The name of the SQL instance to be configured.
-* **`[String]` Notification Method** _(Write)_: The method of notification for the
-  Failsafe Operator.
+* **`[String]` NotificationMethod** _(Write)_: The method of notification for the
+  Failsafe Operator. The default is none.
 
 #### Examples
 
@@ -398,7 +398,7 @@ the operators email address.
 * **`[String]` Name** _(Key)_: The name of the SQL Agent Operator.
 * **`[String]` Ensure** _(Write)_: Specifies if the SQL Agent Operator should
   be present or absent. Default is Present. { *Present* | Absent }
-* **`[String]` ServerName** _(Key)_: The host name of the SQL Server to be
+* **`[String]` ServerName** _(Write)_: The host name of the SQL Server to be
   configured. Default is $env:COMPUTERNAME.
 * **`[String]` InstanceName** _(Key)_: The name of the SQL instance to be configured.
 * **`[String]` EmailAddress** _(Write)_: The email address to be used for

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ A full list of changes in each version can be found in the [change log](CHANGELO
   to manage the database membership in Availability Groups.
 * [**SqlAgentAlert**](#sqlagentalert)
   resource to manage SQL Agent Alerts.
+* [**SqlAgentFailsafe**](#sqlagentfailsafe)
+  resource to manage SQL Agent Failsafe Operator.
 * [**SqlAgentOperator**](#sqlagentoperator)
   resource to manage SQL Agent Operators.
 * [**SqlAGListener**](#sqlaglistener)
@@ -350,6 +352,36 @@ update the severity or message id.
 #### Known issues
 
 All issues are not listed here, see [here for all open issues](https://github.com/PowerShell/SqlServerDsc/issues?q=is%3Aissue+is%3Aopen+in%3Atitle+SqlAgentAlert).
+
+### SqlAgentFailsafe
+
+This resource is used to add/remove the SQL Agent Failsafe Operator. You can also
+update the Notification method.
+
+#### Requirements
+
+* Target machine must be running Windows Server 2008 R2 or later.
+* Target machine must be running SQL Server Database Engine 2008 or later.
+
+#### Parameters
+
+* **`[String]` Name** _(Key)_: The name of the SQL Agent Failsafe Operator.
+* **`[String]` Ensure** _(Write)_: Specifies if the SQL Agent Failsafe Operator
+  should be present or absent. Default is Present. { *Present* | Absent }
+* **`[String]` ServerName** _(Key)_: The host name of the SQL Server to be
+  configured. Default is $env:COMPUTERNAME.
+* **`[String]` InstanceName** _(Key)_: The name of the SQL instance to be configured.
+* **`[String]` Notification Method** _(Write)_: The method of notification for the
+  Failsafe Operator.
+
+#### Examples
+
+* [Add SQL Agent Failsafe Operator](/Examples/Resources/SqlAgentFailsafe/1-AddFailsafe.ps1)
+* [Remove SQL Agent Failsafe Operator](/Examples/Resources/SqlAgentFailsafe/2-RemoveFailsafe.ps1)
+
+#### Known issues
+
+All issues are not listed here, see [here for all open issues](https://github.com/PowerShell/SqlServerDsc/issues?q=is%3Aissue+is%3Aopen+in%3Atitle+SqlAgentFailsafe).
 
 ### SqlAgentOperator
 

--- a/Tests/Integration/MSFT_SqlAgentFailsafe.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlAgentFailsafe.Integration.Tests.ps1
@@ -1,0 +1,147 @@
+# This is used to make sure the integration test run in the correct order.
+[Microsoft.DscResourceKit.IntegrationTest(OrderNumber = 2)]
+param()
+
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
+if (Test-SkipContinuousIntegrationTask -Type 'Integration' -Category @('Integration_SQL2016','Integration_SQL2017'))
+{
+    return
+}
+
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceFriendlyName = 'SqlAgentFailsafe'
+$script:dscResourceName = "MSFT_$($script:dscResourceFriendlyName)"
+
+##region HEADER
+# Integration Test Template Version: 1.3.2
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DscResource.Tests'))
+}
+
+Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
+    -TestType Integration
+#endregion
+
+# Using try/finally to always cleanup.
+try
+{
+    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dscResourceName).config.ps1"
+    . $configFile
+
+    Describe "$($script:dscResourceName)_Integration" {
+        BeforeAll {
+            $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
+        }
+
+        $configurationName = "$($script:dscResourceName)_Add_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath           = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData    = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.Ensure | Should -Be 'Present'
+                $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.Name
+                $resourceCurrentState.NotificationMethod | Should -Be $ConfigurationData.AllNodes.NotificationMethod
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+        }
+
+        $configurationName = "$($script:dscResourceName)_Remove_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath           = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData    = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.Ensure | Should -Be 'Absent'
+                $resourceCurrentState.Name | Should -BeNullOrEmpty
+                $resourceCurrentState.NotificationMethod | Should 'None'
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+        }
+    }
+}
+finally
+{
+    #region FOOTER
+
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+
+    #endregion
+}

--- a/Tests/Integration/MSFT_SqlAgentFailsafe.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_SqlAgentFailsafe.Integration.Tests.ps1
@@ -128,7 +128,7 @@ try
 
                 $resourceCurrentState.Ensure | Should -Be 'Absent'
                 $resourceCurrentState.Name | Should -BeNullOrEmpty
-                $resourceCurrentState.NotificationMethod | Should 'None'
+                $resourceCurrentState.NotificationMethod | Should -BeNullOrEmpty
             }
 
             It 'Should return $true when Test-DscConfiguration is run' {

--- a/Tests/Integration/MSFT_SqlAgentFailsafe.config.ps1
+++ b/Tests/Integration/MSFT_SqlAgentFailsafe.config.ps1
@@ -25,7 +25,7 @@ else
                 InstanceName        = 'DSCSQLTEST'
 
                 Name                = 'FailsafeOp'
-                NotificationMethod  = 'Email'
+                NotificationMethod  = 'NotifyEmail'
 
                 CertificateFile     = $env:DscPublicCertificatePath
             }

--- a/Tests/Integration/MSFT_SqlAgentFailsafe.config.ps1
+++ b/Tests/Integration/MSFT_SqlAgentFailsafe.config.ps1
@@ -1,0 +1,86 @@
+#region HEADER
+# Integration Test Config Template Version: 1.2.0
+#endregion
+
+$configFile = [System.IO.Path]::ChangeExtension($MyInvocation.MyCommand.Path, 'json')
+if (Test-Path -Path $configFile)
+{
+    <#
+        Allows reading the configuration data from a JSON file,
+        for real testing scenarios outside of the CI.
+    #>
+    $ConfigurationData = Get-Content -Path $configFile | ConvertFrom-Json
+}
+else
+{
+    $ConfigurationData = @{
+        AllNodes = @(
+            @{
+                NodeName            = 'localhost'
+
+                UserName            = "$env:COMPUTERNAME\SqlInstall"
+                Password            = 'P@ssw0rd1'
+
+                ServerName          = $env:COMPUTERNAME
+                InstanceName        = 'DSCSQLTEST'
+
+                Name                = 'FailsafeOp'
+                NotificationMethod  = 'Email'
+
+                CertificateFile     = $env:DscPublicCertificatePath
+            }
+        )
+    }
+}
+
+<#
+    .SYNOPSIS
+        Adds a SQL Agent Failsafe Operator.
+#>
+Configuration MSFT_SqlAgentFailsafe_Add_Config
+{
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node $AllNodes.NodeName
+    {
+        SqlAgentFailsafe 'Integration_Test'
+        {
+            Ensure               = 'Present'
+            ServerName           = $Node.ServerName
+            InstanceName         = $Node.InstanceName
+            Name                 = $Node.Name
+            NotificationMethod   = $Node.NotificationMethod
+
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Username, (ConvertTo-SecureString -String $Node.Password -AsPlainText -Force))
+        }
+    }
+}
+
+<#
+    .SYNOPSIS
+        Removes a SQL Agent Failsafe Operator.
+#>
+Configuration MSFT_SqlAgentFailsafe_Remove_Config
+{
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node $AllNodes.NodeName
+    {
+        SqlAgentFailsafe 'Integration_Test'
+        {
+            Ensure               = 'Absent'
+            ServerName           = $Node.ServerName
+            InstanceName         = $Node.InstanceName
+            Name                 = $Node.Name
+            NotificationMethod   = $Node.NotificationMethod
+
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Username, (ConvertTo-SecureString -String $Node.Password -AsPlainText -Force))
+        }
+    }
+}
+
+

--- a/Tests/Unit/MSFT_SqlAgentFailsafe.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAgentFailsafe.Tests.ps1
@@ -92,7 +92,7 @@ try
                 )
             )
         }
-    #endregion
+        #endregion
 
         Describe "MSFT_SqlAgentFailsafe\Get-TargetResource" -Tag 'Get' {
             BeforeEach {
@@ -104,16 +104,20 @@ try
                     Mock -CommandName Connect-SQL -MockWith {
                         return $null
                     }
+
                     $testParameters = $mockDefaultParameters
+
                     $testParameters += @{
                         Name   = 'FailsafeOp'
                     }
+
                     { Get-TargetResource @testParameters } | Should -Throw ($script:localizedData.ConnectServerFailed -f $testParameters.ServerName, $testParameters.InstanceName)
                 }
             }
 
             Context 'When the system is not in the desired state' {
                 $testParameters = $mockDefaultParameters
+
                 $testParameters += @{
                     Name         = 'DifferentOp'
                 }
@@ -135,8 +139,8 @@ try
             }
 
             Context 'When the system is in the desired state for a sql agent failsafe operator' {
-
                 $testParameters = $mockDefaultParameters
+
                 $testParameters += @{
                     Name         = 'FailsafeOp'
                 }
@@ -157,9 +161,7 @@ try
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 2 -Scope Context
                 }
-
             }
-
             Assert-VerifiableMock
         }
 
@@ -171,6 +173,7 @@ try
             Context 'When the system is not in the desired state and Ensure is set to Present' {
                 It 'Should return the state as false when desired sql agent failsafe operator does not exist' {
                     $testParameters = $mockDefaultParameters
+
                     $testParameters += @{
                         Name                = 'MissingFailsafe'
                         NotificationMethod  = 'NotifyEmail'
@@ -183,6 +186,7 @@ try
 
                 It 'Should return the state as false when desired sql agent failsafe operator exists but has the incorrect notification method' {
                     $testParameters = $mockDefaultParameters
+
                     $testParameters += @{
                         Name               = 'FailsafeOp'
                         Ensure             = 'Present'
@@ -196,12 +200,12 @@ try
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 2 -Scope Context
                 }
-
             }
 
             Context 'When the system is not in the desired state and Ensure is set to Absent' {
                 It 'Should return the state as false when non-desired sql agent failsafe operator exists' {
                     $testParameters = $mockDefaultParameters
+
                     $testParameters += @{
                         Name   = 'FailsafeOp'
                         Ensure = 'Absent'
@@ -214,12 +218,12 @@ try
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope Context
                 }
-
             }
 
             Context 'When the system is in the desired state and Ensure is set to Present' {
                 It 'Should return the state as true when desired sql agent failsafe operator exist' {
                     $testParameters = $mockDefaultParameters
+
                     $testParameters += @{
                         Name      = 'FailsafeOp'
                         Ensure    = 'Present'
@@ -231,6 +235,7 @@ try
 
                 It 'Should return the state as true when desired sql agent failsafe operator exists and has the correct notification method' {
                     $testParameters = $mockDefaultParameters
+
                     $testParameters += @{
                         Name               = 'FailsafeOp'
                         Ensure             = 'Present'
@@ -244,12 +249,12 @@ try
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 2 -Scope Context
                 }
-
             }
 
             Context 'When the system is in the desired state and Ensure is set to Absent' {
                 It 'Should return the state as true when desired sql agent failsafe operator does not exist' {
                     $testParameters = $mockDefaultParameters
+
                     $testParameters += @{
                         Name   = 'NotFailsafe'
                         Ensure = 'Absent'
@@ -262,9 +267,7 @@ try
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope Context
                 }
-
             }
-
             Assert-VerifiableMock
         }
 
@@ -279,11 +282,14 @@ try
                     Mock -CommandName Connect-SQL -MockWith {
                         return $null
                     }
+
                     $testParameters = $mockDefaultParameters
+
                     $testParameters += @{
                         Name   = 'FailsafeOp'
                         Ensure = 'Present'
                     }
+
                     { Set-TargetResource @testParameters } | Should -Throw ($script:localizedData.ConnectServerFailed -f $testParameters.ServerName, $testParameters.InstanceName)
                 }
             }
@@ -291,40 +297,48 @@ try
             Context 'When the system is not in the desired state and Ensure is set to Present'{
                 It 'Should not throw when adding the sql agent failsafe operator' {
                     $testParameters = $mockDefaultParameters
+
                     $testParameters += @{
                         Name   = 'Newfailsafe'
                         Ensure = 'Present'
                     }
+
                     { Set-TargetResource @testParameters } | Should -Not -Throw
                 }
 
                 It 'Should not throw when changing the severity'  {
                     $testParameters = $mockDefaultParameters
+
                     $testParameters += @{
                         Name                = 'Newfailsafe'
                         Ensure              = 'Present'
                         NotificationMethod  = 'Pager'
                     }
+
                     { Set-TargetResource @testParameters } | Should -Not -Throw
                 }
 
                 It 'Should throw when notification method is not valid' {
                     $testParameters = $mockDefaultParameters
+
                     $testParameters += @{
                         Name                = 'Newfailsafe'
                         Ensure              = 'Present'
                         NotificationMethod  = 'Letter'
                     }
+
                     { Set-TargetResource @testParameters } | Should -Throw
                 }
 
                 $mockInvalidOperationForAlterMethod = $true
                 It 'Should throw the correct error when Alter() method was called with invalid operation' {
                     $testParameters = $mockDefaultParameters
+
                     $testParameters += @{
                         Name   = 'NewFailsafe'
                         Ensure = 'Present'
                     }
+
                     $errorMessage = ($script:localizedData.UpdateFailsafeOperatorError -f $testParameters.Name, $testParameters.ServerName, $testParameters.InstanceName)
                     { Set-TargetResource @testParameters } | Should -Throw $errorMessage
                 }
@@ -332,26 +346,29 @@ try
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 3 -Scope Context
                 }
-
             }
 
             Context 'When the system is not in the desired state and Ensure is set to Absent' {
                 It 'Should not throw when removing the sql agent failsafe operator' {
                     $testParameters = $mockDefaultParameters
+
                     $testParameters += @{
                         Name   = 'FailsafeOp'
                         Ensure = 'Absent'
                     }
+
                     { Set-TargetResource @testParameters } | Should -Not -Throw
                 }
 
                 $mockInvalidOperationForAlterMethod = $true
                 It 'Should throw the correct error when Alter() method was called with invalid operation' {
                     $testParameters = $mockDefaultParameters
+
                     $testParameters += @{
                         Name   = 'FailsafeOp'
                         Ensure = 'Absent'
                     }
+
                     $errorMessage = ($script:localizedData.UpdateFailsafeOperatorError -f $testParameters.Name, $testParameters.ServerName, $testParameters.InstanceName)
                     { Set-TargetResource @testParameters } | Should -Throw $errorMessage
                 }
@@ -359,9 +376,8 @@ try
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 2 -Scope Context
                 }
-
             }
-             Assert-VerifiableMock
+            Assert-VerifiableMock
         }
     }
 }

--- a/Tests/Unit/MSFT_SqlAgentFailsafe.Tests.ps1
+++ b/Tests/Unit/MSFT_SqlAgentFailsafe.Tests.ps1
@@ -1,0 +1,371 @@
+<#
+    .SYNOPSIS
+        Automated unit test for MSFT_SqlAgentFailsafe DSC resource.
+
+    .NOTES
+        To run this script locally, please make sure to first run the bootstrap
+        script. Read more at
+        https://github.com/PowerShell/SqlServerDsc/blob/dev/CONTRIBUTING.md#bootstrap-script-assert-testenvironment
+#>
+
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
+if (Test-SkipContinuousIntegrationTask -Type 'Unit')
+{
+    return
+}
+
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'MSFT_SqlAgentFailsafe'
+
+#region HEADER
+
+# Unit Test Template Version: 1.2.0
+$script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
+    -TestType Unit
+
+#endregion HEADER
+
+function Invoke-TestSetup
+{
+    # Loading mocked classes
+}
+
+function Invoke-TestCleanup
+{
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+}
+
+# Begin Testing
+try
+{
+    Invoke-TestSetup
+
+    InModuleScope $script:dscResourceName {
+        $mockServerName = 'localhost'
+        $mockInstanceName = 'MSSQLSERVER'
+        $mockSqlAgentFailsafeName = 'FailsafeOp'
+        $mockSqlAgentFailsafeNotification = 'NotifyEmail'
+        $mockInvalidOperationForAlterMethod = $false
+
+        # Default parameters that are used for the It-blocks
+        $mockDefaultParameters = @{
+            InstanceName = $mockInstanceName
+            ServerName   = $mockServerName
+        }
+
+        #region Function mocks
+        $mockConnectSQL = {
+            return @(
+                (
+                New-Object -TypeName Object |
+                    Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockInstanceName -PassThru |
+                    Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockServerName -PassThru |
+                    Add-Member -MemberType ScriptProperty -Name JobServer -Value {
+                        return (New-Object -TypeName Object |
+                            Add-Member -MemberType NoteProperty -Name Name -Value $mockServerName -PassThru |
+                            Add-Member -MemberType ScriptProperty -Name AlertSystem -Value {
+                                return ( New-Object -TypeName Object |
+                                    Add-Member -MemberType NoteProperty -Name FailSafeOperator -Value $mockSqlAgentFailsafeName -PassThru -Force |
+                                    Add-Member -MemberType NoteProperty -Name NotificationMethod -Value $mockSqlAgentFailsafeNotification -PassThru -Force |
+                                    Add-Member -MemberType ScriptMethod -Name Alter -Value {
+                                        if ($mockInvalidOperationForAlterMethod)
+                                        {
+                                            throw 'Mock Alter Method was called with invalid operation.'
+                                        }
+                                    } -PassThru -Force
+                                )
+                            } -PassThru
+                        )
+                    } -PassThru -Force
+                )
+            )
+        }
+    #endregion
+
+        Describe "MSFT_SqlAgentFailsafe\Get-TargetResource" -Tag 'Get' {
+            BeforeEach {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+            }
+
+            Context 'When Connect-SQL returns nothing' {
+                It 'Should throw the correct error' {
+                    Mock -CommandName Connect-SQL -MockWith {
+                        return $null
+                    }
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        Name   = 'FailsafeOp'
+                    }
+                    { Get-TargetResource @testParameters } | Should -Throw ($script:localizedData.ConnectServerFailed -f $testParameters.ServerName, $testParameters.InstanceName)
+                }
+            }
+
+            Context 'When the system is not in the desired state' {
+                $testParameters = $mockDefaultParameters
+                $testParameters += @{
+                    Name         = 'DifferentOp'
+                }
+
+                It 'Should return the state as absent' {
+                    $result = Get-TargetResource @testParameters
+                    $result.Ensure | Should -Be 'Absent'
+                }
+
+                It 'Should return the same values as passed as parameters' {
+                    $result = Get-TargetResource @testParameters
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
+                }
+
+                It 'Should call the mock function Connect-SQL' {
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 2 -Scope Context
+                }
+            }
+
+            Context 'When the system is in the desired state for a sql agent failsafe operator' {
+
+                $testParameters = $mockDefaultParameters
+                $testParameters += @{
+                    Name         = 'FailsafeOp'
+                }
+
+                It 'Should return the state as present' {
+                    $result = Get-TargetResource @testParameters
+                    $result.Ensure | Should -Be 'Present'
+                }
+
+                It 'Should return the same values as passed as parameters' {
+                    $result = Get-TargetResource @testParameters
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
+                    $result.Name | Should -Be $testParameters.Name
+                    $result.NotificationMethod | Should -Be $mockSqlAgentFailsafeNotification
+                }
+
+                It 'Should call the mock function Connect-SQL' {
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 2 -Scope Context
+                }
+
+            }
+
+            Assert-VerifiableMock
+        }
+
+        Describe "MSFT_SqlAgentFailsafe\Test-TargetResource" -Tag 'Test' {
+            BeforeEach {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+            }
+
+            Context 'When the system is not in the desired state and Ensure is set to Present' {
+                It 'Should return the state as false when desired sql agent failsafe operator does not exist' {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        Name                = 'MissingFailsafe'
+                        NotificationMethod  = 'NotifyEmail'
+                        Ensure              = 'Present'
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should -Be $false
+                }
+
+                It 'Should return the state as false when desired sql agent failsafe operator exists but has the incorrect notification method' {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        Name               = 'FailsafeOp'
+                        Ensure             = 'Present'
+                        NotificationMethod = 'Pager'
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should -Be $false
+                }
+
+                It 'Should call the mock function Connect-SQL' {
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 2 -Scope Context
+                }
+
+            }
+
+            Context 'When the system is not in the desired state and Ensure is set to Absent' {
+                It 'Should return the state as false when non-desired sql agent failsafe operator exists' {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        Name   = 'FailsafeOp'
+                        Ensure = 'Absent'
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should -Be $false
+                }
+
+                It 'Should call the mock function Connect-SQL' {
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope Context
+                }
+
+            }
+
+            Context 'When the system is in the desired state and Ensure is set to Present' {
+                It 'Should return the state as true when desired sql agent failsafe operator exist' {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        Name      = 'FailsafeOp'
+                        Ensure    = 'Present'
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should -Be $true
+                }
+
+                It 'Should return the state as true when desired sql agent failsafe operator exists and has the correct notification method' {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        Name               = 'FailsafeOp'
+                        Ensure             = 'Present'
+                        NotificationMethod = 'NotifyEmail'
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should -Be $true
+                }
+
+                It 'Should call the mock function Connect-SQL' {
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 2 -Scope Context
+                }
+
+            }
+
+            Context 'When the system is in the desired state and Ensure is set to Absent' {
+                It 'Should return the state as true when desired sql agent failsafe operator does not exist' {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        Name   = 'NotFailsafe'
+                        Ensure = 'Absent'
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should -Be $true
+                }
+
+                It 'Should call the mock function Connect-SQL' {
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope Context
+                }
+
+            }
+
+            Assert-VerifiableMock
+        }
+
+        Describe "MSFT_SqlAgentFailsafe\Set-TargetResource" -Tag 'Set' {
+            BeforeEach {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+            }
+
+            Context 'When Connect-SQL returns nothing' {
+                It 'Should throw the correct error' {
+                    Mock -CommandName Get-TargetResource -Verifiable
+                    Mock -CommandName Connect-SQL -MockWith {
+                        return $null
+                    }
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        Name   = 'FailsafeOp'
+                        Ensure = 'Present'
+                    }
+                    { Set-TargetResource @testParameters } | Should -Throw ($script:localizedData.ConnectServerFailed -f $testParameters.ServerName, $testParameters.InstanceName)
+                }
+            }
+
+            Context 'When the system is not in the desired state and Ensure is set to Present'{
+                It 'Should not throw when adding the sql agent failsafe operator' {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        Name   = 'Newfailsafe'
+                        Ensure = 'Present'
+                    }
+                    { Set-TargetResource @testParameters } | Should -Not -Throw
+                }
+
+                It 'Should not throw when changing the severity'  {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        Name                = 'Newfailsafe'
+                        Ensure              = 'Present'
+                        NotificationMethod  = 'Pager'
+                    }
+                    { Set-TargetResource @testParameters } | Should -Not -Throw
+                }
+
+                It 'Should throw when notification method is not valid' {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        Name                = 'Newfailsafe'
+                        Ensure              = 'Present'
+                        NotificationMethod  = 'Letter'
+                    }
+                    { Set-TargetResource @testParameters } | Should -Throw
+                }
+
+                $mockInvalidOperationForAlterMethod = $true
+                It 'Should throw the correct error when Alter() method was called with invalid operation' {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        Name   = 'NewFailsafe'
+                        Ensure = 'Present'
+                    }
+                    $errorMessage = ($script:localizedData.UpdateFailsafeOperatorError -f $testParameters.Name, $testParameters.ServerName, $testParameters.InstanceName)
+                    { Set-TargetResource @testParameters } | Should -Throw $errorMessage
+                }
+
+                It 'Should call the mock function Connect-SQL' {
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 3 -Scope Context
+                }
+
+            }
+
+            Context 'When the system is not in the desired state and Ensure is set to Absent' {
+                It 'Should not throw when removing the sql agent failsafe operator' {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        Name   = 'FailsafeOp'
+                        Ensure = 'Absent'
+                    }
+                    { Set-TargetResource @testParameters } | Should -Not -Throw
+                }
+
+                $mockInvalidOperationForAlterMethod = $true
+                It 'Should throw the correct error when Alter() method was called with invalid operation' {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        Name   = 'FailsafeOp'
+                        Ensure = 'Absent'
+                    }
+                    $errorMessage = ($script:localizedData.UpdateFailsafeOperatorError -f $testParameters.Name, $testParameters.ServerName, $testParameters.InstanceName)
+                    { Set-TargetResource @testParameters } | Should -Throw $errorMessage
+                }
+
+                It 'Should call the mock function Connect-SQL' {
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 2 -Scope Context
+                }
+
+            }
+             Assert-VerifiableMock
+        }
+    }
+}
+finally
+{
+    Invoke-TestCleanup
+}


### PR DESCRIPTION
#### Pull Request (PR) description
Adds the `SqlAgentFailsafe` resource, to allow you to manage adding a failsafe operator to the agent alert system, and choosing the notification:
![image](https://user-images.githubusercontent.com/981370/62157245-b624f200-b2da-11e9-8595-84d3d1c35b72.png)

#### This Pull Request (PR) fixes the following issues
None

#### Task list
- [X] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [X] Resource documentation added/updated in README.md.
- [X] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [X] Comment-based help added/updated.
- [X] Localization strings added/updated in all localization files as appropriate.
- [X] Examples appropriately added/updated.
- [X] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [X] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [X] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/1414)
<!-- Reviewable:end -->
